### PR TITLE
allow for empty error history when TGLFNN fails

### DIFF
--- a/src/actors/transport/flux_matcher_actor.jl
+++ b/src/actors/transport/flux_matcher_actor.jl
@@ -283,14 +283,18 @@ function _step(actor::ActorFluxMatcher{D,P}) where {D<:Real,P<:Real}
             # NonlinearSolve returns the first value if the optimization was not successful
             # but we want it to return the best solution, even if the optimization did not
             # reach the desired tolerance
-            if norm(err_history[end]) == norm(err_history[1])
+            if !isempty(err_history) && length(err_history) > 1 && norm(err_history[end]) == norm(err_history[1])
                 pop!(err_history)
                 pop!(z_scaled_history)
             end
 
             # Extract the solution vector
-            k = argmin(map(norm, err_history))
-            res = (zero=z_scaled_history[k],)
+            if !isempty(err_history)
+                k = argmin(map(norm, err_history))
+                res = (zero=z_scaled_history[k],)
+            else
+                res = (zero=opt_parameters,)
+            end
         end
 
     finally


### PR DESCRIPTION
When running the flux-matcher, and TGLF-NN fails (e.g. running TGLF-NN `stfpp` model, with the default `act.ActorTGLF.lump_ions = true` and thus missing inputs), then the error history of the fluxmatcher is empty and causes an opaque failure. This edit allows the true nature of the failure and helpful hints to be presented to the user