### PR TITLE
Layer shape development

### DIFF
--- a/src/actors/build/cx_actor.jl
+++ b/src/actors/build/cx_actor.jl
@@ -877,7 +877,11 @@ function optimize_layer_outline(
         func = shape_function(shape; resolution)
         initial_clerance = max(hfs_thickness, lfs_thickness) * vertical_clearance
         shape_parameters0 = initialize_shape_parameters(shape, oR, oZ, l_start, l_end, initial_clerance)
-        shape_parameters = optimize_outline(oR, oZ, hfs_thickness, lfs_thickness, func, l_start, l_end, shape_parameters0; use_curvature)
+        if occursin("TF",layer.name)
+            shape_parameters = shape_parameters0
+        else
+            shape_parameters = optimize_outline(oR, oZ, hfs_thickness, lfs_thickness, func, l_start, l_end, shape_parameters0; use_curvature)
+        end
         layer.outline.r, layer.outline.z = func(l_start, l_end, shape_parameters...)
     end
 
@@ -953,7 +957,7 @@ function optimize_outline(
             if hfs_thickness != lfs_thickness
                 hbuf = hfs_thickness - target_clearance
                 lbuf = lfs_thickness - target_clearance
-                r_obstruction, z_obstruction = buffer(r_obstruction, z_obstruction, hbuf, lbuf)
+                r_obstruction, z_obstruction = buffer(r_obstruction, z_obstruction, hbuf, hbuf)
             else
                 hbuf = 0.0
                 lbuf = 0.0

--- a/src/parameters/parameters_inits.jl
+++ b/src/parameters/parameters_inits.jl
@@ -3,7 +3,7 @@ import SimulationParameters: SwitchOption
 
 import IMAS: BuildLayerType, _plasma_, _gap_, _oh_, _tf_, _shield_, _blanket_, _wall_, _vessel_, _cryostat_, _divertor_, _port_
 import IMAS: BuildLayerSide, _lfs_, _lhfs_, _hfs_, _in_, _out_
-import IMAS: BuildLayerShape, _offset_, _negative_offset_, _convex_hull_, _princeton_D_exact_, _princeton_D_, _princeton_D_scaled_, _rectangle_, _double_ellipse_, _circle_ellipse_,
+import IMAS: BuildLayerShape, _offset_, _negative_offset_, _convex_hull_, _princeton_D_exact_, _princeton_D_, _princeton_D_scaled_, _rectangle_, _double_ellipse_, _rectangle_ellipse_, _circle_ellipse_,
     _triple_arc_, _miller_, _silo_, _racetrack_, _undefined_
 
 const layer_shape_options = Dict(Symbol(string(e)[2:end-1]) => SwitchOption(e, string(e)[2:end-1]) for e in instances(IMAS.BuildLayerShape))

--- a/src/physics.jl
+++ b/src/physics.jl
@@ -224,7 +224,7 @@ function princeton_D_scaled(r_start::T, r_end::T, height::T; n_points::Integer=1
     centerpost_maxz = 2 * pi * r0 * k * SpecialFunctions.besseli(1, k) / 2 # Gralnick Eq. 28
     coil_maxz = pi * r0 * k * (SpecialFunctions.besseli(1, k) + struveL(1, k) + 2 / pi) / 2  # Gralnick Eq. 34
 
-    centerpost_height = height - (coil_maxz - centerpost_maxz) * 2
+    centerpost_height = height
 
     inboard_curve_dz = coil_maxz - centerpost_maxz
     centerpost_maxz = centerpost_height / 2
@@ -263,7 +263,7 @@ function double_ellipse(r_start::T, r_end::T, r_center::T, centerpost_height::T,
 end
 
 function double_ellipse(r_start::T, r_end::T, height::T; n_points::Integer=100, resolution::Float64=1.0) where {T<:Real}
-    return double_ellipse(r_start, r_end, r_start+(r_end-r_start)*0.4, height, 0.0, height; n_points, resolution)
+    return double_ellipse(r_start, r_end, r_start+(r_end-r_start)*0.5, height, 0.0, height; n_points, resolution)
 end
 
 function double_ellipse(r_start::T, r_end::T, r_center::T, centerpost_height::T, outerpost_height::T, height::T; n_points::Integer=100, resolution::Float64=1.0) where {T<:Real}

--- a/src/physics.jl
+++ b/src/physics.jl
@@ -53,6 +53,8 @@ function initialize_shape_parameters(shape_function_index, r_obstruction, z_obst
             r_center = (r_obstruction[argmax(z_obstruction)] + r_obstruction[argmin(z_obstruction)]) / 2.0
             centerpost_height = (maximum(z_obstruction) - minimum(z_obstruction)) * 2.0 / 3.0
             shape_parameters = [r_center, centerpost_height, height]
+        elseif shape_index_mod == Int(_rectangle_ellipse_)
+            shape_parameters = [height]
         elseif shape_index_mod == Int(_circle_ellipse_)
             centerpost_height = (maximum(z_obstruction) - minimum(z_obstruction)) * 2.0 / 3.0
             shape_parameters = [centerpost_height, height]
@@ -98,6 +100,8 @@ function shape_function(shape_function_index::Int; resolution::Float64)
         elseif shape_index_mod == Int(_circle_ellipse_)
             func = circle_ellipse
         elseif shape_index_mod == Int(_double_ellipse_)
+            func = double_ellipse
+        elseif shape_index_mod == Int(_rectangle_ellipse_)
             func = double_ellipse
         elseif shape_index_mod == Int(_rectangle_)
             func = rectangle_shape
@@ -259,7 +263,7 @@ function double_ellipse(r_start::T, r_end::T, r_center::T, centerpost_height::T,
 end
 
 function double_ellipse(r_start::T, r_end::T, height::T; n_points::Integer=100, resolution::Float64=1.0) where {T<:Real}
-    return double_ellipse(r_start, r_end, (r_start + r_end) / 2, height, 0.0, height; n_points, resolution)
+    return double_ellipse(r_start, r_end, r_start+(r_end-r_start)*0.4, height, 0.0, height; n_points, resolution)
 end
 
 function double_ellipse(r_start::T, r_end::T, r_center::T, centerpost_height::T, outerpost_height::T, height::T; n_points::Integer=100, resolution::Float64=1.0) where {T<:Real}


### PR DESCRIPTION
### Summary:

A new layer shape has been added named `rectangle_ellipse`. This is a simple version of the `double_ellipse` shape in which the inboard ellipses have radius = 0, and are therefor right angles instead of curves.

In addition to this new shape, the vertical_clearance calculation has been modified so that vertical_clearance is equal to the inboard clearance (instead of an average of the inboard and outboard clearances). This is a more efficient use of vertical space.

### Example:

The FPP case with `rectangle_ellipse` blanket, shield, and vacuum vessel looks like this:

![Screen Shot 2024-09-30 at 3 15 23 PM](https://github.com/user-attachments/assets/8e6db0b8-b3e7-4028-adc7-fee6846d4b71)

### Unfinished work:

The `optimize_outline` function in `cx_actor.jl` is not correctly adjusting the height of the TF shape `princeton_D_scaled` to avoid overlaps with interior layers. As a temporary work-around, the TF coil has been removed from the layers that are optimized by `optimize_outline`. An example of the problem is shown here:

![Screen Shot 2024-09-30 at 3 26 17 PM](https://github.com/user-attachments/assets/84c4469a-a60e-493d-8634-9c1f0ed325b3)

Ideally, the `height` of the `princeton_D_scaled` TF shape would be optimized to avoid any overlaps, and to conform to the requested `vertical_clearance`. But for now, excluding the TF layer from this results in a non-optimized TF shape that seems to be ok for this case.
