### PR TITLE
Add MXH to FUSE

### DIFF
--- a/src/actors/transport/qlgyro_actor.jl
+++ b/src/actors/transport/qlgyro_actor.jl
@@ -16,6 +16,7 @@ import GACODE
     max_time::Entry{Float64} = Entry{Float64}("-", "Max simulation time (a/cs)"; default=100.0)
     rho_transport::Entry{AbstractVector{T}} = Entry{AbstractVector{T}}("-", "rho_tor_norm values to compute QLGYRO fluxes on"; default=0.25:0.1:0.85)
     lump_ions::Entry{Bool} = Entry{Bool}("-", "Lumps the fuel species (D,T) as well as the impurities together"; default=true)
+    MXH_modes::Entry{Int} = Entry{Int}("-", "Number of MXH harmonic modes (1 = standard Miller geometry)"; default=1)
 end
 
 mutable struct ActorQLGYRO{D,P} <: SingleAbstractActor{D,P}
@@ -92,7 +93,7 @@ function _step(actor::ActorQLGYRO)
             actor.input_qlgyros[k].SAT_RULE = 1
         end
 
-        actor.input_cgyros[k] = InputCGYRO(dd, gridpoint_cp, par.lump_ions)
+        actor.input_cgyros[k] = InputCGYRO(dd, gridpoint_cp, par.lump_ions; MXH_modes=par.MXH_modes)
         actor.input_cgyros[k].N_FIELD = par.n_field
         actor.input_cgyros[k].DELTA_T = par.delta_t
         actor.input_cgyros[k].MAX_TIME = par.max_time

--- a/src/actors/transport/tglf_actor.jl
+++ b/src/actors/transport/tglf_actor.jl
@@ -22,6 +22,7 @@ import GACODE
         Entry{Union{Vector{<:InputTGLF},Vector{<:InputTJLF}}}("-", "Sets up the input file that will be run with the custom input file as a mask")
     lump_ions::Entry{Bool} = Entry{Bool}("-", "Lumps the fuel species (D,T) as well as the impurities together"; default=true)
     save_input_tglfs_to_folder::Entry{String} = Entry{String}("-", "Save the intput.tglf files in designated folder"; default="")
+    MXH_modes::Entry{Int} = Entry{Int}("-","number of MXH harmonics",default=1)
 end
 
 mutable struct ActorTGLF{D,P} <: SingleAbstractActor{D,P}
@@ -80,7 +81,7 @@ function _step(actor::ActorTGLF{D,P}) where {D<:Real, P<:Real}
     par = actor.par
     dd = actor.dd
 
-    input_tglfs = InputTGLF(dd, par.rho_transport, par.sat_rule, par.electromagnetic, par.lump_ions)
+    input_tglfs = InputTGLF(dd, par.rho_transport, par.sat_rule, par.electromagnetic, par.lump_ions; MXH_modes=par.MXH_modes)
     for k in eachindex(par.rho_transport)
         input_tglf = input_tglfs[k]
         if par.model ∈ [:TGLF, :TGLFNN, :GKNN]


### PR DESCRIPTION
This pull request adds higher-order MXH fits to FUSE. The MXH branch of IMAS and TurbulentTransport are required to use. 

The previous logic for Miller geometry is maintained as the default to avoid any disruptions in workflows.