### PR TITLE
Fix R0 used in stresses_actor

### DIFF
--- a/src/actors/build/stresses_actor.jl
+++ b/src/actors/build/stresses_actor.jl
@@ -42,24 +42,24 @@ function _step(actor::ActorStresses; n_points::Integer=5)
     bd = actor.dd.build
     sm = actor.dd.solid_mechanics
 
-    TFhfs = IMAS.get_build(dd.build, type=_tf_, fs=_hfs_)
-    TFlfs = IMAS.get_build(dd.build, type=_tf_, fs=_lfs_)
+    R0 = eq.vacuum_toroidal_field.r0
+    B0 = maximum(abs.(eq.vacuum_toroidal_field.b0))
 
-    R_tf_in = TFhfs.start_radius
-    R_tf_out = TFhfs.end_radius
-
-    R0 = (TFhfs.end_radius + TFlfs.start_radius) / 2.0
-    B0 = maximum(abs.(eq.vacuum_toroidal_field.b0)) * eq.vacuum_toroidal_field.r0 / R0
-
+    R_tf_in = IMAS.get_build(bd, type=_tf_, fs=_hfs_).start_radius
+    R_tf_out = IMAS.get_build(bd, type=_tf_, fs=_hfs_).end_radius
+    
     Bz_oh = bd.oh.max_b_field
+    
     R_oh_in = IMAS.get_build(bd, type=_oh_).start_radius
     R_oh_out = IMAS.get_build(bd, type=_oh_).end_radius
+    
     f_struct_tf = bd.tf.technology.fraction_stainless
     f_struct_oh = bd.oh.technology.fraction_stainless
 
     bucked = sm.center_stack.bucked == 1
     noslip = sm.center_stack.noslip == 1
     plug = sm.center_stack.plug == 1
+    
     empty!(sm.center_stack)
 
     for oh_on in [true, false]


### PR DESCRIPTION
For the TF stresses calculation I'd like to use a R0 that is independent of the equilibrium. That's why I picked the midpoint of between the end of the TF legs.

This closes #310