### PR TITLE
Fix FluxControlPoint vector type and Base.Dict extension

### DIFF
--- a/src/actors/equilibrium/chease_actor.jl
+++ b/src/actors/equilibrium/chease_actor.jl
@@ -112,7 +112,7 @@ function _finalize(actor::ActorCHEASE{D,P}) where {D<:Real, P<:Real}
 
         # Flux control points
         mag = VacuumFields.FluxControlPoint{D}(actor.chease.gfile.rmaxis, actor.chease.gfile.zmaxis, actor.chease.gfile.psi[1], iso_cps[1].weight)
-        flux_cps = VacuumFields.FluxControlPoint[mag]
+        flux_cps = VacuumFields.FluxControlPoint{D}[mag]
         strike_weight = act.ActorPFactive.strike_points_weight / length(eqt.boundary.strike_point)
         strike_cps = [VacuumFields.FluxControlPoint{D}(strike_point.r, strike_point.z, ψbound, strike_weight) for strike_point in eqt.boundary.strike_point]
         append!(flux_cps, strike_cps)

--- a/src/actors/equilibrium/tequila_actor.jl
+++ b/src/actors/equilibrium/tequila_actor.jl
@@ -219,7 +219,7 @@ function _finalize(actor::ActorTEQUILA{D,P}) where {D<:Real,P<:Real}
 
         # Flux control points
         mag = VacuumFields.FluxControlPoint{D}(eqt.global_quantities.magnetic_axis.r, eqt.global_quantities.magnetic_axis.z, psia, iso_cps[1].weight)
-        flux_cps = VacuumFields.FluxControlPoint[mag]
+        flux_cps = VacuumFields.FluxControlPoint{D}[mag]
         strike_weight = act.ActorPFactive.strike_points_weight / length(eqt.boundary.strike_point)
         strike_cps = [VacuumFields.FluxControlPoint{D}(strike_point.r, strike_point.z, ψbound, strike_weight) for strike_point in eqt.boundary.strike_point]
         append!(flux_cps, strike_cps)

--- a/src/utils_end.jl
+++ b/src/utils_end.jl
@@ -280,7 +280,7 @@ end
 
 Construct a Dictionary with the evaluated values of a dictionary of IMAS.ExtractFunction
 """
-function Dict(xtract::AbstractDict{Symbol,IMAS.ExtractFunction})
+function Base.Dict(xtract::AbstractDict{Symbol,IMAS.ExtractFunction})
     tmp = Dict()
     for xfun in values(xtract)
         tmp[xfun.name] = xfun.value


### PR DESCRIPTION
Two unrelated minor changes. The Base.Dict change is required in julia 1.12