### PR TITLE
Fix user-defined ped_to_sep ratio in ActorPedestal and add fast ion physics to ActorSimpleNB

### DIFF
--- a/src/actors/hcd/nbi/nb_simple_actor.jl
+++ b/src/actors/hcd/nbi/nb_simple_actor.jl
@@ -263,6 +263,10 @@ function _step(actor::ActorSimpleNB)
         ion.power_inside = source1d.total_ion_power_inside
         ion.fast_particles_energy = beam_energy
     end
+    # Add this line to populate fast ion physics
+    IMAS.fast_particles_profiles!(dd)
+
+
     IMAS.unfreeze!(cp1d, :zeff)
 
     return actor

--- a/src/actors/pedestal/pedestal_actor.jl
+++ b/src/actors/pedestal/pedestal_actor.jl
@@ -22,6 +22,8 @@ Base.@kwdef mutable struct FUSEparameters__ActorPedestal{T<:Real} <: ParametersA
     #== actor parameters==#
     density_match::Switch{Symbol} = Switch{Symbol}([:ne_line, :ne_ped], "-", "Matching density based on ne_ped or line averaged density"; default=:ne_ped)
     model::Switch{Symbol} = Switch{Symbol}([:EPED, :WPED, :dynamic, :analytic, :replay, :none], "-", "Pedestal model to use"; default=:EPED)
+    apply_pedestal_density_tanh::Entry{Bool} = Entry{Bool}("-", "Apply tanh-shaped density profile in pedestal region"; default=true)
+
     #== L to H and H to L transition model ==#
     tau_t::Entry{T} = Entry{T}("s", "pedestal temperature LH transition tanh evolution time (95% of full transition)")
     tau_n::Entry{T} = Entry{T}("s", "pedestal density LH transition tanh evolution time (95% of full transition)")
