### PR TITLE
Add check function for ini.requirements vs constraint functions in optimization

### DIFF
--- a/studies/MultiObjectiveOptimizer.jl
+++ b/studies/MultiObjectiveOptimizer.jl
@@ -67,6 +67,42 @@ function _setup(study::StudyMultiObjectiveOptimizer)
 
     parallel_environment(sty.server, sty.n_workers)
 
+    function check_matching(requirement::Symbol, constraint_functions::Vector{Symbol})
+    check_vector = Union{Symbol,Nothing}[]
+        for cf in constraint_functions
+            if contains(String(cf), String(requirement))
+                match = requirement
+            else 
+                match = nothing
+            end
+            push!(check_vector, match)
+        end
+    return check_vector
+    end
+
+    set_requirements = Symbol[]
+    for fld in fieldnames(typeof(study.ini.requirements))
+        if fld == :_parent || fld == :_name
+            continue
+        end
+        req = getfield(study.ini.requirements, fld)
+        
+        if !ismissing(req.value)
+            push!(set_requirements, fld)
+        end 
+    end
+    
+    cfs = Symbol[]
+    for cf in study.constraint_functions
+        push!(cfs, cf.name)
+    end
+
+    for req in set_requirements
+        check_vector = check_matching(req, cfs)
+        if all(x -> x isa Nothing, check_vector)
+            @warn "You have set some ini.requirements without setting the corresponding constraint functions: $req"
+        end
+    end
 
     # import FUSE and IJulia on workers
     if isdefined(Main, :IJulia)


### PR DESCRIPTION
In the [code camp](https://github.com/ProjectTorreyPines/FUSE.jl/issues/786) there was a suggestion to add a check function in the multi-objective optimization setup that ensures that each requirement that is set in ini.requirements also has a constraint function that goes with it. This (+ a supporting PR in IMAS) implements that functionality, giving the user a warning if they set a requirement without setting a constraint function for it. 

Doing this also made me realize that we have no constraint function for TBR - is that an oversight or is there some particular reason? @TimSlendebroek 