### PR TITLE
Fix twist initialization

### DIFF
--- a/src/parameters/parameters_inits.jl
+++ b/src/parameters/parameters_inits.jl
@@ -542,7 +542,7 @@ function MXHboundary(ini::ParametersAllInits, dd::IMAS.dd; kw...)::MXHboundary
             ini.equilibrium.ϵ,
             ini_equilibrium_elongation_true(ini.equilibrium),
             ini.equilibrium.tilt,
-            [ini.equilibrium.𝚶, 0.0],
+            [ini.equilibrium.𝚶, ini.equilibrium.twist],
             [asin(ini.equilibrium.δ), -ini.equilibrium.ζ])
     else
         error("ini.equilibrium.boundary_from must be one of [:scalars, :rz_points, :MXH_params, :ods]")


### PR DESCRIPTION
This properly passes `twist` from `ini` when initializing. From `plot(ini)` with different values of `ini.equilibrium.twist`:

<img width="941" alt="Screenshot 2024-12-10 at 10 42 36 AM" src="https://github.com/user-attachments/assets/80080722-fa56-46ec-b4f1-8e2ab2f242cf">
