### PR TITLE
Include magnetics hardware in DIII-D OMAS fetch

### DIFF
--- a/src/cases/D3D.jl
+++ b/src/cases/D3D.jl
@@ -91,6 +91,9 @@ function case_parameters(::Type{Val{:D3D}}, shot::Int;
         printe("- Fetching wall data")
         d3d.wall(ods, $shot)
 
+        printe("- Fetching magnetic hardware data")
+        d3d.magnetics_hardware(ods, $shot)
+
         printe("- Fetching coils data")
         d3d.pf_active_hardware(ods, $shot)
         d3d.pf_active_coil_current_data(ods, $shot)


### PR DESCRIPTION
This is essential to define the correct measurement positions and does vary throughout the machine history (e.g. with shot number).