### PR TITLE
Make flux-matcher auto-diff compatible for gradient-based methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -137,3 +137,6 @@ TroyonBetaNN = "1"
 TurbulentTransport = "1"
 VacuumFields = "6"
 Weave = "0.10"
+
+[sources]
+FRESCO = {url = "https://github.com/ProjectTorreyPines/FRESCO.jl.git"}

--- a/Project.toml
+++ b/Project.toml
@@ -137,6 +137,3 @@ TroyonBetaNN = "1"
 TurbulentTransport = "1"
 VacuumFields = "6"
 Weave = "0.10"
-
-[sources]
-FRESCO = {url = "https://github.com/ProjectTorreyPines/FRESCO.jl.git"}

--- a/src/actors/transport/flux_matcher_actor.jl
+++ b/src/actors/transport/flux_matcher_actor.jl
@@ -213,11 +213,10 @@ function _step(actor::ActorFluxMatcher{D,P}) where {D<:Real,P<:Real}
         opt_parameters = [1.0; z_init_scaled]
     end
 
-    autodiff = NonlinearSolve.ADTypes.AutoFiniteDiff()
-    if D <: ForwardDiff.Dual
-        autodiff = NonlinearSolve.ADTypes.AutoForwardDiff()
-    elseif par.jacobian_method === :forward_ad
-        autodiff = NonlinearSolve.ADTypes.AutoForwardDiff()
+    autodiff = if (D <: ForwardDiff.Dual) || par.jacobian_method === :forward_ad
+        NonlinearSolve.ADTypes.AutoForwardDiff()
+    else
+        NonlinearSolve.ADTypes.AutoFiniteDiff()
     end
 
     # Validate forward_ad requirements
@@ -562,7 +561,7 @@ function profiles_title(cp1d, profiles_path)
 end
 
 function errors_by_channel(errors::Vector{T}, N_radii::Int, N_channels::Int, N_specials::Int) where {T<:Real}
