### PR TITLE
Update DTT case

### DIFF
--- a/src/cases/DTT.jl
+++ b/src/cases/DTT.jl
@@ -98,6 +98,8 @@ function case_parameters(::Type{Val{:DTT}})
 
     #### ACT ####
     act.ActorPFdesign.symmetric = true
+    act.ActorPFactive.x_points_weight = 0.025
+    act.ActorTEQUILA.number_of_MXH_harmonics = 6
 
     act.ActorTGLF.tglfnn_model = "sat1_em_d3d"
 


### PR DESCRIPTION
The equilibrium solves in the DTT case are somewhat finnicky. These seem to be more robust settings, and hopefully fix the test that currently failing.