### PR TITLE
Clamp Ti fit edge undershoot to avoid avgZ DomainError; defensive clamps for Te/ne

### DIFF
--- a/src/actors/diagnostics/fits_actor.jl
+++ b/src/actors/diagnostics/fits_actor.jl
@@ -90,13 +90,12 @@ function _step(actor::ActorFitProfiles{D,P}) where {D<:Real,P<:Real}
 
     method = IMAS.NaturalNeighbours.Triangle()
 
-    # fit Te
-    itp_te = IMAS.fit2d(Val(:t_e), dd; transform=abs)
+    # fit Te in log space to guarantee positivity
+    itp_te = IMAS.fit2d(Val(:t_e), dd; transform=x -> log(abs(x)))
     for (kt, time0) in enumerate(time_basis)
         cp1d = dd.core_profiles.profiles_1d[kt]
         data = itp_te(rho_tor_norm12, range(time0, time0, length(rho_tor_norm12)); method)
-        te = IMAS.fit1d(rho_tor_norm12, data, rho_tor_norm; smooth1, smooth2).fit
-        cp1d.electrons.temperature = max.(te, 1.0)
+        cp1d.electrons.temperature = exp.(IMAS.fit1d(rho_tor_norm12, data, rho_tor_norm; smooth1, smooth2).fit)
     end
 
     # scale thomson scattering density based on interferometer measurements
@@ -178,13 +177,12 @@ function _step(actor::ActorFitProfiles{D,P}) where {D<:Real,P<:Real}
         end
     end
 
-    # fit ne
-    itp_ne = IMAS.fit2d(Val(:n_e), dd; transform=abs)
+    # fit ne in log space to guarantee positivity
+    itp_ne = IMAS.fit2d(Val(:n_e), dd; transform=x -> log(abs(x)))
     for (k, time0) in enumerate(time_basis)
         cp1d = dd.core_profiles.profiles_1d[k]
         data = itp_ne(rho_tor_norm12, range(time0, time0, length(rho_tor_norm12)); method)
-        ne = IMAS.fit1d(rho_tor_norm12, data, rho_tor_norm; smooth1, smooth2).fit
-        cp1d.electrons.density_thermal = max.(ne, 1e10)
+        cp1d.electrons.density_thermal = exp.(IMAS.fit1d(rho_tor_norm12, data, rho_tor_norm; smooth1, smooth2).fit)
         IMAS.unfreeze!(cp1d.electrons, :density)
     end
 
@@ -207,7 +205,7 @@ function _step(actor::ActorFitProfiles{D,P}) where {D<:Real,P<:Real}
         imp_ion = cp1d.ion[2]
 
         data = itp_nimp(rho_tor_norm12, range(time0, time0, length(rho_tor_norm12)); method)
-        data .*= itp_ne(rho_tor_norm12, range(time0, time0, length(rho_tor_norm12)); method)
+        data .*= exp.(itp_ne(rho_tor_norm12, range(time0, time0, length(rho_tor_norm12)); method))
         n_i = IMAS.fit1d(rho_tor_norm12, data, rho_tor_norm; smooth1, smooth2).fit
 
         bulk_ion.density_thermal = zero(rho_tor_norm)
@@ -215,14 +213,13 @@ function _step(actor::ActorFitProfiles{D,P}) where {D<:Real,P<:Real}
         IMAS.unfreeze!(bulk_ion, :density)
         IMAS.unfreeze!(imp_ion, :density)
     end
-
-    # fit Ti
-    itp_ti = IMAS.fit2d(Val(:t_i), dd; transform=abs)
+    
+    # fit Ti in log space to guarantee positivity (prevents avgZ DomainError)
+    itp_ti = IMAS.fit2d(Val(:t_i), dd; transform=x -> log(abs(x)))
     for (k, time0) in enumerate(time_basis)
         cp1d = dd.core_profiles.profiles_1d[k]
         data = itp_ti(rho_tor_norm12, range(time0, time0, length(rho_tor_norm12)); method)
