### PR TITLE
Return pid list in parallel_environment for cleanup

### DIFF
--- a/src/utils_begin.jl
+++ b/src/utils_begin.jl
@@ -163,6 +163,7 @@ Start multiprocessing environment
 """
 function parallel_environment(cluster::String="localhost", nworkers::Integer=-1, cpus_per_task::Int=1; memory_usage_fraction::Float64=0.5, kw...)
     if nworkers == 0
+        pid_list = []
         #pass
 
     elseif cluster == "omega"
@@ -178,7 +179,7 @@ function parallel_environment(cluster::String="localhost", nworkers::Integer=-1,
             gigamem_per_cpu = Int(ceil(memory_usage_fraction * gigamem_per_node / cpus_per_node * cpus_per_task))
             ENV["JULIA_WORKER_TIMEOUT"] = "360"
             if Distributed.nprocs() < np
-                Distributed.addprocs(
+                pid_list = Distributed.addprocs(
                     ClusterManagers.SlurmManager(np - Distributed.nprocs());
                     partition="ga-ird",
                     exclusive="",
@@ -206,7 +207,7 @@ function parallel_environment(cluster::String="localhost", nworkers::Integer=-1,
             gigamem_per_cpu = Int(ceil(memory_usage_fraction * gigamem_per_node / cpus_per_node * cpus_per_task))
             ENV["JULIA_WORKER_TIMEOUT"] = "360"
             if Distributed.nprocs() < np
-                Distributed.addprocs(
+                pid_list = Distributed.addprocs(
                     ClusterManagers.SlurmManager(np - Distributed.nprocs());
                     partition="pppl-medium",
                     exclusive="",
@@ -234,7 +235,7 @@ function parallel_environment(cluster::String="localhost", nworkers::Integer=-1,
             gigamem_per_cpu = Int(ceil(memory_usage_fraction * gigamem_per_node / cpus_per_node * cpus_per_task))
             ENV["JULIA_WORKER_TIMEOUT"] = "180"
             if Distributed.nprocs() < np
-                Distributed.addprocs(
+                pid_list = Distributed.addprocs(
                     ClusterManagers.SlurmManager(np - Distributed.nprocs());
                     exclusive="",
                     topology=:master_worker,
@@ -260,7 +261,7 @@ function parallel_environment(cluster::String="localhost", nworkers::Integer=-1,
             gigamem_per_cpu = Int(ceil(memory_usage_fraction * gigamem_per_node / cpus_per_node * cpus_per_task))
             ENV["JULIA_WORKER_TIMEOUT"] = "360"
             if Distributed.nprocs() < np
-                Distributed.addprocs(
+                pid_list = Distributed.addprocs(
                     ClusterManagers.SlurmManager(np - Distributed.nprocs());
                     partition="LocalQ",
                     topology=:master_worker,
@@ -287,7 +288,7 @@ function parallel_environment(cluster::String="localhost", nworkers::Integer=-1,
             gigamem_per_cpu = Int(ceil(memory_usage_fraction * gigamem_per_node / cpus_per_node * cpus_per_task))
             ENV["JULIA_WORKER_TIMEOUT"] = "360"
             if Distributed.nprocs() < np
-                Distributed.addprocs(
+                pid_list = Distributed.addprocs(
                     ClusterManagers.SlurmManager(np - Distributed.nprocs());
                     partition="sched_mit_psfc_r8",
                     exclusive="",
@@ -310,14 +311,14 @@ function parallel_environment(cluster::String="localhost", nworkers::Integer=-1,
         end
         np = nworkers + 1
         if Distributed.nprocs() < np
-            Distributed.addprocs(np - Distributed.nprocs(); topology=:master_worker, exeflags=["--heap-size-hint=$(mem_size)G"])
+            pid_list = Distributed.addprocs(np - Distributed.nprocs(); topology=:master_worker, exeflags=["--heap-size-hint=$(mem_size)G"])
         end
 
     else
         error("Cluster `$cluster` is unknown. Use `localhost` or add `$cluster` to the FUSE.parallel_environment")
     end
-
-    return println("Using $(Distributed.nprocs()-1) workers on $(gethostname())")
+    println("Using $(Distributed.nprocs()-1) workers on $(gethostname())")
+    return pid_list
 end
 
 """


### PR DESCRIPTION
This is a very simple addition that makes `parallel_environment` return the pids of the worker processes it creates. I am not 100% certain that this is the problem, but in my tests of FUSE in IRI running the code in https://github.com/ProjectTorreyPines/FuseExamples/pull/9 creates a Zombie in the end which I attribute to the  `Distributed` worker that is created but never terminated. In order to properly cleanup you need the pids from `parallel_environment`'s `Distributed.addprocs` call. This propagates them through.
Example of how it is used in https://github.com/ProjectTorreyPines/FuseExamples/pull/9