### PR TITLE
Pin Revise in user's base Project.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ Pkg.develop([["FUSE"] ; fuse_packages]);\
 
 # install revise and load it when Julia starts up
 revise:
-	julia -e 'import Pkg; Pkg.add(Pkg.PackageSpec(;name="Revise", version="3.4.0"))'
+	julia -e 'import Pkg; Pkg.compat("Revise", "< 3.4.1"); Pkg.update(); Pkg.add("Revise")'
 	mkdir -p $(JULIA_DIR)/config
 	touch $(JULIA_CONF)
 	grep -v -F -x "using Revise" "$(JULIA_CONF)" > "$(JULIA_CONF).tmp" || true


### PR DESCRIPTION
This puts an appropriate `compat` entry in a user's base `Project.toml`. The `update()` is required to downgrade Revise if necessary. Maybe that should be `Pkg.update("Revise")`?