### PR TITLE
Update perlmutter deploy script

### DIFF
--- a/deploy/perlmutter/deploy.sh
+++ b/deploy/perlmutter/deploy.sh
@@ -29,14 +29,7 @@ send_failure_notification() {
     
     # Create email body
     {
-        echo "Subject: Perlmutter FUSE build failure"
-        echo "From: $(whoami)@$(hostname)"
-        echo "To: $USER"
-        echo ""
         echo "Julia regression test/sysimage build failed with exit code: $exit_code"
-        echo "Timestamp: $(date)"
-        echo "Host: $(hostname)"
-        echo "User: $(whoami)"
         echo ""
         echo "Last 200 lines of output:"
         echo "=========================="

--- a/deploy/perlmutter/deploy.sh
+++ b/deploy/perlmutter/deploy.sh
@@ -67,4 +67,5 @@ if [[ $JULIA_EXIT_CODE -ne 0 ]]; then
 else
     /bin/cp -r $installdir $envdir
     /bin/cp $installdir/$fuse_env.lua $basedir/modules/fuse
+    /bin/ln -s $basedir/modules/fuse/$fuse_env.lua $basedir/modules/fuse/default.lua
 fi

--- a/deploy/perlmutter/deploy.sh
+++ b/deploy/perlmutter/deploy.sh
@@ -67,5 +67,6 @@ if [[ $JULIA_EXIT_CODE -ne 0 ]]; then
 else
     /bin/cp -r $installdir $envdir
     /bin/cp $installdir/$fuse_env.lua $basedir/modules/fuse
+    rm $basedir/modules/fuse/default.lua
     /bin/ln -s $basedir/modules/fuse/$fuse_env.lua $basedir/modules/fuse/default.lua
 fi

--- a/deploy/perlmutter/deploy.sh
+++ b/deploy/perlmutter/deploy.sh
@@ -55,6 +55,8 @@ export IJULIA_NODEFAULTKERNEL=1
 export JUPYTER_DATA_DIR="$installdir/.jupyter"
 
 scriptdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# This can be run as a scrontab so we need to clear SLURM environment variables
+unset ${!SLURM_@}
 
 srun --nodes 1 --qos regular --time 04:00:00 --constraint cpu --account m3739 --output $logfile julia $scriptdir/install_fuse_environment.jl
 JULIA_EXIT_CODE=$?


### PR DESCRIPTION
This PR:
- Adds E-Mail notifications of failed builds (for whoever is running the script)
- Adds a version specific log-file to the build process that also tracks previous attempts at building a version
- Moves the build process to the regular queue to adhere to NERSC's user guidelines
- Prevent copying of folders that do not exist due to failed build.