### PR TITLE
Update install.md

### DIFF
--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -114,9 +114,10 @@ make chease
 # Install GACODE
 1. Download and Install Xquartz: https://www.xquartz.org
 
-1. Download and Install Xcode: https://developer.apple.com/xcode
-   This will have git: check with `git --version`
-   Typing this will prompt installing of Xcode command line tools
+1. Download and Install Xcode version 14.3.1 or below: https://xcodereleases.com
+
+   This will have git: check with `git --version`.
+   Typing this will prompt installation of Xcode command line tools.
 
 1. Download and Install Macports: https://www.macports.org/install.php
 


### PR DESCRIPTION
The latest version of Xcode (version 15.0) causes an error in the gacode compilation (`ld: unknown options: -commons`). Gacode install instructions now point to Xcode version 14.3.1 to avoid this