### PR TITLE
Adding in ITB to ini

### DIFF
--- a/src/parameters/parameters_inits_plasma.jl
+++ b/src/parameters/parameters_inits_plasma.jl
@@ -68,6 +68,10 @@ Base.@kwdef mutable struct FUSEparameters__core_profiles{T} <: ParametersInitPla
     helium_fraction::Entry{T} = Entry{T}("-", "Helium density / electron density fraction"; check=x -> @assert 0.0 <= x <= 0.5 "must be: 0.0 <= helium_fraction <= 0.5")
     ejima::Entry{T} = Entry{T}("-", "Ejima coefficient"; default=0.4, check=x -> @assert 0.0 <= x < 1.0 "must be: 0.0 <= ejima < 1.0")
     polarized_fuel_fraction::Entry{T} = Entry{T}("-", "Spin polarized fuel fraction"; default=0.0, check=x -> @assert 0.0 < x < 1.0 "must be: 0.0 < polarized_fuel_fraction < 1.0")
+    ITB_radius::Entry{T} = Entry{T}("-", "Radius at which the ITB starts in rho")
+    ITB_width::Entry{T} = Entry{T}("-", "Width of the ITB in rho")
+    ITB_height_temperature::Entry{T} = Entry{T}("eV", "Height of the temperature ITB")
+    ITB_height_density::Entry{T} = Entry{T}("m⁻³", "Height of the density ITB")
 end
 
 Base.@kwdef mutable struct FUSEparameters__pf_active{T} <: ParametersInitPlasma{T}


### PR DESCRIPTION
@orso82  this is a temp fix as we had a discussion on how we actually want to do it per channel but this will suffice for now for @tomneiser @nanshi1177  to work together


example

```julia
ini,act= FUSE.case_parameters(:ITER;init_from=:scalars);

#ini.core_profiles.ITB_radius
ini.core_profiles.ITB_radius = 0.6
ini.core_profiles.ITB_width = 0.05
ini.core_profiles.ITB_height_temperature  = 2e3
ini.core_profiles.ITB_height_density = 0.3e20
```

<img width="783" alt="image" src="https://github.com/ProjectTorreyPines/FUSE.jl/assets/32385057/db50c329-ef97-4ed7-8154-4361a1bc2470">
