### PR TITLE
init sysimg script

### DIFF
--- a/sysimg/Project.toml
+++ b/sysimg/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
+WarmupFUSE = "94a5eb1c-6ef7-444c-826b-8a288397da7c"

--- a/sysimg/build.jl
+++ b/sysimg/build.jl
@@ -1,0 +1,11 @@
+using PackageCompiler
+
+create_sysimage(["FUSE"],
+                sysimage_path=joinpath(@__DIR__, "sysimg.so"),
+                project=joinpath(@__DIR__, ".."),
+                precompile_execution_file="precompile_script.jl",
+                incremental=true, # set this to false to generate a smaller sysimg
+                filter_stdlibs=false # set this to true to generate a smaller sysimg
+                #uncomment this line to anonymize the sysimg for proprietary distributions
+                #, sysimage_build_args=`-g0 --strip-ir --strip-metadata --compile=all`
+                )

--- a/sysimg/precompile_script.jl
+++ b/sysimg/precompile_script.jl
@@ -1,0 +1,1 @@
+using WarmupFUSE


### PR DESCRIPTION
This uses WarmupFUSE.jl as the executing environment, though the contents of that package are so simple, it may save time to just be explicit about the precompilation workload again here. I have annotated various flags that may be of interest for deployment in commerical settings as well.