### PR TITLE
add optimization test

### DIFF
--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -33,37 +33,3 @@ function case_parameters(case::Symbol; kw...)
     end
     return case_parameters(Val{case}; kw...)
 end
-
-#= ====================== =#
-#  Optimization parameter  #
-#= ====================== =#
-struct OptParameter
-    nominal::Real
-    lower::Real
-    upper::Real
-end
-
-"""
-    ↔(x::Real, r::AbstractVector)
-
-"leftrightarrow" unicode constructor for OptParameter
-"""
-function ↔(x::Real, r::AbstractVector)
-    @assert typeof(x) == typeof(r[1]) == typeof(r[end]) "type of optimization range does not match the nominal value"
-    return OptParameter(x, r[1], r[end])
-end
-
-function opt_parameters(p::AbstractParameters, opt_vector=AbstractParameter[])
-    _parameters = getfield(p, :_parameters)
-    for k in keys(_parameters)
-        parameter = _parameters[k]
-        if typeof(parameter) <: AbstractParameters
-            opt_parameters(parameter, opt_vector)
-        elseif typeof(parameter) <: Entry
-            if parameter.lower !== missing
-                push!(opt_vector, parameter)
-            end
-        end
-    end
-    return opt_vector
-end

--- a/test/runtests_workflows.jl
+++ b/test/runtests_workflows.jl
@@ -47,16 +47,27 @@ using Test
     @testset "SPARC" begin
         dd, ini, act = FUSE.init(:SPARC)
     end
-
-    @testset "warmup" begin
-        FUSE.warmup()
-    end
-    @testset "optimization" begin
-        ini = FUSE.ParametersInits()
-        ini.core_profiles.zeff = 2.0 ↔ [1.2, 2.5]
-    end
 end
 
+@testset "warmup" begin
+    FUSE.warmup()
+end
+
+@testset "optimization" begin
+    ini = FUSE.ParametersInits()
+
+    ini.core_profiles.zeff = 2.0 ↔ [1.2, 2.5]
+    @test ini.core_profiles.zeff == 2.0
+    @test typeof(ini.core_profiles.zeff) <: Float64
+
+    ini.equilibrium.ngrid = 200.0 ↔ [129, 257]
+    @test ini.equilibrium.ngrid == 200
+    @test typeof(ini.equilibrium.ngrid) <: Int
+
+    ini.build.symmetric = 1.0 ↔ [0, 1]
+    @test ini.build.symmetric == true
+    @test typeof(ini.build.symmetric) <: Bool
+end
 
 # @testset "QEDcurrent_actor" begin
 #     # Load TRANSP data at 2.91 s


### PR DESCRIPTION
Setting up optimization bounds with ini is broken now

i.e.
```julia
    ini, act = FUSE.case_parameters(:FPP,version=:v1_demount,init_from=:scalars)
    ini.core_profiles.zeff = 2.0 ↔ [1.1, 2.5]
    ini.equilibrium.δ = 0.6 ↔ [-0.7,0.7]
```

probably related to the new way of setting up ini & act