### PR TITLE
Add ability to StudyDatabaseGenerator to vary act parameters

### DIFF
--- a/studies/DatabaseGenerator.jl
+++ b/studies/DatabaseGenerator.jl
@@ -22,7 +22,7 @@ function study_parameters(::Type{Val{:DatabaseGenerator}})::Tuple{FUSEparameters
     act.ActorTGLF.warn_nn_train_bounds = false
     act.ActorFluxMatcher.evolve_rotation = :fixed
 
-    # finalize 
+    # finalize
     set_new_base!(sty)
     set_new_base!(act)
 
@@ -43,8 +43,8 @@ end
 
 mutable struct StudyDatabaseGenerator <: AbstractStudy
     sty::FUSEparameters__ParametersStudyDatabaseGenerator
-    ini::Union{ParametersAllInits,Vector{ParametersAllInits}}
-    act::Union{ParametersAllActors,Vector{ParametersAllActors}}
+    ini::Union{ParametersAllInits,Vector{<:ParametersAllInits}}
+    act::Union{ParametersAllActors,Vector{<:ParametersAllActors}}
     dataframe::Union{DataFrame,Missing}
     iterator::Union{Vector{Int},Missing}
     workflow::Union{Function,Missing}
@@ -56,7 +56,7 @@ function StudyDatabaseGenerator(sty::ParametersStudy, ini::ParametersAllInits, a
     return setup(study)
 end
 
-function StudyDatabaseGenerator(sty::ParametersStudy, inis::Vector{ParametersAllInits}, acts::Vector{ParametersAllActors}; kw...)
+function StudyDatabaseGenerator(sty::ParametersStudy, inis::Vector{<:ParametersAllInits}, acts::Vector{<:ParametersAllActors}; kw...)
     @assert length(inis) == length(acts)
     sty = sty(kw...)
     study = StudyDatabaseGenerator(sty, inis, acts, missing, missing, missing)
@@ -85,7 +85,7 @@ function _run(study::StudyDatabaseGenerator)
 
     if typeof(study.ini) <: ParametersAllInits && typeof(study.act) <: ParametersAllActors
         iterator = collect(1:sty.n_simulations)
-    elseif typeof(study.ini) <: Vector{ParametersAllInits} && typeof(study.act) <: Vector{ParametersAllActors}
+    elseif typeof(study.ini) <: Vector{<:ParametersAllInits} && typeof(study.act) <: Vector{<:ParametersAllActors}
         @assert length(study.ini) == length(study.act)
         iterator = collect(1:length(study.ini))
     else
@@ -146,12 +146,12 @@ function run_case(study::AbstractStudy, item::Int)
     # ini/act variations
     if typeof(study.ini) <: ParametersAllInits
         ini = rand(study.ini)
-    elseif typeof(study.ini) <: Vector{ParametersAllInits}
+    elseif typeof(study.ini) <: Vector{<:ParametersAllInits}
         ini = study.ini[item]
     end
     if typeof(study.act) <: ParametersAllActors
         act = rand(study.act)
-    elseif typeof(study.act) <: Vector{ParametersAllActors}
+    elseif typeof(study.act) <: Vector{<:ParametersAllActors}
         act = study.act[item]
     end
 

--- a/studies/DatabaseGenerator.jl
+++ b/studies/DatabaseGenerator.jl
@@ -5,9 +5,11 @@
 """
     study_parameters(::Type{Val{:DatabaseGenerator}})::Tuple{FUSEparameters__ParametersStudyDatabaseGenerator,ParametersAllActors}
 
-Generates a database of dds from ini and act based on ranges specified in ini (i.e. ini.equilibrium.R0 = 5.0 ↔ [4.0, 10.0])
-It's also possible to run the database generator on Vector of inis
-There is a example notebook in FUSE_examples/study_database_generator.ipynb that goes through the steps of setting up, running and analyzing this study
+Generates a database of dds from `ini` and `act` based on ranges specified in `ini` (i.e. `ini.equilibrium.R0 = 5.0 ↔ [4.0, 10.0]`)
+
+It's also possible to run the database generator on Vector of `ini`s and `act`s. NOTE: the length of the `ini`s and `act`s must be the same.
+
+There is a example notebook in `FUSE_examples/study_database_generator.ipynb` that goes through the steps of setting up, running and analyzing this study
 """
 function study_parameters(::Type{Val{:DatabaseGenerator}})::Tuple{FUSEparameters__ParametersStudyDatabaseGenerator,ParametersAllActors}
 
@@ -42,7 +44,7 @@ end
 mutable struct StudyDatabaseGenerator <: AbstractStudy
     sty::FUSEparameters__ParametersStudyDatabaseGenerator
     ini::Union{ParametersAllInits,Vector{ParametersAllInits}}
-    act::ParametersAllActors
+    act::Union{ParametersAllActors,Vector{ParametersAllActors}}
     dataframe::Union{DataFrame,Missing}
     iterator::Union{Vector{Int},Missing}
     workflow::Union{Function,Missing}
@@ -54,9 +56,10 @@ function StudyDatabaseGenerator(sty::ParametersStudy, ini::ParametersAllInits, a
     return setup(study)
 end
 
-function StudyDatabaseGenerator(sty::ParametersStudy, inis::Vector{ParametersAllInits}, act::ParametersAllActors; kw...)
+function StudyDatabaseGenerator(sty::ParametersStudy, inis::Vector{ParametersAllInits}, acts::Vector{ParametersAllActors}; kw...)
+    @assert length(inis) == length(acts)
     sty = sty(kw...)
-    study = StudyDatabaseGenerator(sty, inis, act, missing, missing, missing)
+    study = StudyDatabaseGenerator(sty, inis, acts, missing, missing, missing)
     return setup(study)
 end
 
@@ -80,10 +83,13 @@ function _run(study::StudyDatabaseGenerator)
 
     @assert sty.n_workers == length(Distributed.workers()) "The number of workers =  $(length(Distributed.workers())) isn't the number of workers you requested = $(sty.n_workers)"
 
-    if typeof(study.ini) <: ParametersAllInits
+    if typeof(study.ini) <: ParametersAllInits && typeof(study.act) <: ParametersAllActors
         iterator = collect(1:sty.n_simulations)
-    elseif typeof(study.ini) <: Vector{ParametersAllInits}
+    elseif typeof(study.ini) <: Vector{ParametersAllInits} && typeof(study.act) <: Vector{ParametersAllActors}
+        @assert length(study.ini) == length(study.act)
         iterator = collect(1:length(study.ini))
+    else
+        error("DatabaseGenerator should never be here: ini and act are incompatible")
     end
 
     study.iterator = iterator
@@ -137,11 +143,16 @@ function run_case(study::AbstractStudy, item::Int)
     original_stderr = stderr  # Save the original stderr
     file_log = open("log.txt", "w")
 
-    # deepcopy ini/act to avoid changes
+    # ini/act variations
     if typeof(study.ini) <: ParametersAllInits
         ini = rand(study.ini)
     elseif typeof(study.ini) <: Vector{ParametersAllInits}
         ini = study.ini[item]
+    end
+    if typeof(study.act) <: ParametersAllActors
+        act = rand(study.act)
+    elseif typeof(study.act) <: Vector{ParametersAllActors}
+        act = study.act[item]
     end
 
     dd = IMAS.dd()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,25 +1,30 @@
-if get(ENV, "FUSE_WITH_EXTENSIONS", "false") == "true"
-    using Pkg
-    Pkg.add("ThermalSystemModels")
-    using ThermalSystemModels
+# Check if specific test files are requested via ARGS
+if !isempty(ARGS)
+    for testfile in ARGS
+        @info "Running test file: $testfile"
+        include(testfile)
+    end
+else
+    # Default behavior: run all tests
+
+    # Conditionally run extension tests if environment variable is set.
+    if get(ENV, "FUSE_WITH_EXTENSIONS", "false") == "true"
+        using Pkg
+        Pkg.add("ThermalSystemModels")
+        using ThermalSystemModels
+    end
+
+    include("runtests_warmup.jl")
+    include("runtests_basics.jl")
+    include("runtests_ini_act.jl")
+    include("runtests_cases.jl")
+    include("runtests_actors.jl")
+    include("runtests_init_expressions.jl")
+
+    # Conditionally run extension tests if environment variable is set.
+    if get(ENV, "FUSE_WITH_EXTENSIONS", "false") == "true"
+        include("runtests_study.jl")
+    end
+
+    println(FUSE.timer)
 end
-using FUSE
-using Test
-
-include("runtests_warmup.jl")
-
-include("runtests_basics.jl")
-
-include("runtests_ini_act.jl")
-
-include("runtests_cases.jl")
-
-include("runtests_actors.jl")
-
-include("runtests_init_expressions.jl")
-
-if get(ENV, "FUSE_WITH_EXTENSIONS", "false") == "true"
-    include("runtests_study.jl")
-end
-
-println(FUSE.timer)

--- a/test/runtests_study.jl
+++ b/test/runtests_study.jl
@@ -9,21 +9,49 @@ using Distributed
     sty.file_save_mode = :append
     sty.save_folder = mktempdir()
     sty.n_simulations = 2
+    sty.release_workers_after_run = false
+
 
     ini, act = FUSE.case_parameters(:ITER; init_from=:scalars)
     act.ActorPedestal.density_match = :ne_line
     ini.core_profiles.ne_setting = :greenwald_fraction
     ini.core_profiles.ne_value = 0.2 ↔ [0.2, 1.0]
 
+    act.ActorSimpleEC.actuator[1].rho_0 = 0.3 ↔ [0.29, 0.81]
+
+    # The study must be created first, inside of which the parallel_environment is set.
+    study = FUSE.StudyDatabaseGenerator(sty, ini, act)
+
     @everywhere import FUSE
+    @everywhere ProgressMeter = FUSE.ProgressMeter
 
     @everywhere function workflow_DatabaseGenerator(dd::FUSE.IMAS.dd, ini::FUSE.ParametersAllInits, act::FUSE.ParametersAllActors)
         FUSE.init(dd, ini, act)
         return nothing
     end
 
-    study = FUSE.StudyDatabaseGenerator(sty, ini, act)
     study.workflow = workflow_DatabaseGenerator
 
+    @info "Running study... "
     FUSE.run(study)
+
+    @testset "inis and acts" begin
+        ini_list = [rand(ini) for _ in 1:2]
+        act_list = [rand(act) for _ in 1:2]
+
+        study = FUSE.StudyDatabaseGenerator(sty, ini_list, act_list)
+        study.workflow = workflow_DatabaseGenerator
+
+        @info "Running study for predefined `inis` and `acts`..."
+        FUSE.run(study)
+    end
+
+    # Manual release of workers
+    workers_list = Distributed.workers()
+    if !isempty(workers_list)
+        Distributed.rmprocs(workers_list)
+        @info "released $(length(workers_list)) workers: $workers_list"
+    else
+        @info "no workers to release"
+    end
 end


### PR DESCRIPTION
## Summary
- This PR is based on the open PR https://github.com/ProjectTorreyPines/FUSE.jl/pull/816
- Fixed type annotations in `DatabaseGenerator` for handling multiple `inis` and `acts`
- Added new tests for `DatabaseGenerateor`
  - One can test only this by running `Pkg.test(;test_args=["runtests_study.jl"])`

## Description

This PR makes several improvements to the DatabaseGenerator study and test runner:
  
- **DatabaseGenerator Updates:**
  - Changed the type annotation for `ini` and `act` to allow vectors (i.e., `Vector{<:ParametersAllInits}` and `Vector{<:ParametersAllActors}`), ensuring flexibility of study for multiple inis and acts.
  - Modified `StudyDatabaseGenerator` to properly handle both single and vector cases for `ini` and `act`.  

- **Test Runner Enhancements:**
  - Revised `runtests.jl` to support both environment variable `FUSE_WITH_EXTENSIONS` and ARGS-based test selection, allowing users to run only specific test files if desired.
    - e.g., `Pkg.test(;test_args=["runtests_study.jl"])`
  - Improved logging for worker release in `runtests_study.jl`, explicitly checking for existing workers before removing them.

## Testing
- Passed a test of `test/runtests_study.jl`.

