### PR TITLE
Flattop duration fix

### DIFF
--- a/src/actors/build/fluxswing_actor.jl
+++ b/src/actors/build/fluxswing_actor.jl
@@ -64,7 +64,7 @@ function _step(actor::ActorFluxSwing)
     bd.flux_swing.rampup = rampup_flux_estimates(eqt, cp)
     bd.flux_swing.pf = pf_flux_estimates(eqt)
     if !ismissing(requirements, :flattop_duration) && !par.operate_oh_at_j_crit
-        bd.flux_swing.flattop = flattop_flux_estimates(requirements, cp1d; requirements.coil_j_margin) # flattop flux based on requirements duration
+        bd.flux_swing.flattop = flattop_flux_estimates(requirements, cp1d) # flattop flux based on requirements duration
         oh_required_J_B!(bd)
     else
         oh_maximum_J_B!(bd; requirements.coil_j_margin)
@@ -109,7 +109,7 @@ function rampup_flux_estimates(eqt::IMAS.equilibrium__time_slice, cp::IMAS.core_
 end
 
 """
-    flattop_flux_estimates(requirements::IMAS.requirements, cp1d::IMAS.core_profiles__profiles_1d; coil_j_margin::Float64)
+    flattop_flux_estimates(requirements::IMAS.requirements, cp1d::IMAS.core_profiles__profiles_1d)
 
 Estimate OH flux requirement during flattop
 """

--- a/src/actors/build/fluxswing_actor.jl
+++ b/src/actors/build/fluxswing_actor.jl
@@ -113,11 +113,11 @@ end
 
 Estimate OH flux requirement during flattop
 """
-function flattop_flux_estimates(requirements::IMAS.requirements, cp1d::IMAS.core_profiles__profiles_1d; coil_j_margin::Float64)
+function flattop_flux_estimates(requirements::IMAS.requirements, cp1d::IMAS.core_profiles__profiles_1d)
     j_ohmic = cp1d.j_ohmic
     conductivity_parallel = cp1d.conductivity_parallel
     f = (k, x) -> j_ohmic[k] / conductivity_parallel[k]
-    return abs(trapz(cp1d.grid.area, f)) * requirements.flattop_duration * (1.0 + coil_j_margin) # V*s
+    return abs(trapz(cp1d.grid.area, f)) * requirements.flattop_duration # V*s
 end
 
 """

--- a/src/actors/build/hfs_actor.jl
+++ b/src/actors/build/hfs_actor.jl
@@ -129,7 +129,7 @@ function _step(actor::ActorHFSsizing)
 
         # flattop
         if (dd.requirements.coil_j_margin >= 0) && !ismissing(dd.requirements, :flattop_duration)
-            c_flt = -target_value(dd.build.oh.flattop_duration, dd.requirements.flattop_duration, dd.requirements.coil_j_margin)
+            c_flt = -target_value(dd.build.oh.flattop_duration, dd.requirements.flattop_duration, 0.0)
         else
             c_flt = 0.0
         end
@@ -144,7 +144,7 @@ function _step(actor::ActorHFSsizing)
             push!(margins, cs.properties.yield_strength.pl / maximum(cs.stress.vonmises.pl) - 1.0 - dd.requirements.coil_stress_margin)
         end
         if (dd.requirements.coil_j_margin >= 0) && !ismissing(dd.requirements, :flattop_duration)
-            push!(margins, dd.build.oh.flattop_duration / dd.requirements.flattop_duration - 1.0 - dd.requirements.coil_j_margin)
+            push!(margins, dd.build.oh.flattop_duration / dd.requirements.flattop_duration - 1.0)
         end
 
         c_mgn = norm(margins)


### PR DESCRIPTION
Fixed bugs in `flattop_duration` matching, namely to remove the dependence on `coil_j_margin`. 

Previously, the output `flattop_duration` was forced be equal to the `requirements.flattop_duration * (1 + requirements.coil_j_margin)` 

Now the output `flattop_duration` is exactly equal to requirements.flattop_duration.

- Calculation of `flattop_flux_estimates` should not be scaled by `1 + coil_j_margin`
- `c_flt` should have a margin of 0.0, not `coil_j_margin`
- the margin for `flattop_duration` should not be dependent on `coil_j_margin`.