### PR TITLE
Enhance load_database Performance & Reduce Database File Size

### DIFF
--- a/src/parameters/parameters_inits.jl
+++ b/src/parameters/parameters_inits.jl
@@ -205,7 +205,7 @@ Base.@kwdef mutable struct FUSEparameters__build_layer{T} <: ParametersInit{T}
     name::Entry{String} = Entry{String}("-", "Name of the layer")
     thickness::Entry{Float64} =
         Entry{Float64}("-", "Relative thickness of the layer (layers actual thickness is scaled to match plasma R0)"; check=x -> @assert x >= 0.0 "must be: thickness >= 0.0")
-    material::Switch{Symbol} = Switch{Symbol}(FusionMaterials.all_materials(), "-", "Material of the layer")
+    material::Switch{Symbol} = Switch{Symbol}(FusionMaterials.ALL_MATERIALS, "-", "Material of the layer")
     coils_inside::Entry{Union{Int,Vector{Int}}} = Entry{Union{Int,Vector{Int}}}(
         "-",
         "List of coils within this layer";

--- a/src/utils_end.jl
+++ b/src/utils_end.jl
@@ -605,9 +605,9 @@ function load_database(filename::AbstractString, parent_groups::Vector{<:Abstrac
     Nparents = length(parent_groups)
 
     # Prepare output data
-    dds = occursin(pattern, "dd.h5") ? fill(IMAS.dd(), Nparents) : nothing
-    inis = occursin(pattern, "ini.h5") ? fill(ParametersInits(), Nparents) : nothing
-    acts = occursin(pattern, "act.h5") ? fill(ParametersActors(), Nparents) : nothing
+    dds = occursin(pattern, "dd.h5") || occursin(pattern, "dd.json") ? fill(IMAS.dd(), Nparents) : nothing
+    inis = occursin(pattern, "ini.h5") || occursin(pattern, "ini.json")  ? fill(ParametersInits(), Nparents) : nothing
+    acts = occursin(pattern, "act.h5") || occursin(pattern, "act.json") ? fill(ParametersActors(), Nparents) : nothing
     logs = occursin(pattern, "log.txt") ? fill("", Nparents) : nothing
     timers = occursin(pattern, "timer.txt") ? fill("", Nparents) : nothing
     errors = occursin(pattern, "error.txt") ? fill("", Nparents) : nothing
@@ -618,10 +618,16 @@ function load_database(filename::AbstractString, parent_groups::Vector{<:Abstrac
             h5path = gparent * "/" * key
             if key == "dd.h5"
                 dds[k] = IMAS.hdf2imas(filename, h5path)
+            elseif key == "dd.json"
+                dds[k] = IMAS.jstr2imas(H5_fid[h5path][])
             elseif key == "ini.h5"
                 inis[k] = SimulationParameters.hdf2par(H5_fid[h5path], ParametersInits())
+            elseif key == "ini.json"
+                inis[k] = SimulationParameters.jstr2par(H5_fid[h5path][], ParametersInits())
             elseif key == "act.h5"
                 acts[k] = SimulationParameters.hdf2par(H5_fid[h5path], ParametersActors())
+            elseif key == "act.json"
+                acts[k] = SimulationParameters.jstr2par(H5_fid[h5path][], ParametersActors())
             elseif key == "log.txt"
                 logs[k] = H5_fid[h5path][]
             elseif key == "timer.txt"


### PR DESCRIPTION
## Prerequisite
- This PR depends on https://github.com/ProjectTorreyPines/FusionMaterials.jl/pull/13

## Summary
- **Use cached `ALL_MATERIALS` instead of `all_materials()`**
  - This change significantly improves the performance of loading `ini`
  
- **New keyword `sub_format` for `sample_and_write_database` function**
  - If `sub_format=:json`, it samples and writes the new database with `dd.json`, `ini.json`, and `act.json`.
  - Using `JSON` for subgroups (e.g., `dd.json`) leads to a smaller `database.h5` size and so faster loading, although it may lose some additional meta information.
  
- **JSON support  in `load_database` function**
  - The `load_database` can now read `dd.json`, `ini.json`, and `act.json` in addition to existing HDF5 formats (`dd.h5`, `ini.h5`, `act.h5`).

## Example 
- Before this PR: 
  - Test database file: `filtered_only.h5`  (851 MB for 153 cases) (@TimSlendebroek provided)
  - `load_database("filtered_only.h5")` took about 135 seconds.
  
- After this PR:
  - First, convert the original database file into new one with `json` sub-groups: 
     ```julia
     FUSE.sample_and_write_database("filtered_only.h5", "filtered_json.h5"; sampling_ratio=1.01, sub_format=:json)
    ```
   -  new database file: `filtered_json.h5`  (225 MB for 153 cases)
  - `load_database("filtered_json.h5")` took about 30 seconds.

- File size: 851 MB ==> 225 MB 
- Loading time: 135 secs ==> 30 secs

## Future work
- I will implement an additional option in StudyParameters to allow using `sub_format=:json` for creating smaller `database.h5`