### PR TITLE
Fix pf plot.

### DIFF
--- a/src/utils_end.jl
+++ b/src/utils_end.jl
@@ -535,7 +535,7 @@ function digest(
         time0 = dd.equilibrium.time[end]
         l = @layout [a{0.5w} b{0.5w}]
         p = plot(; layout=l, size=(900, 400))
-        plot!(p, dd.pf_active, currents; time0, title="PF currents at t=$(time0) s", subplot=1)
+        plot!(p, dd.pf_active, :currents; time0, title="PF currents at t=$(time0) s", subplot=1)
         plot!(p, dd.equilibrium; time0, cx=true, subplot=2)
         plot!(p, dd.build; subplot=2, legend=false, equilibrium=false, pf_active=false)
         plot!(p, dd.pf_active; time0, subplot=2, coil_identifiers=true)


### PR DESCRIPTION
Small fix in pf plotting that will prevent errors in (e.g.) FUSE.digest().