### PR TITLE
Removed obsolete code from tutorials

### DIFF
--- a/examples/tutorials/1_July_2022.ipynb
+++ b/examples/tutorials/1_July_2022.ipynb
@@ -528,24 +528,13 @@
    "id": "ae4f51f1-6c51-495f-b991-75de571146b3",
    "metadata": {},
    "source": [
-    "#### Access detailed descriptions either [online](https://fuse.help/ini_details.html#ini.tf.shape) or by accessing leaves with `[:...]`\n",
+    "#### Access detailed descriptions [online](https://fuse.help/ini_details.html#ini.equilibrium.Z0)\n",
     "* Notice **units**, **descriptons**\n",
     "* Some fields only allow a limited set of **options**\n",
     "* Each field stores three things:\n",
     "    * **default**: default value when `ini = ParametersInit()` is first called\n",
     "    * **base**: value when `FUSE.set_new_base!(ini)` is called\n",
     "    * **value**: current value"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "be1569c5-9088-4652-8fa1-54206fd3e9d9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# take a look at the info for a leaf in the `ini`\n",
-    "new_ini.tf[:shape]"
    ]
   },
   {
@@ -883,11 +872,11 @@
  ],
  "metadata": {
   "@webio": {
-   "lastCommId": "230d7025-d126-4d1d-9056-3172bc90cc18",
-   "lastKernelId": "7c615881-8ed1-422a-bf66-5d87606b12fb"
+   "lastCommId": "a782a072-97f2-4a29-be57-b636bd4af2f9",
+   "lastKernelId": "786df1b8-4648-4980-b093-ff9853c6ef8b"
   },
   "kernelspec": {
-   "display_name": "Julia",
+   "display_name": "Julia 1.8.5",
    "language": "julia",
    "name": "julia-1.8"
   },
@@ -895,7 +884,7 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.7.2"
+   "version": "1.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Removed references to inline access to leaf descriptors using `[:...]` notation, which is no a valid access option in `get_index`. Now reflects the online documentation as main tool for accessing variable descriptors.