### PR TITLE
Use equilibrium for both toroidal & poloidal grids

### DIFF
--- a/src/actors/equilibrium/equilibrium_actor.jl
+++ b/src/actors/equilibrium/equilibrium_actor.jl
@@ -209,11 +209,10 @@ function prepare(actor::ActorEquilibrium)
     # set j_tor and pressure, forcing zero derivative on axis
     eq1d = dd.equilibrium.time_slice[].profiles_1d
     eq1d.psi = cp1d.grid.psi
+    eq1d.rho_tor_norm = cp1d.grid.rho_tor_norm
+
     eq1d.j_tor = j_itp.(sqrt.(eq1d.psi_norm))
     eq1d.pressure = p_itp.(sqrt.(eq1d.psi_norm))
-
-    cp1d.j_tor = j_itp.(sqrt.(cp1d.grid.psi_norm))
-    cp1d.pressure = p_itp.(sqrt.(cp1d.grid.psi_norm))
 
     return dd
 end

--- a/src/actors/equilibrium/tequila_actor.jl
+++ b/src/actors/equilibrium/tequila_actor.jl
@@ -17,7 +17,7 @@ Base.@kwdef mutable struct FUSEparameters__ActorTEQUILA{T<:Real} <: ParametersAc
     tolerance::Entry{Float64} = Entry{Float64}("-", "Tolerance for terminating iterations"; default=1e-3)
     #== data flow parameters ==#
     ip_from::Switch{Symbol} = switch_get_from(:ip)
-    profiles_from::Switch{Symbol} = Switch{Symbol}([:equilibrium, :core_profiles], "-", "Take P and Jt from this IDS"; default=:equilibrium)
+    fixed_grid::Switch{Symbol} = Switch{Symbol}([:poloidal, :toroidal], "-", "Fix P and Jt on this rho grid"; default=:toroidal)
     #== display and debugging parameters ==#
     do_plot::Entry{Bool} = act_common_parameters(; do_plot=false)
     debug::Entry{Bool} = Entry{Bool}("-", "Print debug information withing TEQUILA solve"; default=false)
@@ -60,7 +60,6 @@ function _step(actor::ActorTEQUILA)
     par = actor.par
     eqt = dd.equilibrium.time_slice[]
     eq1d = eqt.profiles_1d
-    cp1d = dd.core_profiles.profiles_1d[]
 
     # BCL 5/30/23: ψbound should be set time dependently, related to the flux swing of the OH coils
     #              For now setting to zero as initial eq1d.psi profile from prepare() can be nonsense
@@ -68,19 +67,19 @@ function _step(actor::ActorTEQUILA)
 
     Ip_target = eqt.global_quantities.ip
 
-    if par.profiles_from === :equilibrium
+    if par.fixed_grid === :poloidal
         rho = sqrt.(eq1d.psi_norm)
         rho[1] = 0.0
         P = (TEQUILA.FE(rho, eq1d.pressure), :poloidal)
         # don't allow current to change sign
         Jt = (TEQUILA.FE(rho, [sign(j) == sign(Ip_target) ? j : 0.0 for j in eq1d.j_tor]), :poloidal)
         Pbnd = eq1d.pressure[end]
-    elseif par.profiles_from === :core_profiles
-        rho = cp1d.grid.rho_tor_norm
-        P = (TEQUILA.FE(rho, cp1d.pressure), :toroidal)
+    elseif par.fixed_grid === :toroidal
+        rho = eq1d.rho_tor_norm
+        P = (TEQUILA.FE(rho, eq1d.pressure), :toroidal)
         # don't allow current to change sign
-        Jt = (TEQUILA.FE(rho, [sign(j) == sign(Ip_target) ? j : 0.0 for j in cp1d.j_tor]), :toroidal)
-        Pbnd = cp1d.pressure[end]
+        Jt = (TEQUILA.FE(rho, [sign(j) == sign(Ip_target) ? j : 0.0 for j in eq1d.j_tor]), :toroidal)
+        Pbnd = eq1d.pressure[end]
     end
 
     Fbnd = eq1d.f[end] # only in equilibrium IDS
@@ -106,13 +105,9 @@ function _step(actor::ActorTEQUILA)
         actor.shot = solve_function(actor.shot, par.number_of_iterations; tol=par.tolerance, par.debug, par.relax, concentric_first)
     catch e
         display(plot(eqt.boundary.outline.r, eqt.boundary.outline.z; marker=:dot, aspect_ratio=:equal))
-        if par.profiles_from === :equilibrium
-            display(plot(rho, eq1d.pressure; marker=:dot, xlabel="sqrt(ψ)", title="Pressure [Pa]"))
-            display(plot(rho, eq1d.j_tor; marker=:dot, xlabel="sqrt(ψ)", title="Jtor [A]"))
-        else
-            display(plot(rho, cp1d.pressure; marker=:dot, xlabel="sqrt(ψ)", title="Pressure [Pa]"))
-            display(plot(rho, cp1d.j_tor; marker=:dot, xlabel="sqrt(ψ)", title="Jtor [A]"))
-        end
+        display(plot(rho, eq1d.pressure; marker=:dot, xlabel="ρ", title="Pressure [Pa]"))
+        display(plot(rho, eq1d.j_tor; marker=:dot, xlabel="ρ", title="Jtor [A]"))
+
         rethrow(e)
     end
 


### PR DESCRIPTION
Seems to work fine. There's a slight change in P on-axis compared to the old way of doing it. Maybe just an interpolation issue. I get, with this code,
```
dd  = IMAS.dd()
ini, act = FUSE.case_parameters(:ITER; init_from=:scalars)
act.ActorEquilibrium.do_plot = true
act.ActorTEQUILA.profiles_from = :core_profiles
FUSE.init(dd, ini, act)
FUSE.ActorStationaryPlasma(dd, act);
```
I get:

Direct from core_profiles (old way):
![image](https://github.com/ProjectTorreyPines/FUSE.jl/assets/1216060/6a4ee6eb-c0a4-4093-936a-d7ca6ac35bea)

From equilibrium (new way):
![image](https://github.com/ProjectTorreyPines/FUSE.jl/assets/1216060/c2aa87ca-d3ea-46d9-96ec-c6fadcc3804b)
