### PR TITLE
Remove vestigial `P` parameter in ActorTGLF

### DIFF
--- a/src/actors/transport/tglf_actor.jl
+++ b/src/actors/transport/tglf_actor.jl
@@ -46,7 +46,7 @@ function ActorTGLF(dd::IMAS.dd, act::ParametersAllActors; kw...)
     return actor
 end
 
-function ActorTGLF(dd::IMAS.dd{D}, par::FUSEparameters__ActorTGLF; kw...) where {D<:Real,P<:Real}
+function ActorTGLF(dd::IMAS.dd{D}, par::FUSEparameters__ActorTGLF; kw...) where {D<:Real}
     logging_actor_init(ActorTGLF)
     par = OverrideParameters(par; kw...)
     if par.model ∈ [:TGLF, :TGLFNN, :GKNN]


### PR DESCRIPTION
This was creating a precompilation warning:
```
┌ FUSE
│  WARNING: method definition for #ActorTGLF#1428 at /Users/lyons/.julia/dev/FUSE/src/actors/transport/tglf_actor.jl:49 declares type variable P but does not use it.
└  
```