### PR TITLE
don't dev in global env with `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,6 @@ develop:
 using Pkg;\
 Pkg.activate(".");\
 Pkg.develop(["IMAS", "IMASDD", "CoordinateConventions", "MillerExtendedHarmonic", "FusionMaterials", "VacuumFields", "Equilibrium", "TAUENN", "EPEDNN", "TGLFNN", "QED", "FiniteElementHermite", "Fortran90Namelists", "CHEASE", "NNeutronics", "SimulationParameters"]);\
-Pkg.activate();\
-Pkg.develop(["FUSE", "IMAS", "IMASDD", "CoordinateConventions", "MillerExtendedHarmonic", "FusionMaterials", "VacuumFields", "Equilibrium", "TAUENN", "EPEDNN", "TGLFNN", "QED", "FiniteElementHermite", "Fortran90Namelists", "CHEASE", "NNeutronics", "SimulationParameters"]);\
 '
 
 rm_manifests:


### PR DESCRIPTION
I am not sure what all this affects. But IMO its a no-no to mess with my global environment.

That said, you could make the argument that this is a good idea for a team that all uses the same environment. ie, maybe this only affects me. 

I'm happy to keep it as is, or add a similar install command that doesn't global dev

Let me know what your thoughts are on this. 