### PR TITLE
Add `DeepWiki` badge in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ProjectTorreyPines/FUSE.jl)
+
 # FUSE.jl
 
 FUSE (**FU**sion **S**ynthesis **E**ngine) is an open-source framework for integrated simulations of fusion devices.
@@ -41,7 +43,7 @@ FUSE is entirely written in Julia and is structured around the following core co
 6. **🔄 Studies**: Studies pre-bake commonly used functionalities, typically involving multiple FUSE simulations (eg. database generation or multi objective optimizations).
 7. **🌍 Interoperability**: FUSE interfaces via `dd` with existing modeling tools like OMFIT/OMAS and the IMAS ecosystem.
 
-A diagram illustrating these concepts is provided below:  
+A diagram illustrating these concepts is provided below:
 ![FUSE Diagram](./docs/src/assets/FUSE.svg)
 
 ## Usage Example


### PR DESCRIPTION
This pull request adds a `DeepWiki` badge to the `README.md` file to link to the project's DeepWiki page.
`DeepWiki` appears to be very helpful for users to understand the general code structure and usage, in addition to our existing online documentation.

FYI, the DeepWiki page for `FUSE` is the following:
https://deepwiki.com/ProjectTorreyPines/FUSE.jl