@@ -281,7 +283,9 @@ function run_selected_pedestal_model(actor::ActorPedestal; density_factor::Float
     eqt = eq.time_slice[]
     cp1d = dd.core_profiles.profiles_1d[]
     if par.density_match == :ne_ped
-        pedestal_density_tanh(dd, par; density_factor, zeff_factor)
+        if par.apply_pedestal_density_tanh
+            pedestal_density_tanh(dd, par; density_factor, zeff_factor)
+        end 
         finalize(step(actor.ped_actor))
 
     elseif par.density_match == :ne_line
@@ -291,8 +295,10 @@ function run_selected_pedestal_model(actor::ActorPedestal; density_factor::Float
 
         # run pedestal model on scaled density
         par.ne_from = :core_profiles
-        pedestal_density_tanh(dd, par; density_factor=1.0, zeff_factor)
-
+        if par.apply_pedestal_density_tanh
+            pedestal_density_tanh(dd, par; density_factor=1.0, zeff_factor)
+        end
+        
         try
             # scale thermal densities to match desired line average (and temperatures accordingly, in case they matter)
             # we can do this because EPED and WPED only operate on temperature profiles

--- a/src/actors/pedestal/pedestal_actor.jl
+++ b/src/actors/pedestal/pedestal_actor.jl
@@ -22,8 +22,6 @@ Base.@kwdef mutable struct FUSEparameters__ActorPedestal{T<:Real} <: ParametersA
     #== actor parameters==#
     density_match::Switch{Symbol} = Switch{Symbol}([:ne_line, :ne_ped], "-", "Matching density based on ne_ped or line averaged density"; default=:ne_ped)
     model::Switch{Symbol} = Switch{Symbol}([:EPED, :WPED, :dynamic, :analytic, :replay, :none], "-", "Pedestal model to use"; default=:EPED)
-    apply_pedestal_density_tanh::Entry{Bool} = Entry{Bool}("-", "Apply tanh-shaped density profile in pedestal region"; default=true)
-
     #== L to H and H to L transition model ==#
     tau_t::Entry{T} = Entry{T}("s", "pedestal temperature LH transition tanh evolution time (95% of full transition)")
     tau_n::Entry{T} = Entry{T}("s", "pedestal density LH transition tanh evolution time (95% of full transition)")
@@ -242,21 +240,36 @@ function pedestal_density_tanh(dd::IMAS.dd, par::OverrideParameters{P,FUSEparame
     # Throughout FUSE, the "pedestal" values are defined at rho=0.9
     rho09 = 0.9
 
+    # Preserve user's desired sep-to-ped ratio from ini parameters
+    current_ne_ped = IMAS.interp1d(rho, cp1d.electrons.density_thermal)(rho09)
+    current_ne_sep = cp1d.electrons.density_thermal[end]
+    user_sep_to_ped_ratio = current_ne_sep / current_ne_ped
+
     # density pedestal width to match the existing temperature pedestal width
     w_ped = IMAS.pedestal_tanh_width_half_maximum(rho, cp1d.electrons.temperature)
 
     ne_old = copy(cp1d.electrons.density_thermal)
     ne_ped = IMAS.get_from(dd, Val{:ne_ped}, par.ne_from, rho09) * density_factor
-    cp1d.electrons.density_thermal[end] = ne_ped / 4.0
+    
+    # Use user's ratio instead of hardcoded /4.0
+    cp1d.electrons.density_thermal[end] = ne_ped * user_sep_to_ped_ratio
+    
     ne = IMAS.blend_core_edge_Hmode(cp1d.electrons.density_thermal, rho, ne_ped, w_ped, par.rho_nml, par.rho_ped; method=:scale)
     cp1d.electrons.density_thermal = ne = IMAS.ped_height_at_09(rho, ne, ne_ped)
     ratio = ne ./ ne_old
 
     for ion in cp1d.ion
         if !ismissing(ion, :density_thermal)
+            # Preserve user's ion ratio instead of always 25% of ne_ped
+            current_ni_ped = IMAS.interp1d(rho, ion.density_thermal)(rho09)
+            current_ni_sep = ion.density_thermal[end]
+            ion_user_sep_to_ped_ratio = current_ni_sep / current_ni_ped
+            
             ion.density_thermal = ion.density_thermal .* ratio
             ni_ped = IMAS.interp1d(rho, ion.density_thermal).(rho09)
-            ion.density_thermal[end] = ni_ped / 4.0
+            
+            ion.density_thermal[end] = ni_ped * ion_user_sep_to_ped_ratio
+            
             ni = IMAS.blend_core_edge_Hmode(ion.density_thermal, rho, ni_ped, w_ped, par.rho_nml, par.rho_ped; method=:scale)
             ion.density_thermal = IMAS.ped_height_at_09(rho, ni, ni_ped)
         end
@@ -283,9 +296,7 @@ function run_selected_pedestal_model(actor::ActorPedestal; density_factor::Float
     eqt = eq.time_slice[]
     cp1d = dd.core_profiles.profiles_1d[]
     if par.density_match == :ne_ped
-        if par.apply_pedestal_density_tanh
-            pedestal_density_tanh(dd, par; density_factor, zeff_factor)
-        end 
+        pedestal_density_tanh(dd, par; density_factor, zeff_factor)
         finalize(step(actor.ped_actor))
 
     elseif par.density_match == :ne_line
@@ -295,10 +306,8 @@ function run_selected_pedestal_model(actor::ActorPedestal; density_factor::Float
 
         # run pedestal model on scaled density
         par.ne_from = :core_profiles
-        if par.apply_pedestal_density_tanh
-            pedestal_density_tanh(dd, par; density_factor=1.0, zeff_factor)
-        end
-        
+        pedestal_density_tanh(dd, par; density_factor=1.0, zeff_factor)
+
         try
             # scale thermal densities to match desired line average (and temperatures accordingly, in case they matter)
             # we can do this because EPED and WPED only operate on temperature profiles

--- a/src/studies/multi_objective_optimization.jl
+++ b/src/studies/multi_objective_optimization.jl
@@ -61,27 +61,71 @@ function StudyMultiObjectiveOptimizer(
     return setup(study)
 end
 
+# Helper function for safe worker cleanup (only targets distributed workers)
+function cleanup_workers(study::StudyMultiObjectiveOptimizer)
+    current_workers = Distributed.workers()
+    if !isempty(current_workers)
+        try
+            @info "Cleaning up $(length(current_workers)) distributed workers (PIDs: $current_workers)..."
+            Distributed.rmprocs(current_workers)
+            @info "Distributed workers successfully cleaned up"
+        catch e
+            @warn "Failed to clean up workers: $e"
+            # Force kill if cleanup fails
+            try
+                for pid in current_workers
+                    Distributed.rmprocs(pid; waitfor=0)
+                end
+            catch
+                @warn "Force cleanup also failed - you may need to manually kill worker processes"
+            end
+        end
+    else
+        @info "No distributed workers to clean up"
+    end
+end
+
 function _setup(study::StudyMultiObjectiveOptimizer)
     sty = study.sty
 
-    check_and_create_file_save_mode(sty)
+    try
+        check_and_create_file_save_mode(sty)
+        
+        # CLEAN STARTUP - Use our helper function to clean any existing workers
+        cleanup_workers(study)
+        
+        # Now set up exactly what we need
+        parallel_environment(sty.server, sty.n_workers)
+        
+        # Verify we got what we expected
+        actual_workers = length(Distributed.workers())
+        if actual_workers != sty.n_workers
+            error("Expected $(sty.n_workers) workers but got $actual_workers")
+        end
+        
+        @info "Successfully set up $actual_workers fresh workers"
 
-    parallel_environment(sty.server, sty.n_workers)
-
-    # import FUSE and IJulia on workers
-    if isdefined(Main, :IJulia)
-        code = """
-        using Distributed
-        @everywhere import FUSE
-        @everywhere import IJulia
-        """
-    else
-        code = """
-        using Distributed
-        @everywhere import FUSE
-        """
+        # Import packages on workers
+        if isdefined(Main, :IJulia)
+            code = """
+            using Distributed
+            @everywhere import FUSE
+            @everywhere import IJulia
+            """
+        else
+            code = """
+            using Distributed
+            @everywhere import FUSE
+            """
+        end
+        Base.include_string(Main, code)
+        
+    catch e
+        @error "Setup failed: $(string(e))"
+        cleanup_workers(study)
+        rethrow(e)
     end
-    Base.include_string(Main, code)
+    
     return study
 end
 
@@ -96,75 +140,94 @@ function _run(study::StudyMultiObjectiveOptimizer)
         max_gens_per_iteration = sty.restart_workers_after_n_generations
         steps = Int(ceil(sty.number_of_generations / max_gens_per_iteration))
         sty_bkp = deepcopy(sty)
-        for i in 1:steps
-            try
-                println("Running $max_gens_per_iteration generations ($i / $steps)")
-                gens = max_gens_per_iteration
-                if i == steps && mod(sty.number_of_generations, max_gens_per_iteration) != 0
-                    gens = mod(sty.restart_workers_after_n_generations, max_gens_per_iteration)
-                end
-                sty.restart_workers_after_n_generations = 0
-                sty.release_workers_after_run = false
-                sty.file_save_mode = :append
-                sty.number_of_generations = gens
+        
+        try
+            for i in 1:steps
+                try
+                    println("Running $max_gens_per_iteration generations ($i / $steps)")
+                    gens = max_gens_per_iteration
+                    if i == steps && mod(sty.number_of_generations, max_gens_per_iteration) != 0
+                        gens = mod(sty.restart_workers_after_n_generations, max_gens_per_iteration)
+                    end
+                    sty.restart_workers_after_n_generations = 0
+                    sty.release_workers_after_run = false
+                    sty.file_save_mode = :append
+                    sty.number_of_generations = gens
 
-                if study.state !== nothing
-                    study.state = load_optimization(joinpath(sty.save_folder, "results.jls")).state
-                    study.generation += study.state.iteration
+                    if study.state !== nothing
+                        study.state = load_optimization(joinpath(sty.save_folder, "results.jls")).state
+                        study.generation += study.state.iteration
+                    end
+                    run(study)
+                    
+                catch e
+                    @error "Error occurred in step $i: $(string(e))"
+                    if isa(e, InterruptException)
+                        @info "Interrupted - cleaning up workers before exit"
+                        cleanup_workers(study)
+                        rethrow(e)
+                    else
+                        # For any other error, clean workers and stop execution
+                        @error "Optimization failed - cleaning workers and stopping execution"
+                        cleanup_workers(study)
+                        rethrow(e)  # This will stop the script!
+                    end
+                finally
+                    # Restore original parameters
+                    sty.restart_workers_after_n_generations = sty_bkp.restart_workers_after_n_generations
+                    sty.release_workers_after_run = sty_bkp.release_workers_after_run
+                    sty.file_save_mode = sty_bkp.file_save_mode
                 end
-                run(study)
-            catch e
-                if isa(e, InterruptException)
-                    rethrow(e)
-                end
-                @warn "error occured in step $i \n $(string(e))"
-            finally
-                sty.restart_workers_after_n_generations = sty_bkp.restart_workers_after_n_generations
-                sty.release_workers_after_run = sty_bkp.release_workers_after_run
-                sty.file_save_mode = sty_bkp.file_save_mode
             end
+        finally
+            # Always cleanup workers at the end, regardless of what happened
+            cleanup_workers(study)
         end
-        Distributed.rmprocs(Distributed.workers())
-        @info "released workers"
 
     else
-        setup(study)
-        optimization_parameters = Dict(
-            :N => sty.population_size,
-            :iterations => sty.number_of_generations,
-            :continue_state => study.state,
-            :save_folder => sty.save_folder)
+        # Single run without restarts
+        try
+            # Workers already set up in constructor - no need to setup again
+            optimization_parameters = Dict(
+                :N => sty.population_size,
+                :iterations => sty.number_of_generations,
+                :continue_state => study.state,
+                :save_folder => sty.save_folder)
 
-        @assert !isempty(sty.save_folder) "Specify where you would like to store your optimization results in sty.save_folder"
+            @assert !isempty(sty.save_folder) "Specify where you would like to store your optimization results in sty.save_folder"
 
-        study.state = workflow_multiobjective_optimization(
-            study.ini, study.act, ActorStationaryPlasma, study.objective_functions, study.constraint_functions;
-            optimization_parameters..., generation_offset=study.generation, database_policy=sty.database_policy,
-            number_of_generations=sty.number_of_generations, population_size=sty.population_size)
+            study.state = workflow_multiobjective_optimization(
+                study.ini, study.act, ActorWholeFacility, study.objective_functions, study.constraint_functions;
+                optimization_parameters..., generation_offset=study.generation, database_policy=sty.database_policy,
+                number_of_generations=sty.number_of_generations, population_size=sty.population_size)
 
-        save_optimization(
-            joinpath(sty.save_folder, "optimization_state.bson"),
-            study.state,
-            study.ini,
-            study.act,
-            study.objective_functions,
-            study.constraint_functions)
+            save_optimization(
+                joinpath(sty.save_folder, "optimization_state.bson"),
+                study.state,
+                study.ini,
+                study.act,
+                study.objective_functions,
+                study.constraint_functions)
 
-        if study.sty.database_policy == :separate_folders
-            analyze(study; extract_results=true)
-        else
-            study.dataframe = _merge_tmp_study_files(sty.save_folder; cleanup=true)
-            analyze(study; extract_results=false)
+            if study.sty.database_policy == :separate_folders
+                analyze(study; extract_results=true)
+            else
+                study.dataframe = _merge_tmp_study_files(sty.save_folder; cleanup=true)
+                analyze(study; extract_results=false)
+            end
+
+        catch e
+            @error "Optimization failed: $(string(e))"
+            rethrow(e)
+        finally
+            # Always cleanup workers if requested or on error
+            if sty.release_workers_after_run
+                cleanup_workers(study)
+            end
         end
-
-        # Release workers after run
-        if sty.release_workers_after_run
-            Distributed.rmprocs(Distributed.workers())
-            @info "released workers"
-        end
-
-        return study
     end
+    
+    return study
 end
 
 function _merge_tmp_study_files(save_folder::AbstractString; cleanup::Bool=false)

--- a/src/studies/multi_objective_optimization.jl
+++ b/src/studies/multi_objective_optimization.jl
@@ -138,7 +138,7 @@ function _run(study::StudyMultiObjectiveOptimizer)
         @assert !isempty(sty.save_folder) "Specify where you would like to store your optimization results in sty.save_folder"
 
         study.state = workflow_multiobjective_optimization(
-            study.ini, study.act, ActorWholeFacility, study.objective_functions, study.constraint_functions;
+            study.ini, study.act, ActorStationaryPlasma, study.objective_functions, study.constraint_functions;
             optimization_parameters..., generation_offset=study.generation, database_policy=sty.database_policy,
             number_of_generations=sty.number_of_generations, population_size=sty.population_size)
 


### PR DESCRIPTION
## PR: Fix user-defined ped_to_sep ratio in ActorPedestal and add fast ion physics to ActorSimpleNB

### **Change 1: Fix ActorPedestal User-Defined Density Ratios** 
ActorPedestal was defaulting sep-to-ped density ratios ($n_{e,i}^{ped}/4$) instead of preserving user-defined ratios from initial conditions. Now calculates and maintains the user's existing `sep_to_ped_ratio` from the input profile for both electrons and ions when EPED & WPED models are called.

### **Change 2: Add Fast Ion Physics to ActorSimpleNB** 
Attempted to add `IMAS.fast_particles_profiles!(dd)` call to populate fast ion density/pressure profiles. Currently creates species mismatch error with FluxMatcher actor when ActorStationaryPlasma is run. 

### **Change 3: Fix Worker Buildup in Multi-Objective Optimizer**
(I am not sure if this fix is needed, but I was interested in seeing if I could deploy a fix)

Large buildup of Julia workers was occurring when MOOP crashed, leaving orphaned processes that consumed memory but no CPU time. Added `cleanup_workers()` function to remove distributed workers on startup and error conditions. Enhanced error handling with try-catch blocks to ensure workers are cleaned up even when optimization fails. 

Example of buildup after crash and rerun: 
<img width="1611" height="1041" alt="Screenshot 2025-07-21 at 1 46 08 PM" src="https://github.com/user-attachments/assets/ed5b9ea6-2c3e-48d0-865e-4bea518cc0a8" />