### PR TITLE
WIP: remove GS_IMAS_pf_active__coil

### DIFF
--- a/src/actors/pf/pf_plots.jl
+++ b/src/actors/pf/pf_plots.jl
@@ -79,16 +79,7 @@ Plot recipe for ActorPFdesign and ActorPFactive
         R = range(xlim[1], xlim[2], ngrid)
         Z = range(ylim[1], ylim[2], Int(ceil(ngrid * (ylim[2] - ylim[1]) / (xlim[2] - xlim[1]))))
 
-        coils = VacuumFields.GS_IMAS_pf_active__coil{D,D}[]
-        for coil in dd.pf_active.coil
-            if IMAS.is_ohmic_coil(coil)
-                coil_tech = dd.build.oh.technology
-            else
-                coil_tech = dd.build.pf_active.technology
-            end
-            coil = VacuumFields.GS_IMAS_pf_active__coil(coil, coil_tech, par.green_model)
-            push!(coils, coil)
-        end
+        coils = VacuumFields.MultiCoils(dd.pf_active)
 
         # ψ coil currents
         ψbound = actor.eqt_out.global_quantities.psi_boundary

--- a/src/cases/SPARC.jl
+++ b/src/cases/SPARC.jl
@@ -14,7 +14,6 @@ function case_parameters(::Type{Val{:SPARC}}; init_from::Symbol, flux_matcher::B
         ini.ods.filename = "$(machine_ods)"
         act.ActorCXbuild.rebuild_wall = false
         act.ActorWholeFacility.update_build = false
-        act.ActorPFactive.green_model = :point
         act.ActorVerticalStability.model = false # throws an error
     end
 
@@ -29,7 +28,7 @@ function case_parameters(::Type{Val{:SPARC}}; init_from::Symbol, flux_matcher::B
     ini.equilibrium.ip = 8.7e6
     ini.equilibrium.xpoints = :double
 
-    # explicitly set thickness of 
+    # explicitly set thickness of
     ini.build.n_first_wall_conformal_layers = 4
     layers = OrderedCollections.OrderedDict{Symbol,Float64}()
     layers[:gap_OH] = 0.43


### PR DESCRIPTION
The goal here is to use VacuumFields coils more broadly in ActorPFdesign, ideally getting rid of the GS_IMAS_pf_active__coil infrastructure which is kind of a Frankenstein of IMAS and VacuumFields.

Currently this is only partial work, which I'm saving for posterity.