### PR TITLE
BgB model

### DIFF
--- a/src/actors/transport/analytical_turbulence_actor.jl
+++ b/src/actors/transport/analytical_turbulence_actor.jl
@@ -1,4 +1,5 @@
 import GACODE
+import IMAS
 
 #= ======================= =#
 #  ActorAnalyticTurbulence  #
@@ -7,7 +8,8 @@ Base.@kwdef mutable struct FUSEparameters__ActorAnalyticTurbulence{T<:Real} <: P
     _parent::WeakRef = WeakRef(nothing)
     _name::Symbol = :not_set
     _time::Float64 = NaN
-    model::Switch{Symbol} = Switch{Symbol}([:GyroBohm], "-", "Analytic transport model"; default=:GyroBohm)
+    model::Switch{Symbol} = Switch{Symbol}([:GyroBohm,:BgB], "-", "Analytic transport model"; default=:GyroBohm)
+    αBgB::Entry{T} = Entry{T}("-", "Scale factor for BgB transport"; default=0.2)
     rho_transport::Entry{AbstractVector{T}} = Entry{AbstractVector{T}}("-", "rho_tor_norm values to compute fluxes on"; default=0.25:0.1:0.85)
 end
 
@@ -45,9 +47,55 @@ function _step(actor::ActorAnalyticTurbulence)
     par = actor.par
 
     cp1d = dd.core_profiles.profiles_1d[]
+    eqt = dd.equilibrium.time_slice[]
+    eqt1d = eqt.profiles_1d
+    b0 = eqt.global_quantities.vacuum_toroidal_field.b0
+    if actor.par.model == :GyroBohm
+        flux_solution = GACODE.FluxSolution(1.0, 1.0, 1.0, [1.0 for ion in cp1d.ion], 1.0)
+        actor.flux_solutions = [flux_solution for irho in par.rho_transport]
+    elseif actor.par.model == :BgB
+        A1  = 1.0
+        A2 = 0.3
+    
+        rho_cp = cp1d.grid.rho_tor_norm
+        rho_eq = eqt1d.rho_tor_norm
+    
+        q_profile = IMAS.interp1d(rho_eq, eqt1d.q).(rho_cp)
 
-    flux_solution = GACODE.FluxSolution(1.0, 1.0, 1.0, [1.0 for ion in cp1d.ion], 1.0)
-    actor.flux_solutions = [flux_solution for irho in par.rho_transport]
+        rmin = GACODE.r_min_core_profiles(eqt1d, rho_cp)
+        Te = cp1d.electrons.temperature
+        dlntedr = .-IMAS.calc_z(rmin, Te, :backward)
+        ne = cp1d.electrons.density_thermal #./ IMAS.cgs.m³_to_cm³
+        dlnnedr = .-IMAS.calc_z(rmin, ne, :backward)
+
+        Ti = cp1d.ion[1].temperature
+        zeff = cp1d.zeff
+        dlntidr = .-IMAS.calc_z(rmin, Ti, :backward)
+
+        Q_GB = GACODE.gyrobohm_energy_flux(cp1d,eqt)
+        Γ_GB = GACODE.gyrobohm_particle_flux(cp1d,eqt)
+        rho_s = GACODE.rho_s(cp1d,eqt)/IMAS.cgs.m_to_cm# *1e-2
+
+        dpe = @. ne*IMAS.mks.e*Te*(dlntedr .+ dlnnedr) 
+        dpi = @. ne*IMAS.mks.e*Ti*(dlntidr .+ dlnnedr) / zeff
+        χeB = @.  (Te/abs(b0)) * rmin[end] *  (dlntedr .+ dlnnedr) * q_profile^2
+        χeGB = @. (Te/abs(b0)) * abs(rho_s) * rmin[end] * dlntedr 
+        χe = @. actor.par.αBgB * (0.01*χeB+50.0*χeGB)
+        χi = @. actor.par.αBgB * (0.001*χeB+1.0*χeGB)
+        Γe = @. (A1+(A2-A1)*rho_cp)*χe*χi/(χe+χi) * dlnnedr  * ne
+        gridpoint_cp = [argmin_abs(cp1d.grid.rho_tor_norm, ρ) for ρ in par.rho_transport]
+
+        actor.flux_solutions = [
+            GACODE.FluxSolution(
+                χe[irho] * dpe[irho] / Q_GB[irho],
+                χi[irho] * dpi[irho] / Q_GB[irho],
+                Γe[irho]/Γ_GB[irho],
+                [Γe[irho]/Γ_GB[irho] / ion.element[1].z_n for ion in cp1d.ion],
+                1.0
+            )
+            for irho in gridpoint_cp
+        ]
+    end
 
     return actor
 end

