### PR TITLE
Fix install smoke test and IJulia kernel install for Julia 1.12 (#6)

### DIFF
--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -66,7 +66,7 @@ Start Julia (`julia` at the terminal), then:
 
    ```julia
    using FUSE
-   ini, act = FUSE.case_parameters(:ITER)
+   ini, act = FUSE.case_parameters(:FPP)
    dd = FUSE.init(ini, act)   # if this completes without error, your install is working
    ```
 

--- a/scripts/install_ijulia_kernels.jl
+++ b/scripts/install_ijulia_kernels.jl
@@ -19,18 +19,17 @@ function kernels_parent_dir()
 end
 
 function kernel_slug(name::AbstractString)
-    slug = lowercase(replace(strip(name), r"[^a-z0-9]+" => "-"))
+    slug = lowercase(strip(name))
+    slug = replace(slug, r"[^a-z0-9]+" => "-")
+    slug = strip(slug, '-')
     return isempty(slug) ? "julia" : slug
 end
 
 function install_one_kernel!(display_name::AbstractString, nthreads::AbstractString)
-    import IJulia
-    parent = kernels_parent_dir()
-    specdir = joinpath(parent, kernel_slug(display_name))
-    mkpath(specdir)
-    IJulia.installkernel(
+    specdir = IJulia.installkernel(
         display_name;
-        specdir,
+        specname=kernel_slug(display_name),
+        displayname=display_name,
         env=Dict("JULIA_NUM_THREADS" => nthreads),
     )
     println("Installed kernel \"", display_name, "\" at ", specdir)


### PR DESCRIPTION
Fix install smoke test to use case_parameters(:FPP):

The documented smoke test called case_parameters(:ITER) without the required init_from keyword, causing UndefKeywordError on fresh installs. Use :FPP instead, which matches the README usage example and needs no extra arguments.

Fix IJulia kernel install script for Julia 1.12 and current IJulia API:
- Remove invalid import inside function (syntax error on Julia 1.12)
- Use specname/displayname kwargs instead of unsupported specdir
- Strip leading/trailing hyphens from generated kernel directory names
