### PR TITLE
Change to ActorNeutronics with general particle tracker

### DIFF
--- a/src/actors/nuclear/neutronics_actor.jl
+++ b/src/actors/nuclear/neutronics_actor.jl
@@ -78,9 +78,10 @@ end
 
 function define_neutrons(dd::IMAS.dd, N::Int)
     cp1d = dd.core_profiles.profiles_1d[]
+    eqt = dd.equilibrium.time_slice[]
     source_1d = IMAS.D_T_to_He4_heating(cp1d) .* 4.0 .+ IMAS.D_D_to_He3_heating(cp1d) .* 3.0
     psi = cp1d.grid.psi
-    neutrons, W_per_trace = IMAS.define_particles(dd, psi, source_1d, N)
+    neutrons, W_per_trace = IMAS.define_particles(eqt, psi, source_1d, N)
 
     return neutrons, W_per_trace
 end


### PR DESCRIPTION
With the general particle tracker included in IMAS, the neutronics actor is modified.

It still works:

FPP
<img width="594" alt="image" src="https://github.com/ProjectTorreyPines/FUSE.jl/assets/142927307/1e70279b-bb4e-4593-9882-382ee5bf9426">

KDEMO:

<img width="573" alt="image" src="https://github.com/ProjectTorreyPines/FUSE.jl/assets/142927307/0aa2d7fb-074a-4875-a09c-9277ee1fd2a1">

STEP:

<img width="260" alt="image" src="https://github.com/ProjectTorreyPines/FUSE.jl/assets/142927307/d33ffe16-c6da-47b7-bf12-2926db87cba1">