--- a/src/actors/transport/analytical_turbulence_actor.jl
+++ b/src/actors/transport/analytical_turbulence_actor.jl
@@ -9,7 +9,7 @@ Base.@kwdef mutable struct FUSEparameters__ActorAnalyticTurbulence{T<:Real} <: P
     _name::Symbol = :not_set
     _time::Float64 = NaN
     model::Switch{Symbol} = Switch{Symbol}([:GyroBohm,:BgB], "-", "Analytic transport model"; default=:GyroBohm)
-    αBgB::Entry{T} = Entry{T}("-", "Scale factor for BgB transport"; default=0.2)
+    αBgB::Entry{T} = Entry{T}("-", "Scale factor for BgB transport"; default=0.15)
     rho_transport::Entry{AbstractVector{T}} = Entry{AbstractVector{T}}("-", "rho_tor_norm values to compute fluxes on"; default=0.25:0.1:0.85)
 end
 
@@ -61,11 +61,10 @@ function _step(actor::ActorAnalyticTurbulence)
         rho_eq = eqt1d.rho_tor_norm
     
         q_profile = IMAS.interp1d(rho_eq, eqt1d.q).(rho_cp)
-
         rmin = GACODE.r_min_core_profiles(eqt1d, rho_cp)
         Te = cp1d.electrons.temperature
         dlntedr = .-IMAS.calc_z(rmin, Te, :backward)
-        ne = cp1d.electrons.density_thermal #./ IMAS.cgs.m³_to_cm³
+        ne = cp1d.electrons.density_thermal
         dlnnedr = .-IMAS.calc_z(rmin, ne, :backward)
 
         Ti = cp1d.ion[1].temperature
@@ -74,7 +73,7 @@ function _step(actor::ActorAnalyticTurbulence)
 
         Q_GB = GACODE.gyrobohm_energy_flux(cp1d,eqt)
         Γ_GB = GACODE.gyrobohm_particle_flux(cp1d,eqt)
-        rho_s = GACODE.rho_s(cp1d,eqt)/IMAS.cgs.m_to_cm# *1e-2
+        rho_s = GACODE.rho_s(cp1d,eqt)/IMAS.cgs.m_to_cm
 
         dpe = @. ne*IMAS.mks.e*Te*(dlntedr .+ dlnnedr) 
         dpi = @. ne*IMAS.mks.e*Ti*(dlntidr .+ dlnnedr) / zeff


### PR DESCRIPTION
I've implemented the BgB from what I can tell χe and χi are from: https://arxiv.org/pdf/2403.09460 and https://iopscience.iop.org/article/10.1088/0029-5515/38/7/305/meta

Example use of it. 

```
using Revise
using FUSE

ini,act = FUSE.case_parameters(:STEP)
dd = FUSE.init(ini, act);

act.ActorFluxCalculator.turbulence_model = :analytical
act.ActorFluxMatcher.algorithm = :broyden #:simple
act.ActorFluxMatcher.evolve_densities = :flux_match
act.ActorFluxMatcher.max_iterations = 20
act.ActorAnalyticTurbulence.model = :BgB
act.ActorAnalyticTurbulence.αBgB = 0.15
act.ActorFluxMatcher.step_size =0.25
FUSE.ActorFluxMatcher(dd,act)
display(FUSE.plot(dd.core_profiles))
FUSE.plot(dd.core_transport)
```

![Screenshot 2025-05-30 at 11 46 16 AM](https://github.com/user-attachments/assets/5c7a9bd5-84b2-4179-b315-94d68e3168b6)
