### PR TITLE
GASC Benchmarking Process

### DIFF
--- a/src/actors/build/stresses_actor.jl
+++ b/src/actors/build/stresses_actor.jl
@@ -60,8 +60,6 @@ function _step(actor::ActorStresses; n_points::Integer=5)
     noslip = sm.center_stack.noslip == 1
     plug = sm.center_stack.plug == 1
     
-    empty!(sm.center_stack)
-
     for oh_on in [true, false]
         solve_1D_solid_mechanics!(
             sm.center_stack,
@@ -79,6 +77,7 @@ function _step(actor::ActorStresses; n_points::Integer=5)
             f_struct_oh=f_struct_oh,
             f_struct_pl=1.0,
             n_points=n_points,
+            empty_smcs=oh_on,
             verbose=false
         )
     end

--- a/src/technology.jl
+++ b/src/technology.jl
@@ -215,8 +215,12 @@ function solve_1D_solid_mechanics!(
     f_tf_sash=0.873,                       # : (float), conversion factor from hoop stress to axial stress for TF coil (nominally 0.873)
     f_oh_sash=0.37337,                     # : (float), conversion factor from hoop stress to axial stress for OH coil (nominally 0.37337)
     n_points::Integer=21,                  # : (int), number of radial points
-    verbose::Bool=false                   # : (bool), flag for verbose output to terminal
-)
+    empty_smcs::Bool=true,                 # : (bool), flag to empty the smcs structure (useful to identify worst case in a series of scenarios)
+    verbose::Bool=false)                   # : (bool), flag for verbose output to terminal
+
+    if empty_smcs
+        empty!(smcs)
+    end
 
     tp = typeof(promote(R0, B0, R_tf_in, R_tf_out, Bz_oh, R_oh_in, R_oh_out)[1])
 
@@ -476,10 +480,6 @@ function solve_1D_solid_mechanics!(
         axial_stress_oh_avg = -f_oh_sash * hoop_stress_oh_avg
     end
 
-    ## calculate Von Mises stress
-    vonmises_stress_tf = svm.(radial_stress_tf, hoop_stress_tf, axial_stress_tf_avg)
-    vonmises_stress_oh = svm.(radial_stress_oh, hoop_stress_oh, axial_stress_oh_avg)
-
     if noslip
         # calc cross-sectional areas of OH and TF
         cx_surf_tf = pi * (R_tf_out^2 - R_tf_in^2)
@@ -509,6 +509,10 @@ function solve_1D_solid_mechanics!(
         axial_stress_pl_avg = missing
         vonmises_stress_pl = missing
     end
+
+    ## calculate Von Mises stress
+    vonmises_stress_tf = svm.(radial_stress_tf, hoop_stress_tf, axial_stress_tf_avg)
+    vonmises_stress_oh = svm.(radial_stress_oh, hoop_stress_oh, axial_stress_oh_avg)
 
     # apply structural composition fractions to get effective stress on structural materials
     radial_stress_tf *= 1.0 / f_struct_tf


### PR DESCRIPTION
Caught a bug:
Calculation of the updated von misses stresses is done after the `if noslip` which updates the axial stresses

Introduced a flag 'empty_smcs' that would allow the experienced user to calculate the stresses of the worst case scenario of a series of possibilities. The casual user has it off by default.