### PR TITLE
allow finalize and step on a missing actor?

### DIFF
--- a/src/FUSE.jl
+++ b/src/FUSE.jl
@@ -43,6 +43,7 @@ include(joinpath("ddinit", "gasc.jl"))
 #= ====== =#
 # the order of include matters due to import/using statements as well as the dependency of defines structures
 include(joinpath("actors", "abstract_actors.jl"))
+include(joinpath("actors", "noop_actor.jl"))
 
 include(joinpath("actors", "equilibrium", "solovev_actor.jl"))
 include(joinpath("actors", "equilibrium", "chease_actor.jl"))

--- a/src/actors/abstract_actors.jl
+++ b/src/actors/abstract_actors.jl
@@ -46,10 +46,6 @@ function step(actor::T, args...; kw...) where {T<:AbstractActor}
     return actor
 end
 
-function step(actor::Missing)
-    return actor
-end
-
 #= ======== =#
 #  finalize  #
 #= ======== =#
@@ -79,10 +75,6 @@ function finalize(actor::T) where {T<:AbstractActor}
         end
     end
     memory_time_tag("$(name(actor)) - finalize OUT")
-    return actor
-end
-
-function finalize(actor::Missing)
     return actor
 end
 

--- a/src/actors/noop_actor.jl
+++ b/src/actors/noop_actor.jl
@@ -1,0 +1,44 @@
+#= ========= =#
+#  ActorNoOP  #
+#= ========= =#
+Base.@kwdef mutable struct FUSEparameters__ActorNoOP{T} <: ParametersActor where {T<:Real}
+    _parent::WeakRef = WeakRef(nothing)
+    _name::Symbol = :not_set
+end
+
+mutable struct ActorNoOP{D,P} <: AbstractActor
+    dd::IMAS.dd{D}
+    par::FUSEparameters__ActorNoOP{P}
+    function ActorNoOP(dd::IMAS.dd{D}, par::FUSEparameters__ActorNoOP{P}; kw...) where {D<:Real,P<:Real}
+        par = par(kw...)
+        return new{D,P}(dd, par)
+    end
+end
+
+"""
+    ActorNoOP(dd::IMAS.dd, act::ParametersAllActors; kw...)
+
+This actor doesn't do anything. It can be useful to turn off models, for example.
+"""
+function ActorNoOP(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    actor = ActorNoOP(dd, act.ActorNoOP; kw...)
+    step(actor)
+    finalize(actor)
+    return actor
+end
+
+function _step(actor::ActorNoOP)
+    return actor
+end
+
+function _finalize(actor::ActorNoOP)
+    return actor
+end
+
+function step(actor::ActorNoOP)
+    return actor
+end
+
+function finalize(actor::ActorNoOP)
+    return actor
+end


### PR DESCRIPTION
this would be the case when you want to do the following:

```
act.ActorFluxCalculator.neoclassical_model = :none
```

which will set actor_neoc = missing

then the expected behavior would be not a crashing actor but nothing happening in the step(finalize(acotr_neoc)) 