-        ti = IMAS.fit1d(rho_tor_norm12, data, rho_tor_norm; smooth1, smooth2).fit
-        ti = max.(ti, 1.0)
+        ti = exp.(IMAS.fit1d(rho_tor_norm12, data, rho_tor_norm; smooth1, smooth2).fit)
         for ion in cp1d.ion
             ion.temperature = ti
         end

--- a/src/actors/diagnostics/fits_actor.jl
+++ b/src/actors/diagnostics/fits_actor.jl
@@ -95,7 +95,8 @@ function _step(actor::ActorFitProfiles{D,P}) where {D<:Real,P<:Real}
     for (kt, time0) in enumerate(time_basis)
         cp1d = dd.core_profiles.profiles_1d[kt]
         data = itp_te(rho_tor_norm12, range(time0, time0, length(rho_tor_norm12)); method)
-        cp1d.electrons.temperature = IMAS.fit1d(rho_tor_norm12, data, rho_tor_norm; smooth1, smooth2).fit
+        te = IMAS.fit1d(rho_tor_norm12, data, rho_tor_norm; smooth1, smooth2).fit
+        cp1d.electrons.temperature = max.(te, 1.0)
     end
 
     # scale thomson scattering density based on interferometer measurements
@@ -182,7 +183,8 @@ function _step(actor::ActorFitProfiles{D,P}) where {D<:Real,P<:Real}
     for (k, time0) in enumerate(time_basis)
         cp1d = dd.core_profiles.profiles_1d[k]
         data = itp_ne(rho_tor_norm12, range(time0, time0, length(rho_tor_norm12)); method)
-        cp1d.electrons.density_thermal = IMAS.fit1d(rho_tor_norm12, data, rho_tor_norm; smooth1, smooth2).fit
+        ne = IMAS.fit1d(rho_tor_norm12, data, rho_tor_norm; smooth1, smooth2).fit
+        cp1d.electrons.density_thermal = max.(ne, 1e10)
         IMAS.unfreeze!(cp1d.electrons, :density)
     end
 
@@ -220,6 +222,7 @@ function _step(actor::ActorFitProfiles{D,P}) where {D<:Real,P<:Real}
         cp1d = dd.core_profiles.profiles_1d[k]
         data = itp_ti(rho_tor_norm12, range(time0, time0, length(rho_tor_norm12)); method)
         ti = IMAS.fit1d(rho_tor_norm12, data, rho_tor_norm; smooth1, smooth2).fit
+        ti = max.(ti, 1.0)
         for ion in cp1d.ion
             ion.temperature = ti
         end


### PR DESCRIPTION
ActorFitProfiles crashes with a DomainError when running D3D shot 174090 with EFIT_tree="EFIT01":                                                                                                                                                                             
                                              
  DomainError with -0.007458611600149166:                                                                                                                                                                                                                                       
  log10 was called with a negative real argument...
   [4] avgZ(func, Z, Ti)  @ IMAS profiles.jl:1569                                                                                                                                                                                                                               
  [16] _step(actor::ActorFitProfiles)  @ FUSE fits_actor.jl:246
                                                                                                                                                                                                                                                                                
  Root cause                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                
  In fits_actor.jl, the Ti profile is built by a smoothing spline (IMAS.fit1d). Smoothing splines can overshoot/undershoot near the boundary when the data is sparse, producing slightly negative values at the edge (here -7.5 eV). That negative Ti is then assigned to  ion.temperature and later passed to IMAS.avgZ, which evaluates log10(Ti/1e3) to look up the average ionization state from the Zavg_z_t.dat table — and log10 of a negative number throws.                                                                                     
                                                                                                                                                                                                                                                                                
  Why EFIT01 but not EFIT02                                                                                                                                                                                                                                                     
   
  fit2d maps each CER channel (R,Z) to ρ_tor_norm using the equilibrium's ρ-interpolant. EFIT01 (auto-EFIT, magnetics-only) and EFIT02 (with kinetic constraints) produce different ψ(R,Z) → different ρ at the same channel locations. With EFIT01's mapping the edge CER points happen to land where the smoothing spline undershoots below zero. EFIT02 doesn't expose the issue, but the underlying fragility is the same.