-    return (specials=errors[1+N_specials], radii_channels=mapslices(norm, reshape(errors[1+N_specials:end], (N_radii, N_channels)); dims=1))
+    return (specials=errors[1:N_specials], radii_channels=mapslices(norm, reshape(errors[1+N_specials:end], (N_radii, N_channels)); dims=1))
 end
 
 """
@@ -1582,7 +1581,7 @@ function ad_flux_match_errors!(
         flux_solutions = [GACODE.FluxSolution{T}(TJLF.Qe(ql), TJLF.Qi(ql), TJLF.Γe(ql), TJLF.Γi(ql), TJLF.Πi(ql)) for ql in QL_fluxes_out]
 
     elseif turb_par.model in (:TGLFNN, :GKNN)
-        # Run TGLFNN/GKNN neural network directly (Dual-compatible via PooledChain fallback)
+        # Run TGLFNN/GKNN neural network directly (Dual-compatible via AdaptiveArrayPools)
         flux_solutions = TurbulentTransport.run_tglfnn(input_tglfs_dual; warn_nn_train_bounds=turb_par.warn_nn_train_bounds, model_filename=model_filename(turb_par), fidelity=turb_par.model)
 
     else

--- a/src/actors/transport/flux_matcher_actor.jl
+++ b/src/actors/transport/flux_matcher_actor.jl
@@ -45,7 +45,7 @@ import NonlinearSolve, FixedPointAcceleration
         Switch{Symbol}(
             [:finite_diff, :forward_ad],
             "-",
-            "Method for computing the transport Jacobian: `:finite_diff` (default) or `:forward_ad` (exact ForwardDiff through TJLF)";
+            "Method for computing the transport Jacobian: `:finite_diff` (default) or `:forward_ad` (exact ForwardDiff through TJLF/TGLFNN/GKNN)";
             default=:finite_diff
         )
     step_size::Entry{T} = Entry{T}(
@@ -267,7 +267,7 @@ function _step(actor::ActorFluxMatcher{D,P}) where {D<:Real,P<:Real}
                 try
                     if eltype(u) <: ForwardDiff.Dual && par.jacobian_method === :forward_ad
                         # AD path: full pipeline through dd{Dual}
-                        ad_flux_match_errors!(F, u, actor, initial_cp1d)
+                        ad_flux_match_errors!(F, u, actor, initial_cp1d; z_scaled_history, err_history, prog)
                     else
                         # Standard path: full pipeline through dd
                         result = flux_match_errors(actor, u, initial_cp1d; z_scaled_history, err_history, prog)
@@ -1530,7 +1530,10 @@ function ad_flux_match_errors!(
     F::AbstractVector,
     opt_parameters::AbstractVector,
     actor::ActorFluxMatcher{D,P},
-    initial_cp1d::IMAS.core_profiles__profiles_1d) where {D<:Real,P<:Real}
+    initial_cp1d::IMAS.core_profiles__profiles_1d;
+    z_scaled_history=nothing,
+    err_history=nothing,
+    prog=nothing) where {D<:Real,P<:Real}
 
     T = eltype(opt_parameters)
     dd_float = actor.dd
@@ -1636,6 +1639,17 @@ function ad_flux_match_errors!(
             norm0 = (norm(fluxes[index] .* surface0) + norm(targets[index] .* surface0)) / 2.0
         end
         F[index] .= (targets[index] .- fluxes[index]) ./ norm0 .* surface0
+    end
+
+    # Log primal values for history/plotting (extract Float64 from Dual)
+    if z_scaled_history !== nothing
+        push!(z_scaled_history, ForwardDiff.value.(opt_parameters))
+    end
+    if err_history !== nothing
+        push!(err_history, ForwardDiff.value.(F))
+    end
+    if prog !== nothing
+        ProgressMeter.next!(prog)
     end
 
     return nothing

--- a/src/actors/transport/flux_matcher_actor.jl
+++ b/src/actors/transport/flux_matcher_actor.jl
@@ -1,6 +1,10 @@
 import NLsolve
 using LinearAlgebra
 import TJLF: InputTJLF
+import GACODE
+import ForwardDiff
+import NeoclassicalTransport
+import TurbulentTransport
 
 import NonlinearSolve, FixedPointAcceleration
 
@@ -37,6 +41,13 @@ import NonlinearSolve, FixedPointAcceleration
         )
     custom_algorithm::Entry{NonlinearSolve.AbstractNonlinearSolveAlgorithm} =
         Entry{NonlinearSolve.AbstractNonlinearSolveAlgorithm}("-", "User-defined custom solver from NonlinearSolve")
+    jacobian_method::Switch{Symbol} =
+        Switch{Symbol}(
+            [:finite_diff, :forward_ad],
+            "-",
+            "Method for computing the transport Jacobian: `:finite_diff` (default) or `:forward_ad` (exact ForwardDiff through TJLF)";
+            default=:finite_diff
+        )
     step_size::Entry{T} = Entry{T}(
         "-",
         "Step size for each algorithm iteration (note this has a different meaning for each algorithm)";
@@ -205,6 +216,15 @@ function _step(actor::ActorFluxMatcher{D,P}) where {D<:Real,P<:Real}
     autodiff = NonlinearSolve.ADTypes.AutoFiniteDiff()
     if D <: ForwardDiff.Dual
         autodiff = NonlinearSolve.ADTypes.AutoForwardDiff()
+    elseif par.jacobian_method === :forward_ad
+        autodiff = NonlinearSolve.ADTypes.AutoForwardDiff()
+    end
+
+    # Validate forward_ad requirements
+    if par.jacobian_method === :forward_ad
+        @assert actor.actor_ct.actor_turb isa ActorTGLF "jacobian_method=:forward_ad requires ActorTGLF as turbulence actor"
+        @assert actor.actor_ct.actor_turb.par.model in (:TJLF, :TGLFNN, :GKNN) "jacobian_method=:forward_ad requires turbulence model :TJLF, :TGLFNN, or :GKNN (got $(actor.actor_ct.actor_turb.par.model))"
+        @assert ismissing(par, :scale_turbulence_law) "jacobian_method=:forward_ad is not compatible with scale_turbulence_law"
     end
 
     algorithm = if par.algorithm === :default
@@ -212,8 +232,13 @@ function _step(actor::ActorFluxMatcher{D,P}) where {D<:Real,P<:Real}
             # combines speed and robustness, but needs smooth derivatives
             :basic_polyalg
         else
-            # derivative-free method
-            :simple_dfsane
+            if par.jacobian_method === :forward_ad
+                # Use gradient-based method with exact Jacobian
+                :basic_polyalg
+            else
+                # derivative-free method
+                :simple_dfsane
+            end
         end
     else
         par.algorithm
@@ -240,7 +265,14 @@ function _step(actor::ActorFluxMatcher{D,P}) where {D<:Real,P<:Real}
             # 1. In-place residual
             function f!(F, u, initial_cp1d)
                 try
-                    F .= flux_match_errors(actor, u, initial_cp1d; z_scaled_history, err_history, prog).errors
+                    if eltype(u) <: ForwardDiff.Dual && par.jacobian_method === :forward_ad
+                        # AD path: full pipeline through dd{Dual}
+                        ad_flux_match_errors!(F, u, actor, initial_cp1d)
+                    else
+                        # Standard path: full pipeline through dd
+                        result = flux_match_errors(actor, u, initial_cp1d; z_scaled_history, err_history, prog)
+                        F .= result.errors
+                    end
                 catch e
                     if isa(e, InterruptException)
                         rethrow(e)
@@ -266,7 +298,11 @@ function _step(actor::ActorFluxMatcher{D,P}) where {D<:Real,P<:Real}
                 )
 
             elseif algorithm == :broyden
-                NonlinearSolve.Broyden(; autodiff)
+                if par.jacobian_method === :forward_ad
+                    NonlinearSolve.Broyden(; autodiff, init_jacobian=Val(:true_jacobian))
+                else
+                    NonlinearSolve.Broyden(; autodiff)
+                end
 
             elseif algorithm == :trust
                 NonlinearSolve.TrustRegion(; autodiff)
@@ -278,7 +314,12 @@ function _step(actor::ActorFluxMatcher{D,P}) where {D<:Real,P<:Real}
                 NonlinearSolve.SimpleDFSane()
 
             elseif algorithm === :basic_polyalg
-                NonlinearSolve.NonlinearSolvePolyAlgorithm((NonlinearSolve.Broyden(; autodiff),
+                broyden_alg = if par.jacobian_method === :forward_ad
+                    NonlinearSolve.Broyden(; autodiff, init_jacobian=Val(:true_jacobian))
+                else
+                    NonlinearSolve.Broyden(; autodiff)
+                end
+                NonlinearSolve.NonlinearSolvePolyAlgorithm((broyden_alg,
                     NonlinearSolve.SimpleTrustRegion(; autodiff),
                     NonlinearSolve.SimpleDFSane()))
 
@@ -1387,4 +1428,241 @@ function _step(replay_actor::ActorReplay, actor::ActorFluxMatcher, replay_dd::IM
     end
 
     return replay_actor
+end
+
+#= ========================================= =#
+#  Forward AD Jacobian for flux matching      #
+#= ========================================= =#
+
+"""
+    copy_ids_data!(dst::IMAS.IDS{T}, src::IMAS.IDS) where {T<:Real}
+
+Recursively copy all filled data from `src` IDS to `dst` IDS, promoting Real values to type `T`.
+Sub-IDSs are recursed into; IDSvectors are resized and elements copied; arrays and scalars are promoted.
+Uses `setfield!` directly to avoid `setproperty!` coordinate-ordering requirements.
+"""
+function copy_ids_data!(dst::IMAS.IDS{T}, src::IMAS.IDS) where {T<:Real}
+    S = eltype(src)
+    filled_src = getfield(src, :_filled)
+    filled_dst = getfield(dst, :_filled)
+    for field in fieldnames(typeof(filled_src))
+        getfield(filled_src, field) || continue
+        val = getfield(src, field)
+        if val isa IMAS.IDS
+            copy_ids_data!(getfield(dst, field), val)
+            setfield!(filled_dst, field, true)
+        elseif val isa IMAS.IDSvector
+            dst_vec = getfield(dst, field)
+            resize!(dst_vec, length(val))
+            for (d, s) in zip(dst_vec, val)
+                copy_ids_data!(d, s)
+            end
+            setfield!(filled_dst, field, true)
+        elseif val isa AbstractMatrix{<:Real}
+            setfield!(dst, field, T.(val))
+            setfield!(filled_dst, field, true)
+        elseif val isa AbstractVector{<:Real}
+            setfield!(dst, field, T.(val))
+            setfield!(filled_dst, field, true)
+        elseif val isa Real
+            setfield!(dst, field, T(val))
+            setfield!(filled_dst, field, true)
+        else
+            # Non-numeric (String, Symbol, Int, Bool, Vector{Int}, Vector{String}, etc.)
+            setfield!(dst, field, deepcopy(val))
+            setfield!(filled_dst, field, true)
+        end
+    end
+end
+
+"""
+    prepare_dd_for_ad(dd_float::IMAS.dd{D}, initial_cp1d::IMAS.core_profiles__profiles_1d, ::Type{T}) where {D<:Real, T<:Real}
+
+Create a lightweight `dd{T}` populated with only the data needed for flux matching:
+- `equilibrium.time_slice[1]` — full geometry (promoted to T with zero partials)
+- `core_profiles.profiles_1d[1]` — restored from `initial_cp1d` (promoted to T)
+- `core_sources` and `core_transport` — left empty (filled by the pipeline)
+
+This avoids copying the entire dd while providing all data needed by
+`intrinsic_sources!`, `InputTGLF`, `flux_gacode_to_imas`, `total_fluxes!`, and `total_sources!`.
+"""
+function prepare_dd_for_ad(dd_float::IMAS.dd{D}, initial_cp1d::IMAS.core_profiles__profiles_1d, ::Type{T}) where {D<:Real,T<:Real}
+    dd_ad = IMAS.dd{T}()
+    dd_ad.global_time = dd_float.global_time
+
+    # Copy equilibrium time_slice (frozen geometry, promoted to T)
+    eqt_float = dd_float.equilibrium.time_slice[]
+    resize!(dd_ad.equilibrium.time_slice, 1)
+    eqt_ad = dd_ad.equilibrium.time_slice[1]
+    copy_ids_data!(eqt_ad, eqt_float)
+
+    # Copy core_profiles from initial_cp1d (promoted to T)
+    cp1d_float = dd_float.core_profiles.profiles_1d[]
+    resize!(dd_ad.core_profiles.profiles_1d, 1)
+    cp1d_ad = dd_ad.core_profiles.profiles_1d[1]
+    copy_ids_data!(cp1d_ad, cp1d_float)
+
+    return dd_ad
+end
+
+"""
+    ad_flux_match_errors!(
+        F::AbstractVector,
+        opt_parameters::AbstractVector,
+        actor::ActorFluxMatcher,
+        initial_cp1d::IMAS.core_profiles__profiles_1d)
+
+AD-compatible flux matching residual evaluation using the full pipeline through `dd{Dual}`.
+
+Creates a lightweight `dd{Dual}` with only the data needed for flux matching,
+then runs the same pipeline as `flux_match_errors`: profile reconstruction,
+intrinsic sources, turbulent transport (TJLF), neoclassical transport (Hirshman-Sigmar),
+flux aggregation, and error computation — all with ForwardDiff.Dual types.
+
+This captures derivatives through: profile gradients (RLTS/RLNS), gyrobohm normalization
+factors (ne, Te), intrinsic sources (radiation, collisional exchange, fusion, ohmic),
+neoclassical transport (thermodynamic driving forces), and secondary TJLF inputs
+(BETAE, XNUE, TAUS, AS).
+
+Frozen at primal: equilibrium geometry, pedestal evolution, time-derivative sources.
+"""
+function ad_flux_match_errors!(
+    F::AbstractVector,
+    opt_parameters::AbstractVector,
+    actor::ActorFluxMatcher{D,P},
+    initial_cp1d::IMAS.core_profiles__profiles_1d) where {D<:Real,P<:Real}
+
+    T = eltype(opt_parameters)
+    dd_float = actor.dd
+    par = actor.par
+
+    # Create dd{Dual} with equilibrium + core_profiles from last primal state
+    dd_ad = prepare_dd_for_ad(dd_float, initial_cp1d, T)
+    cp1d_ad = dd_ad.core_profiles.profiles_1d[]
+
+    # Restore initial profiles (promoted to Dual)
+    # NOTE: prepare_dd_for_ad already copied from dd_float.core_profiles;
+    # now restore primary quantities from initial_cp1d to match flux_match_errors behavior
+    cp1d_copy_primary_quantities_promote!(cp1d_ad, initial_cp1d, T)
+
+    # Unscale z-profiles
+    z_profiles = unscale_z_profiles(opt_parameters)
+
+    # Unpack z-profiles into cp1d (writes Dual profiles)
+    unpack_z_profiles(cp1d_ad, par, z_profiles)
+
+    # Evaluate intrinsic sources (reads Dual cp1d + equilibrium, writes to dd_ad.core_sources)
+    if par.evolve_plasma_sources
+        IMAS.intrinsic_sources!(dd_ad; bootstrap=false)
+    end
+
+    # Build InputTGLF from dd_ad (Dual-typed)
+    eqt_ad = dd_ad.equilibrium.time_slice[]
+    turb_par = actor.actor_ct.actor_turb.par
+    cp_gridpoints = [argmin_abs(cp1d_ad.grid.rho_tor_norm, rho_x) for rho_x in par.rho_transport]
+    input_tglfs_dual = TurbulentTransport.InputTGLF(eqt_ad, cp1d_ad, cp_gridpoints, turb_par.sat_rule, turb_par.electromagnetic, turb_par.lump_ions; MXH_modes=turb_par.MXH_modes)
+
+    if turb_par.model === :TJLF
+        # Convert to InputTJLF and run TJLF
+        input_tjlfs_ad = Vector{InputTJLF{T}}(undef, length(par.rho_transport))
+        for k in eachindex(par.rho_transport)
+            input_tjlfs_ad[k] = InputTJLF{T}(input_tglfs_dual[k])
+            # Copy widths from primal evaluation (don't re-find in AD path)
+            if !par.find_widths && isassigned(actor.actor_ct.actor_turb.input_tglfs, k)
+                existing = actor.actor_ct.actor_turb.input_tglfs[k]
+                input_tjlfs_ad[k].FIND_WIDTH = false
+                input_tjlfs_ad[k].WIDTH = T.(existing.WIDTH)
+                input_tjlfs_ad[k].WIDTH_in = T.(existing.WIDTH_in)
+            end
+        end
+        QL_fluxes_out = TJLF.run_tjlf(input_tjlfs_ad)
+        flux_solutions = [GACODE.FluxSolution{T}(TJLF.Qe(ql), TJLF.Qi(ql), TJLF.Γe(ql), TJLF.Γi(ql), TJLF.Πi(ql)) for ql in QL_fluxes_out]
+
+    elseif turb_par.model in (:TGLFNN, :GKNN)
+        # Run TGLFNN/GKNN neural network directly (Dual-compatible via PooledChain fallback)
+        flux_solutions = TurbulentTransport.run_tglfnn(input_tglfs_dual; warn_nn_train_bounds=turb_par.warn_nn_train_bounds, model_filename=model_filename(turb_par), fidelity=turb_par.model)
+
+    else
+        error("jacobian_method=:forward_ad does not support turbulence model :$(turb_par.model)")
+    end
+
+    # Write turbulent transport to dd_ad.core_transport
+    turb_model = resize!(dd_ad.core_transport.model, :anomalous; wipe=false)
+    turb_model.identifier.name = string(turb_par.model)
+    turb_m1d = resize!(turb_model.profiles_1d)
+    turb_m1d.grid_flux.rho_tor_norm = T.(par.rho_transport)
+    GACODE.flux_gacode_to_imas((:electron_energy_flux, :ion_energy_flux, :electron_particle_flux, :ion_particle_flux, :momentum_flux), flux_solutions, turb_m1d, eqt_ad, cp1d_ad)
+
+    # Neoclassical transport
+    actor_neoc = actor.actor_ct.actor_neoc
+    if !(actor_neoc isa ActorNoOperation)
+        neoc_par = actor_neoc.par
+        if neoc_par.model == :hirshmansigmar
+            # Reuse cached equilibrium_geometry from primal (pure geometry, no profile dependence)
+            eq_geom = actor_neoc.equilibrium_geometry
+            plasma_profiles = NeoclassicalTransport.get_plasma_profiles(eqt_ad, cp1d_ad)
+            rho_s = GACODE.rho_s(cp1d_ad, eqt_ad)
+            rmin = GACODE.r_min_core_profiles(eqt_ad.profiles_1d, cp1d_ad.grid.rho_tor_norm)
+            neoc_flux_solutions = map(ir -> NeoclassicalTransport.hirshmansigmar(ir, eqt_ad, cp1d_ad, plasma_profiles, eq_geom; rho_s, rmin), cp_gridpoints)
+        elseif neoc_par.model == :changhinton
+            neoc_flux_solutions = [NeoclassicalTransport.changhinton(eqt_ad, cp1d_ad, rho, 1) for rho in par.rho_transport]
+        else
+            error("jacobian_method=:forward_ad does not support neoclassical model :$(neoc_par.model)")
+        end
+
+        # Write neoclassical transport to dd_ad.core_transport
+        neoc_model = resize!(dd_ad.core_transport.model, :neoclassical; wipe=false)
+        neoc_model.identifier.name = string(neoc_par.model)
+        neoc_m1d = resize!(neoc_model.profiles_1d)
+        neoc_m1d.grid_flux.rho_tor_norm = T.(par.rho_transport)
+        if neoc_par.model == :changhinton
+            GACODE.flux_gacode_to_imas((:ion_energy_flux,), neoc_flux_solutions, neoc_m1d, eqt_ad, cp1d_ad)
+        else
+            GACODE.flux_gacode_to_imas((:electron_energy_flux, :ion_energy_flux, :electron_particle_flux, :ion_particle_flux), neoc_flux_solutions, neoc_m1d, eqt_ad, cp1d_ad)
+        end
+    end
+
+    # Get transport fluxes and sources (same functions as primal path)
+    fluxes = flux_match_fluxes(dd_ad, par)
+    targets = flux_match_targets(dd_ad, par)
+
+    # Compute errors (same logic as flux_match_errors)
+    surface0 = cp1d_ad.grid.surface[cp_gridpoints] ./ cp1d_ad.grid.surface[end]
+    nrho = length(par.rho_transport)
+    for (inorm, norm0) in enumerate(actor.norms)
+        index = (inorm - 1) * nrho + 1:inorm * nrho
+        if isnan(norm0)
+            # Norms should be set from the primal evaluation, but handle gracefully
+            norm0 = (norm(fluxes[index] .* surface0) + norm(targets[index] .* surface0)) / 2.0
+        end
+        F[index] .= (targets[index] .- fluxes[index]) ./ norm0 .* surface0
+    end
+
+    return nothing
+end
+
+"""
+    cp1d_copy_primary_quantities_promote!(to_cp1d::IMAS.core_profiles__profiles_1d{T}, from_cp1d::IMAS.core_profiles__profiles_1d, ::Type{T}) where {T<:Real}
+
+Like `cp1d_copy_primary_quantities!` but promotes source values from any Real type to `T`.
+Used to restore initial conditions into a `dd{Dual}` core_profiles from a `Float64` snapshot.
+"""
+function cp1d_copy_primary_quantities_promote!(to_cp1d::IMAS.core_profiles__profiles_1d{T}, from_cp1d::IMAS.core_profiles__profiles_1d, ::Type{T}) where {T<:Real}
+    @assert length(to_cp1d.ion) == length(from_cp1d.ion)
+    to_cp1d.electrons.density_thermal = T.(from_cp1d.electrons.density_thermal)
+    to_cp1d.electrons.temperature = T.(from_cp1d.electrons.temperature)
+    if !ismissing(from_cp1d.electrons, :density_fast)
+        to_cp1d.electrons.density_fast = T.(from_cp1d.electrons.density_fast)
+    end
+    IMAS.unfreeze!(to_cp1d.electrons, :density)
+    for (to_ion, from_ion) in zip(to_cp1d.ion, from_cp1d.ion)
+        to_ion.density_thermal = T.(from_ion.density_thermal)
+        to_ion.temperature = T.(from_ion.temperature)
+        if !ismissing(from_ion, :density_fast)
+            to_ion.density_fast = T.(from_ion.density_fast)
+        end
+        IMAS.unfreeze!(to_ion, :density)
+    end
+    to_cp1d.rotation_frequency_tor_sonic = T.(from_cp1d.rotation_frequency_tor_sonic)
+    return to_cp1d
 end

--- a/test/runtests_forward_ad.jl
+++ b/test/runtests_forward_ad.jl
@@ -1,0 +1,99 @@
+using FUSE
+using Test
+
+@testset "forward_ad flux matcher" begin
+    # Initialize ITER case (lightweight scalar init)
+    ini, act = FUSE.case_parameters(:ITER; init_from=:scalars)
+    dd = IMAS.dd()
+    FUSE.init(dd, ini, act)
+
+    # Configure for AD-compatible flux matching: TJLF + Hirshman-Sigmar
+    act.ActorTGLF.model = :TJLF
+    act.ActorNeoclassical.model = :hirshmansigmar
+    act.ActorCoreTransport.model = :FluxMatcher
+    act.ActorFluxMatcher.jacobian_method = :forward_ad
+    act.ActorFluxMatcher.max_iterations = 3
+    act.ActorFluxMatcher.evolve_pedestal = false
+    act.ActorFluxMatcher.find_widths = false
+
+    # Save initial core_profiles for comparison
+    cp1d_before = deepcopy(dd.core_profiles.profiles_1d[])
+
+    @testset "broyden with true_jacobian" begin
+        dd_test = deepcopy(dd)
+        act_test = deepcopy(act)
+        act_test.ActorFluxMatcher.algorithm = :broyden
+
+        actor = FUSE.ActorFluxMatcher(dd_test, act_test)
+
+        # Verify the actor ran without error and produced transport results
+        @test !isempty(dd_test.core_transport.model)
+        cp1d_after = dd_test.core_profiles.profiles_1d[]
+        @test !all(cp1d_after.electrons.temperature .== cp1d_before.electrons.temperature)
+    end
+
+    @testset "basic_polyalg with true_jacobian" begin
+        dd_test = deepcopy(dd)
+        act_test = deepcopy(act)
+        act_test.ActorFluxMatcher.algorithm = :basic_polyalg
+
+        actor = FUSE.ActorFluxMatcher(dd_test, act_test)
+
+        # Verify the actor ran without error and produced transport results
+        @test !isempty(dd_test.core_transport.model)
+        cp1d_after = dd_test.core_profiles.profiles_1d[]
+        @test !all(cp1d_after.electrons.temperature .== cp1d_before.electrons.temperature)
+    end
+
+    @testset "AD vs finite-diff Jacobian agreement" begin
+        dd_test = deepcopy(dd)
+        act_ad = deepcopy(act)
+        act_ad.ActorFluxMatcher.algorithm = :broyden
+        act_ad.ActorFluxMatcher.jacobian_method = :forward_ad
+        act_ad.ActorFluxMatcher.max_iterations = 1
+
+        dd_fd = deepcopy(dd)
+        act_fd = deepcopy(act)
+        act_fd.ActorFluxMatcher.algorithm = :broyden
+        act_fd.ActorFluxMatcher.jacobian_method = :finite_diff
+        act_fd.ActorFluxMatcher.max_iterations = 1
+
+        FUSE.ActorFluxMatcher(dd_test, act_ad)
+        FUSE.ActorFluxMatcher(dd_fd, act_fd)
+
+        # After 1 iteration from same initial condition, both should produce similar profiles
+        Te_ad = dd_test.core_profiles.profiles_1d[].electrons.temperature
+        Te_fd = dd_fd.core_profiles.profiles_1d[].electrons.temperature
+        @test isapprox(Te_ad, Te_fd; rtol=0.05)
+    end
+
+    @testset "TGLFNN forward_ad" begin
+        dd_nn = deepcopy(dd)
+        act_nn = deepcopy(act)
+        act_nn.ActorTGLF.model = :TGLFNN
+        act_nn.ActorFluxMatcher.jacobian_method = :forward_ad
+        act_nn.ActorFluxMatcher.algorithm = :basic_polyalg
+        act_nn.ActorFluxMatcher.max_iterations = 3
+
+        actor = FUSE.ActorFluxMatcher(dd_nn, act_nn)
+
+        @test !isempty(dd_nn.core_transport.model)
+        cp1d_after = dd_nn.core_profiles.profiles_1d[]
+        @test !all(cp1d_after.electrons.temperature .== cp1d_before.electrons.temperature)
+    end
+
+    @testset "GKNN forward_ad" begin
+        dd_gk = deepcopy(dd)
+        act_gk = deepcopy(act)
+        act_gk.ActorTGLF.model = :GKNN
+        act_gk.ActorFluxMatcher.jacobian_method = :forward_ad
+        act_gk.ActorFluxMatcher.algorithm = :basic_polyalg
+        act_gk.ActorFluxMatcher.max_iterations = 3
+
+        actor = FUSE.ActorFluxMatcher(dd_gk, act_gk)
+
+        @test !isempty(dd_gk.core_transport.model)
+        cp1d_after = dd_gk.core_profiles.profiles_1d[]
+        @test !all(cp1d_after.electrons.temperature .== cp1d_before.electrons.temperature)
+    end
+end


### PR DESCRIPTION
## ForwardDiff-based Jacobians for flux matching

Add an exact autodifferentiation (AD) path for computing the transport Jacobian in the flux matcher, replacing finite differences with ForwardDiff through the full physics pipeline: profile reconstruction → intrinsic sources → turbulent transport (TJLF, TGLFNN, or GKNN) → Hirshman-Sigmar → gyrobohm conversion → flux/source aggregation → residual.  See https://github.com/ProjectTorreyPines/FUSE.jl/issues/907

### Motivation

The flux matcher uses finite differences to compute the Jacobian, requiring N+1 full transport evaluations per Newton step (where N ~ 20–40 unknowns). Each evaluation runs the turbulent transport model at every radial grid point — the Jacobian is the dominant cost.

ForwardDiff can compute the exact Jacobian in a single forward pass by propagating `Dual` numbers through the same pipeline. Since `dd{T}` is parametric in IMAS and the entire chain (`unpack_z_profiles`, `intrinsic_sources!`, `InputTGLF`, turbulent transport, `flux_gacode_to_imas`, `total_fluxes!`, `total_sources!`, Hirshman-Sigmar) is pure Julia math, the full pipeline is AD-compatible.

### Approach: Full pipeline through dd{Dual}

The AD path creates a lightweight `dd{Dual}` populated with only the data needed for flux matching, then runs the **same physics pipeline** as the primal:

```
z-profiles ──→ unpack_z_profiles(cp1d{Dual})
           ──→ intrinsic_sources!(dd{Dual})        [radiation, collisional exchange, fusion, ohmic]
           ──→ InputTGLF(eqt{Dual}, cp1d{Dual})    [RLTS, RLNS, BETAE, XNUE, TAUS, AS, ...]
           ──→ TJLF.run_tjlf(InputTJLF{Dual})      [eigensolves via IFT dispatch]
               OR TurbulentTransport.run_tglfnn(InputTGLF{Dual})  [NN forward pass via PooledChain]
           ──→ flux_gacode_to_imas(...)              [gyrobohm → physical, ne/Te/ρs dependence]
           ──→ hirshmansigmar(eqt{Dual}, cp1d{Dual}) [neoclassical transport]
           ──→ total_fluxes! / total_sources!        [aggregation]
           ──→ residual
```

**Supported turbulent transport models:**
- **TJLF**: Eigensolves via IFT dispatch (TJLF.jl AD support merged and released)
- **TGLFNN**: Neural network surrogate — Flux.jl forward pass (weight × x + bias + activations) is inherently differentiable
- **GKNN**: multi-fidelity QLGYRO-NN or CGYRO-NN — same NN forward pass, different model weights and GKNN correction layers

**What is differentiated (everything relevant):**
- Profile gradients (RLTS, RLNS) → through turbulent transport → turbulent fluxes
- Secondary inputs (BETAE, XNUE, TAUS, AS) → depend on absolute ne, Te, ni, Ti
- Gyrobohm normalization factors (ne, Te, ρ_s) → physical flux conversion
- Intrinsic sources (radiation, collisional exchange, fusion, ohmic) → target fluxes
- Neoclassical driving forces (dlntdr, dlnndr) → through Hirshman-Sigmar L-matrix

**What is frozen at primal values:**
- Equilibrium geometry — fixed during flux matching
- Pedestal evolution — only runs in primal path
- Time-derivative sources (∂/∂t) — require previous iteration's cp1d

### Memory-efficient dd{Dual} construction

Creating `dd{Dual}()` is cheap (~1 MB metadata, no data arrays until populated). Rather than copying the entire dd, `prepare_dd_for_ad` copies only:
- `equilibrium.time_slice[1]` — full geometry (promoted to Dual with zero partials)
- `core_profiles.profiles_1d[1]` — restored from initial conditions (promoted to Dual)

The recursive `copy_ids_data!` function walks the IDS `_filled` flags and promotes only populated fields. Total per-evaluation overhead is ~40 vectors × 200 elements × ~100 bytes/Dual ≈ 800 KB, ephemeral (GC'd after each f! call).

### Broyden with AD-initialized Jacobian

The optimal solver configuration pairs this with Broyden's method using `init_jacobian=Val(:true_jacobian)`:

1. **First iteration**: Compute exact J₀ via ForwardDiff (one forward pass per z-component through the full pipeline)
2. **Subsequent iterations**: Rank-1 Broyden updates (one primal evaluation each — no Jacobian recomputation)
3. **On reset** (when convergence stalls): Recompute exact J via AD

### Implementation details

**New parameter:** `jacobian_method::Switch{Symbol}` with options `:finite_diff` (default) and `:forward_ad`

**Modified `f!` closure:** Dispatches on `eltype(u)` — `Float64` calls go through `flux_match_errors` (standard pipeline); `ForwardDiff.Dual` calls go through `ad_flux_match_errors!` (AD pipeline).

**Algorithm selection changes:**
- When `jacobian_method=:forward_ad`, default algorithm switches from `:simple_dfsane` to `:basic_polyalg` (Broyden → SimpleTrustRegion → DFSane fallback). Broyden and SimpleTrustRegion both use AD Jacobians; DFSane is entirely derivative-free.
- Broyden uses `init_jacobian=Val(:true_jacobian)` to seed J₀ via AD, then rank-1 updates (cheap). SimpleTrustRegion recomputes the full AD Jacobian every iteration.

**Algorithms that benefit from `jacobian_method=:forward_ad`:**
| Algorithm | How AD is used | Expected speedup |
|---|---|---|
| `:broyden` | Exact J₀ via ForwardDiff, then rank-1 updates | High — exact J₀ in one tagged pass vs. N+1 finite-difference evaluations; subsequent iterations are Jacobian-free |
| `:trust` | Full AD Jacobian every iteration (`TrustRegion`) | Moderate — exact Jacobian replaces finite differences, but recomputed each step |
| `:simple_trust` | Full AD Jacobian every iteration (`SimpleTrustRegion`) | Moderate — same as `:trust` |
| `:polyalg` | Full AD Jacobian via `FastShortcutNonlinearPolyalg` | Moderate — same as `:trust`, applied within the polyalgorithm's Newton/trust-region sub-solvers |
| `:basic_polyalg` | AD in Broyden (rank-1 updates) and SimpleTrustRegion stages; DFSane stage is unaffected | Moderate — benefit in first two stages |

Derivative-free algorithms (`:simple_dfsane`, `:anderson`, `:old_anderson`, `:simple`) are unaffected by `jacobian_method`.

### Dependencies

- **TJLF.jl**: AD support merged and released (IFT-based eigen dispatch for ForwardDiff compatibility)
- **TurbulentTransport.jl**: AD support merged and released (eltype-generic pool operations for Dual compatibility)
- **NeoclassicalTransport.jl**: AD support merged and released (Hirshman-Sigmar ForwardDiff compatibility)
- IMAS, GACODE — already AD-compatible, no changes needed

### What this does NOT change

- The primal residual evaluation is completely unchanged — `flux_match_errors()` is not modified
- No changes to IMAS or GACODE source code
- The `:finite_diff` default is preserved — this is opt-in via `jacobian_method=:forward_ad`
