### PR TITLE
Perlmutter container

### DIFF
--- a/deploy/perlmutter-container/Containerfile
+++ b/deploy/perlmutter-container/Containerfile
@@ -1,0 +1,72 @@
+# FUSE in a container for podman-hpc on NERSC Perlmutter
+#
+# Build context MUST be the FUSE repo root so the Makefile (which holds the
+# canonical list of ProjectTorreyPines packages) can be copied in:
+#
+#   podman-hpc build -t fuse:<version> -f deploy/perlmutter-container/Containerfile .
+#
+# See deploy/perlmutter-container/build.sh for the full build + migrate flow.
+
+# Fully-qualified base image: on Perlmutter the default registries.conf resolves
+# bare names against registry.suse.com, so we pin Docker Hub explicitly.
+FROM docker.io/library/julia:1.11.7
+
+# --- system dependencies -----------------------------------------------------
+# git + CLI git is used by Pkg to clone the FuseRegistry packages; gcc is the
+# C compiler PackageCompiler invokes when building the system image.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        build-essential \
+        gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+# The FuseRegistry stores package repos as git@github.com: (SSH) URLs, which
+# require SSH keys. All ProjectTorreyPines packages are public, so rewrite SSH
+# GitHub URLs to anonymous HTTPS so the build needs no credentials. Written to
+# the system gitconfig (read regardless of $HOME) as a backstop; the install
+# script also rewrites the registry files directly.
+RUN git config --system url."https://github.com/".insteadOf "git@github.com:" \
+    && git config --system url."https://github.com/".insteadOf "ssh://git@github.com/" \
+    && git config --global url."https://github.com/".insteadOf "git@github.com:" \
+    && git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+
+# --- build-time Julia configuration ------------------------------------------
+# These mirror deploy/perlmutter/deploy.sh. JULIA_NUM_THREADS=1 is REQUIRED by
+# install_fuse_container.jl (PackageCompiler sysimage build asserts 1 thread).
+# The znver3 CPU target matches Perlmutter's AMD Milan login/compute/GPU nodes;
+# building the image on a Perlmutter node keeps the arch consistent.
+ENV FUSE_INSTALL_DIR=/opt/fuse \
+    JULIA_DEPOT_PATH=/opt/fuse/.julia \
+    JULIA_PKG_USE_CLI_GIT=1 \
+    JULIA_CC="gcc -O3" \
+    JULIA_NUM_THREADS=1 \
+    JULIA_CPU_TARGET="generic;znver3,-xsaveopt,-rdrnd,clone_all"
+
+# --- install FUSE + build the sysimage ---------------------------------------
+WORKDIR /opt/build
+COPY deploy/perlmutter-container/install_fuse_container.jl /opt/build/install_fuse_container.jl
+COPY Makefile /opt/build/Makefile
+
+# Installs FUSE and all PTP packages into $FUSE_INSTALL_DIR, builds IJulia, and
+# compiles /opt/fuse/sys_fuse.so. This step is heavy (runs the FUSE test suite
+# and tutorial as precompile workload) and is best run inside a CPU allocation.
+RUN julia /opt/build/install_fuse_container.jl
+
+# --- runtime configuration ---------------------------------------------------
+# At runtime the project + depot point at the baked install. Threads are left
+# unset so users can choose (e.g. JULIA_NUM_THREADS=8) when they run the image.
+ENV JULIA_PROJECT=/opt/fuse \
+    JULIA_DEPOT_PATH=/opt/fuse/.julia \
+    JULIA_CPU_TARGET="generic;znver3,-xsaveopt,-rdrnd,clone_all"
+
+# `fuse` launches a Julia REPL preloaded with the FUSE sysimage.
+RUN printf '%s\n' \
+    '#!/bin/bash' \
+    'exec julia --sysimage=/opt/fuse/sys_fuse.so "$@"' \
+    > /usr/local/bin/fuse \
+    && chmod 0555 /usr/local/bin/fuse
+
+WORKDIR /root
+CMD ["fuse"]

--- a/deploy/perlmutter-container/README.md
+++ b/deploy/perlmutter-container/README.md
@@ -10,7 +10,7 @@ single OCI image instead of an environment module.
 
 | File | Purpose |
 |------|---------|
-| `Containerfile` | Image definition (`FROM julia:1.11.7`), installs FUSE + builds the sysimage. |
+| `Containerfile` | Image definition (`FROM docker.io/library/julia:1.11.7`), installs FUSE + builds the sysimage. |
 | `install_fuse_container.jl` | Runs inside the build: adds registries, installs packages, compiles `sys_fuse.so`. |
 | `build.sh` | Builds and migrates the image on Perlmutter. |
 | `kernel.json.template` | Jupyter kernelspec template wrapping `podman-hpc run --jupyter`. |
@@ -45,6 +45,37 @@ architecture consistent.
 > Re-run `build.sh` (build + migrate) after any change. A migrated image is
 > read-only; you must re-`migrate` to pick up a rebuild.
 
+## Testing the shared image
+
+The project image is published to `/global/cfs/cdirs/m3739/shared_images` and is
+usable by anyone in `m3739` (no build or pull needed) by adding `--squash-dir`.
+On a Perlmutter login node:
+
+```bash
+# shortcut so every command uses the shared image store
+alias fuse-podman='podman-hpc --squash-dir /global/cfs/cdirs/m3739/shared_images'
+
+# 1) confirm the image is visible
+fuse-podman images | grep fuse
+# expect: localhost/fuse  v1.1.3  ...  R/O
+
+# 2) fast smoke test (loads FUSE from the baked-in sysimage, starts in seconds)
+fuse-podman run --rm fuse:v1.1.3 \
+  julia --sysimage=/opt/fuse/sys_fuse.so \
+  -e 'using FUSE; ini,act=FUSE.case_parameters(:D3D,:L_mode); println("FUSE OK: ", pkgversion(FUSE))'
+
+# 3) offline test (proves it is fully self-contained: no "Downloading artifact" lines)
+fuse-podman run --rm --network none fuse:v1.1.3 \
+  julia --sysimage=/opt/fuse/sys_fuse.so \
+  -e 'using FUSE; ini,act=FUSE.case_parameters(:D3D,:L_mode); dd=FUSE.init(ini,act); println("OFFLINE OK")'
+
+# 4) interactive REPL (optional)
+fuse-podman run --rm -it fuse:v1.1.3
+```
+
+For the Jupyter equivalent, see [Interactive use via Jupyter](#3-interactive-use-via-jupyter)
+(install the kernel with `SQUASH_DIR=/global/cfs/cdirs/m3739/shared_images`).
+
 ## 2. Run the FUSE REPL
 
 ```bash
@@ -78,8 +109,34 @@ whose `argv` runs the in-container Julia via `podman-hpc run --rm --jupyter`.
 The `--jupyter` flag bind-mounts `/tmp` and `$HOME` so the kernel can connect
 and create notebooks in your home directory.
 
-Then open [NERSC JupyterHub](https://jupyter.nersc.gov) on a Perlmutter login
-node and select the **Julia FUSE-<version>** kernel.
+To use an image from a shared squash dir (instead of your per-user store), set
+`SQUASH_DIR`; the generated kernel will pass `podman-hpc --squash-dir <dir> run`:
+
+```bash
+SQUASH_DIR=/global/cfs/cdirs/m3739/shared_images \
+FUSE_ENVIRONMENT=<version> ./deploy/perlmutter-container/install_kernel.sh
+```
+
+### Test the kernel
+
+1. Open [NERSC JupyterHub](https://jupyter.nersc.gov) and start a server on a
+   Perlmutter login node.
+2. Create a new notebook and select the **Julia FUSE-<version>** kernel
+   (display name e.g. `Julia FUSE-v1.1.3 (1 thread(s))`).
+3. Run this test cell:
+
+   ```julia
+   using FUSE
+   ini, act = FUSE.case_parameters(:D3D, :L_mode)
+   dd = FUSE.init(ini, act)
+   @show pkgversion(FUSE)
+   ```
+
+Expected: the kernel connects within a few seconds, `using FUSE` returns almost
+instantly (sysimage), the actors run, and `pkgversion(FUSE)` prints the image
+version. If the kernel fails to start, check the kernelspec at
+`$HOME/.local/share/jupyter/kernels/fuse-<version>/kernel.json` and confirm
+`podman-hpc images` (add `--squash-dir <dir>` if shared) lists `fuse:<version>`.
 
 ## Mounting data (optional)
 

--- a/deploy/perlmutter-container/README.md
+++ b/deploy/perlmutter-container/README.md
@@ -1,0 +1,114 @@
+# FUSE in a podman-hpc container on NERSC Perlmutter
+
+This directory builds a self-contained [podman-hpc](https://docs.nersc.gov/development/containers/podman-hpc/overview/)
+image that bakes in FUSE.jl, all ProjectTorreyPines packages, and a precompiled
+PackageCompiler system image (`sys_fuse.so`) for fast startup. It mirrors the
+Lmod module deploy in [`../perlmutter`](../perlmutter) but ships everything in a
+single OCI image instead of an environment module.
+
+## Contents
+
+| File | Purpose |
+|------|---------|
+| `Containerfile` | Image definition (`FROM julia:1.11.7`), installs FUSE + builds the sysimage. |
+| `install_fuse_container.jl` | Runs inside the build: adds registries, installs packages, compiles `sys_fuse.so`. |
+| `build.sh` | Builds and migrates the image on Perlmutter. |
+| `kernel.json.template` | Jupyter kernelspec template wrapping `podman-hpc run --jupyter`. |
+| `install_kernel.sh` | Generates and installs the FUSE Jupyter kernel for the current user. |
+
+## 1. Build the image
+
+The build runs the FUSE test suite + tutorial as the sysimage precompile
+workload, so it is heavy. Run it from an interactive CPU allocation:
+
+```bash
+salloc -N 1 -C cpu -q interactive -A m3739 -t 04:00:00
+
+cd $PSCRATCH/.julia/dev/FUSE        # the FUSE repo root (build context)
+./deploy/perlmutter-container/build.sh
+```
+
+`build.sh` will:
+
+1. Resolve the image tag (`fuse:<version>`) from the latest FUSE.jl release
+   (override with `FUSE_ENVIRONMENT=v1.1.3`).
+2. `podman-hpc build -t fuse:<version> -f deploy/perlmutter-container/Containerfile .`
+3. `podman-hpc migrate fuse:<version>` — converts the image to a read-only
+   squashfs under `$SCRATCH` so it can be used in jobs and on any login node.
+   (Set `SQUASH_DIR=/global/cfs/cdirs/m3739/shared_images` to share it across
+   the project.)
+
+The Containerfile sets `JULIA_CPU_TARGET="generic;znver3,..."` to match
+Perlmutter's AMD Milan CPUs; building on a Perlmutter node keeps the sysimage
+architecture consistent.
+
+> Re-run `build.sh` (build + migrate) after any change. A migrated image is
+> read-only; you must re-`migrate` to pick up a rebuild.
+
+## 2. Run the FUSE REPL
+
+```bash
+podman-hpc run --rm -it fuse:<version>
+```
+
+This launches a Julia REPL with the FUSE sysimage preloaded (startup in
+seconds). Quick smoke test:
+
+```bash
+podman-hpc run --rm fuse:<version> \
+  julia --sysimage=/opt/fuse/sys_fuse.so \
+  -e 'using FUSE; ini,act=FUSE.case_parameters(:D3D,:L_mode); println("FUSE ok")'
+```
+
+Use more threads at runtime:
+
+```bash
+podman-hpc run --rm -it -e JULIA_NUM_THREADS=8 fuse:<version>
+```
+
+## 3. Interactive use via Jupyter
+
+```bash
+FUSE_ENVIRONMENT=<version> ./deploy/perlmutter-container/install_kernel.sh
+# optionally: THREADS=8 FUSE_ENVIRONMENT=<version> ./install_kernel.sh
+```
+
+This writes `$HOME/.local/share/jupyter/kernels/fuse-<version>/kernel.json`,
+whose `argv` runs the in-container Julia via `podman-hpc run --rm --jupyter`.
+The `--jupyter` flag bind-mounts `/tmp` and `$HOME` so the kernel can connect
+and create notebooks in your home directory.
+
+Then open [NERSC JupyterHub](https://jupyter.nersc.gov) on a Perlmutter login
+node and select the **Julia FUSE-<version>** kernel.
+
+## Mounting data (optional)
+
+Containers only see `/tmp` and `$HOME` by default (plus whatever `--jupyter`
+mounts). To read/write data elsewhere, bind-mount it:
+
+```bash
+podman-hpc run --rm -it \
+  --volume $SCRATCH/fuse_runs:/work \
+  fuse:<version>
+```
+
+For the DIII-D time-dependent study, the OMFIT/OMAS roots used by the module
+deploy live on CFS and are **not** baked into the image. Mount them and set the
+matching env vars if needed:
+
+```bash
+podman-hpc run --rm -it \
+  --volume /global/common/software/m3739/perlmutter/OMFIT-CAKE:/omfit:ro \
+  --volume /global/common/software/m3739/perlmutter/FUSE_OMAS:/omas:ro \
+  -e FUSE_OMFIT_ROOT=/omfit -e FUSE_OMAS_ROOT=/omas -e FUSE_OMFIT_HOST=localhost \
+  fuse:<version>
+```
+
+## Notes
+
+- Defaults reuse the existing deploy: account `m3739` and image tag from the
+  latest FUSE release. Adjust via `salloc -A ...` and `FUSE_ENVIRONMENT`.
+- The image is built from the official `julia:1.11.7` base (the required Julia
+  version) rather than rebuilding Julia from the NERSC module.
+- See the NERSC docs: [podman-hpc overview](https://docs.nersc.gov/development/containers/podman-hpc/overview/)
+  and [containers in Jupyter](https://docs.nersc.gov/services/jupyter/how-to-guides/#how-to-use-a-container-to-run-a-jupyter-kernel).

--- a/deploy/perlmutter-container/build.sh
+++ b/deploy/perlmutter-container/build.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Build and migrate the FUSE podman-hpc image on Perlmutter.
+#
+# The sysimage build is heavy (runs the FUSE test suite + tutorial), so run this
+# from inside an interactive CPU allocation rather than bare on a login node:
+#
+#   salloc -N 1 -C cpu -q interactive -A m3739 -t 04:00:00
+#   ./deploy/perlmutter-container/build.sh
+#
+# Override the image tag (defaults to the latest FUSE.jl release) with:
+#   FUSE_ENVIRONMENT=v1.1.3 ./deploy/perlmutter-container/build.sh
+#
+# Share the migrated image across the project (instead of personal SCRATCH):
+#   SQUASH_DIR=/global/cfs/cdirs/m3739/shared_images ./build.sh
+
+set -euo pipefail
+
+scriptdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# FUSE repo root == build context (Containerfile copies the Makefile from here)
+repo_root="$(cd "$scriptdir/../.." && pwd)"
+
+# Resolve the image tag: explicit override, else latest GitHub release name.
+if [[ -n "${FUSE_ENVIRONMENT:-}" ]]; then
+    version="$FUSE_ENVIRONMENT"
+else
+    version="$(curl -s https://api.github.com/repos/ProjectTorreyPines/FUSE.jl/releases/latest | jq -r .name)"
+fi
+if [[ -z "$version" || "$version" == "null" ]]; then
+    echo "ERROR: could not determine FUSE version (set FUSE_ENVIRONMENT)." >&2
+    exit 1
+fi
+
+image="fuse:$version"
+
+if ! command -v podman-hpc >/dev/null 2>&1; then
+    echo "ERROR: podman-hpc not found. Run this on Perlmutter." >&2
+    exit 1
+fi
+
+if [[ -z "${SLURM_JOB_ID:-}" ]]; then
+    echo "WARNING: not inside a Slurm allocation. The sysimage build is heavy;" >&2
+    echo "         prefer 'salloc -N 1 -C cpu -q interactive -A m3739 -t 04:00:00' first." >&2
+fi
+
+echo "### Building $image (context: $repo_root)"
+podman-hpc build -t "$image" -f "$scriptdir/Containerfile" "$repo_root"
+
+echo "### Migrating $image to a squashed read-only image"
+if [[ -n "${SQUASH_DIR:-}" ]]; then
+    podman-hpc --squash-dir "$SQUASH_DIR" migrate "$image"
+else
+    podman-hpc migrate "$image"
+fi
+
+echo
+echo "### Done. Image '$image' is built and migrated."
+echo "Run the FUSE REPL with:"
+echo "    podman-hpc run --rm -it $image"
+echo "Install the Jupyter kernel with:"
+echo "    FUSE_ENVIRONMENT=$version ./deploy/perlmutter-container/install_kernel.sh"

--- a/deploy/perlmutter-container/install_fuse_container.jl
+++ b/deploy/perlmutter-container/install_fuse_container.jl
@@ -1,0 +1,148 @@
+# Install FUSE + all ProjectTorreyPines packages into a container image and
+# compile a PackageCompiler system image (sys_fuse.so).
+#
+# Adapted from deploy/perlmutter/install_fuse_environment.jl, with the Lmod
+# module-file generation, IJulia kernelspec creation, and /global/common host
+# paths removed. Those concerns are handled outside the container:
+#   - the Jupyter kernel is a host-side kernel.json (see install_kernel.sh)
+#   - module loading is replaced by `podman-hpc run`
+#
+# Driven entirely by environment variables set in the Containerfile:
+#   FUSE_INSTALL_DIR   install/depot location          (default /opt/fuse)
+#   JULIA_CPU_TARGET   sysimage CPU target              (required)
+# Optional:
+#   FUSE_MAKEFILE      path to FUSE Makefile to parse   (default /opt/build/Makefile)
+
+@assert (Threads.nthreads() == 1) "Error: Installing FUSE sysimage requires running Julia with one thread"
+@assert ("JULIA_CPU_TARGET" in keys(ENV)) "Error: Must define JULIA_CPU_TARGET environment variable"
+
+install_dir = get(ENV, "FUSE_INSTALL_DIR", "/opt/fuse")
+cpu_target = ENV["JULIA_CPU_TARGET"]
+makefile = get(ENV, "FUSE_MAKEFILE", "/opt/build/Makefile")
+
+import Pkg
+
+println("### Setup main environment for installer")
+Pkg.activate()
+Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/ProjectTorreyPines/FuseRegistry.jl.git"))
+Pkg.Registry.add("General")
+Pkg.add("PackageCompiler")
+Pkg.update()  # also flips Pkg's "registry updated this session" flag so the
+              # Pkg.add() below will not re-fetch (and revert) the registry edits
+using PackageCompiler
+
+println()
+println("### Rewrite FuseRegistry SSH (git@github.com:) URLs to anonymous HTTPS")
+# The FuseRegistry stores package repos as git@github.com: URLs. Julia's CLI git
+# tries to clone those over SSH, which fails in a credential-free container
+# (no ssh binary / no keys). Since all ProjectTorreyPines packages are public,
+# rewrite the cloned registry's Package.toml repo fields to HTTPS so clones work
+# anonymously. This is independent of git config / $HOME, so it always applies.
+function rewrite_registry_ssh_to_https()
+    n = 0
+    for depot in DEPOT_PATH
+        regroot = joinpath(depot, "registries")
+        isdir(regroot) || continue
+        for (root, _, files) in walkdir(regroot)
+            for f in files
+                f == "Package.toml" || continue
+                path = joinpath(root, f)
+                s = read(path, String)
+                s2 = replace(s, "git@github.com:" => "https://github.com/")
+                if s2 != s
+                    chmod(path, 0o644)
+                    write(path, s2)
+                    n += 1
+                end
+            end
+        end
+    end
+    return n
+end
+println("    rewrote ", rewrite_registry_ssh_to_https(), " Package.toml file(s)")
+
+println()
+println("### parse PTP packages from Makefile: ", makefile)
+function get_packages_from_makefile(makefile)
+    for line in eachline(makefile)
+        if occursin(r"^FUSE_PACKAGES_MAKEFILE\s*:=", line)
+            pkg_line = replace(line, r"^FUSE_PACKAGES_MAKEFILE\s*:=" => "")
+            return split(strip(pkg_line))
+        end
+    end
+    error("Could not find FUSE_PACKAGES_MAKEFILE in $makefile")
+end
+packages = get_packages_from_makefile(makefile)
+pkgs_using = join(packages, ", ")
+println("    ", packages)
+
+println()
+println("### Setup FUSE environment in ", install_dir)
+Pkg.activate(install_dir)
+Pkg.add([["FUSE", "Plots", "IJulia", "WebIO", "Interact", "EFIT", "ArgParse"]; packages])
+Pkg.build("IJulia")
+
+println()
+println("### Eagerly install lazy artifacts (e.g. MKL) so the image runs offline")
+# Pkg.add/instantiate skip artifacts marked `lazy = true`; those normally
+# download on first @artifact_str access at runtime (observed: MKL). Walk every
+# (Julia)Artifacts.toml in the depot and download all artifacts for this
+# platform, including lazy ones, so they are baked into the image.
+import Pkg.Artifacts: select_downloadable_artifacts, ensure_artifact_installed
+function install_all_artifacts(depot)
+    installed = 0
+    pkgsdir = joinpath(depot, "packages")
+    isdir(pkgsdir) || return installed
+    for (root, _, files) in walkdir(pkgsdir)
+        for f in files
+            (f == "Artifacts.toml" || f == "JuliaArtifacts.toml") || continue
+            toml = joinpath(root, f)
+            local arts
+            try
+                arts = select_downloadable_artifacts(toml; include_lazy=true)
+            catch err
+                @warn "Could not parse $toml" exception = err
+                continue
+            end
+            for (name, meta) in arts
+                try
+                    ensure_artifact_installed(name, meta, toml)
+                    installed += 1
+                catch err
+                    @warn "Failed to install artifact $name from $toml" exception = err
+                end
+            end
+        end
+    end
+    return installed
+end
+println("    installed/verified ", install_all_artifacts(first(DEPOT_PATH)), " downloadable artifact(s)")
+
+println()
+println("### Create precompile script")
+precompile_execution_file = joinpath(install_dir, "precompile_script.jl")
+precompile_cmds = """
+using FUSE, EFIT, $pkgs_using
+include(joinpath(pkgdir(FUSE), "docs", "src", "tutorial.jl"))
+include(joinpath(pkgdir(FUSE), "test", "runtests.jl"))
+"""
+write(precompile_execution_file, precompile_cmds)
+
+println()
+println("### Precompile FUSE sys image")
+sysimage_path = joinpath(install_dir, "sys_fuse.so")
+create_sysimage(["FUSE"]; sysimage_path, precompile_execution_file, cpu_target)
+chmod(sysimage_path, 0o555)
+
+println()
+println("### Record IJulia kernel.jl path for host-side kernelspec")
+# The host kernel.json (see install_kernel.sh) needs the in-container path to
+# IJulia's kernel.jl. Resolve and persist it next to the sysimage.
+import IJulia
+kernel_jl = joinpath(pkgdir(IJulia), "src", "kernel.jl")
+@assert isfile(kernel_jl) "Could not locate IJulia kernel.jl at $kernel_jl"
+write(joinpath(install_dir, "ijulia_kernel_path.txt"), kernel_jl)
+println("    ", kernel_jl)
+
+println()
+println("### FUSE container install complete")

--- a/deploy/perlmutter-container/install_kernel.sh
+++ b/deploy/perlmutter-container/install_kernel.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Install a host-side Jupyter kernelspec that runs FUSE inside the podman-hpc
+# container. NERSC JupyterHub discovers kernels under
+# $HOME/.local/share/jupyter/kernels/. The kernel's argv wraps the in-container
+# Julia (with the FUSE sysimage) using `podman-hpc run --jupyter`; the
+# --jupyter flag bind-mounts /tmp and $HOME so the kernel can connect and write
+# notebooks.
+#
+# Run this AFTER ./build.sh has built and migrated the image. Usage:
+#   FUSE_ENVIRONMENT=v1.1.3 ./deploy/perlmutter-container/install_kernel.sh
+#
+# Optional:
+#   THREADS=8   number of Julia threads the kernel starts with (default 1)
+
+set -euo pipefail
+
+scriptdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -n "${FUSE_ENVIRONMENT:-}" ]]; then
+    version="$FUSE_ENVIRONMENT"
+else
+    version="$(curl -s https://api.github.com/repos/ProjectTorreyPines/FUSE.jl/releases/latest | jq -r .name)"
+fi
+if [[ -z "$version" || "$version" == "null" ]]; then
+    echo "ERROR: could not determine FUSE version (set FUSE_ENVIRONMENT)." >&2
+    exit 1
+fi
+
+threads="${THREADS:-1}"
+image="localhost/fuse:$version"
+
+if ! command -v podman-hpc >/dev/null 2>&1; then
+    echo "ERROR: podman-hpc not found. Run this on Perlmutter." >&2
+    exit 1
+fi
+
+# Pull the IJulia kernel.jl path that install_fuse_container.jl recorded in the
+# image, so the kernelspec points at the right file inside the container.
+echo "### Resolving IJulia kernel path from $image"
+kernel_jl="$(podman-hpc run --rm "$image" cat /opt/fuse/ijulia_kernel_path.txt | tr -d '\r\n')"
+if [[ -z "$kernel_jl" ]]; then
+    echo "ERROR: could not read /opt/fuse/ijulia_kernel_path.txt from $image." >&2
+    echo "       Did you run build.sh (build + migrate) first?" >&2
+    exit 1
+fi
+echo "    $kernel_jl"
+
+kernel_dir="$HOME/.local/share/jupyter/kernels/fuse-$version"
+mkdir -p "$kernel_dir"
+
+display="Julia FUSE-$version ($threads thread(s))"
+
+sed -e "s|__IMAGE__|$image|g" \
+    -e "s|__KERNEL_JL__|$kernel_jl|g" \
+    -e "s|__THREADS__|$threads|g" \
+    -e "s|__DISPLAY__|$display|g" \
+    "$scriptdir/kernel.json.template" > "$kernel_dir/kernel.json"
+
+echo
+echo "### Installed kernelspec at $kernel_dir/kernel.json"
+echo "Open NERSC JupyterHub (Perlmutter login node) and select the"
+echo "'$display' kernel."

--- a/deploy/perlmutter-container/install_kernel.sh
+++ b/deploy/perlmutter-container/install_kernel.sh
@@ -10,7 +10,13 @@
 #   FUSE_ENVIRONMENT=v1.1.3 ./deploy/perlmutter-container/install_kernel.sh
 #
 # Optional:
-#   THREADS=8   number of Julia threads the kernel starts with (default 1)
+#   THREADS=8      number of Julia threads the kernel starts with (default 1)
+#   SQUASH_DIR=... use an image from a shared squash dir instead of the
+#                  per-user store. The generated kernel will pass
+#                  `podman-hpc --squash-dir <dir> run ...`. Example (project
+#                  image shared with all of m3739):
+#                    SQUASH_DIR=/global/cfs/cdirs/m3739/shared_images \
+#                    FUSE_ENVIRONMENT=v1.1.3 ./install_kernel.sh
 
 set -euo pipefail
 
@@ -28,6 +34,13 @@ fi
 
 threads="${THREADS:-1}"
 image="localhost/fuse:$version"
+squash_dir="${SQUASH_DIR:-}"
+
+# Global podman-hpc flags applied both when probing the image and in the kernel.
+podman_global=()
+if [[ -n "$squash_dir" ]]; then
+    podman_global=(--squash-dir "$squash_dir")
+fi
 
 if ! command -v podman-hpc >/dev/null 2>&1; then
     echo "ERROR: podman-hpc not found. Run this on Perlmutter." >&2
@@ -36,8 +49,8 @@ fi
 
 # Pull the IJulia kernel.jl path that install_fuse_container.jl recorded in the
 # image, so the kernelspec points at the right file inside the container.
-echo "### Resolving IJulia kernel path from $image"
-kernel_jl="$(podman-hpc run --rm "$image" cat /opt/fuse/ijulia_kernel_path.txt | tr -d '\r\n')"
+echo "### Resolving IJulia kernel path from $image${squash_dir:+ (squash-dir: $squash_dir)}"
+kernel_jl="$(podman-hpc "${podman_global[@]}" run --rm "$image" cat /opt/fuse/ijulia_kernel_path.txt | tr -d '\r\n')"
 if [[ -z "$kernel_jl" ]]; then
     echo "ERROR: could not read /opt/fuse/ijulia_kernel_path.txt from $image." >&2
     echo "       Did you run build.sh (build + migrate) first?" >&2
@@ -50,13 +63,24 @@ mkdir -p "$kernel_dir"
 
 display="Julia FUSE-$version ($threads thread(s))"
 
+# Build the optional "--squash-dir", "<dir>", argv entries (as JSON lines), or
+# leave empty so the placeholder line is dropped.
+if [[ -n "$squash_dir" ]]; then
+    squash_repl="    \"--squash-dir\",\\n    \"$squash_dir\","
+else
+    squash_repl=""
+fi
+
 sed -e "s|__IMAGE__|$image|g" \
     -e "s|__KERNEL_JL__|$kernel_jl|g" \
     -e "s|__THREADS__|$threads|g" \
     -e "s|__DISPLAY__|$display|g" \
-    "$scriptdir/kernel.json.template" > "$kernel_dir/kernel.json"
+    -e "s|^__SQUASH_ARGS__\$|$squash_repl|" \
+    "$scriptdir/kernel.json.template" \
+  | sed '/^[[:space:]]*$/d' > "$kernel_dir/kernel.json"
 
 echo
 echo "### Installed kernelspec at $kernel_dir/kernel.json"
+[[ -n "$squash_dir" ]] && echo "    (kernel runs the image from squash-dir: $squash_dir)"
 echo "Open NERSC JupyterHub (Perlmutter login node) and select the"
 echo "'$display' kernel."

--- a/deploy/perlmutter-container/kernel.json.template
+++ b/deploy/perlmutter-container/kernel.json.template
@@ -1,0 +1,19 @@
+{
+  "argv": [
+    "podman-hpc",
+    "run",
+    "--rm",
+    "--jupyter",
+    "__IMAGE__",
+    "julia",
+    "--sysimage=/opt/fuse/sys_fuse.so",
+    "--threads=__THREADS__",
+    "__KERNEL_JL__",
+    "{connection_file}"
+  ],
+  "display_name": "__DISPLAY__",
+  "language": "julia",
+  "metadata": {
+    "debugger": true
+  }
+}

--- a/deploy/perlmutter-container/kernel.json.template
+++ b/deploy/perlmutter-container/kernel.json.template
@@ -1,6 +1,7 @@
 {
   "argv": [
     "podman-hpc",
+__SQUASH_ARGS__
     "run",
     "--rm",
     "--jupyter",

--- a/test/runtests_study.jl
+++ b/test/runtests_study.jl
@@ -97,6 +97,7 @@ using FUSE.SimulationParameters.Distributions
         df1 = CSV.read(joinpath(save_dir, "output.csv"), DataFrame)
 
         db = FUSE.load_study_database(joinpath(save_dir, "database.h5"));
+        dds2 = [ i.dd for i in db.items ];
         inis2 = [ i.ini for i in db.items ];
         acts2 = [ i.act for i in db.items ];
         df2 = db.df


### PR DESCRIPTION
## Summary

Adds a containerized FUSE deployment for NERSC Perlmutter under `deploy/perlmutter-container/`, complementing the existing Lmod module deploy. Builds a self-contained `podman-hpc` image (`FROM docker.io/library/julia:1.11.7`) that bakes in FUSE, all ProjectTorreyPines packages, runtime artifacts (including lazy ones, for fully offline use), and a precompiled `sys_fuse.so` sysimage, and exposes it as a Jupyter kernel. The image can be shared project-wide via a CFS squash dir.

## What's included

- **`Containerfile`** — Julia 1.11.7 base, znver3 CPU target; installs FUSE and builds the sysimage.
- **`install_fuse_container.jl`** — adapted from the module installer (Lmod/host-path logic removed); adds registries, installs FUSE + PTP packages, eagerly installs lazy artifacts (e.g. MKL) for offline use, and compiles the sysimage.
- **`build.sh`** — `podman-hpc build` + `migrate`, run from an interactive/batch CPU allocation; supports `SQUASH_DIR` to migrate straight into a shared (project-wide) squash dir.
- **`install_kernel.sh`** + **`kernel.json.template`** — host-side Jupyter kernelspec wrapping `podman-hpc run --jupyter`; supports `SQUASH_DIR` so the kernel can run a shared image (injects `podman-hpc --squash-dir <dir> run`).
- **`README.md`** — end-to-end build/run/Jupyter instructions, a "Testing the shared image" section (CLI + offline test) and a Jupyter kernel test, plus data bind-mount notes.

## Notes

- Base image is pinned to `docker.io/library/...` because Perlmutter's default `registries.conf` resolves bare names against `registry.suse.com`.
- FuseRegistry's `git@github.com:` SSH URLs are rewritten to anonymous HTTPS at build time, so the build needs no credentials.
- Lazy artifacts are downloaded at build time so the image runs with **no network access** (`--network none`).
- Built and verified on Perlmutter: `localhost/fuse:v1.1.3` (~14.7 GB); `using FUSE` + `case_parameters(:D3D, :L_mode)` + `init` runs from the sysimage, verified both online and fully offline.
- Published to `/global/cfs/cdirs/m3739/shared_images` (group-readable) so anyone in `m3739` can run it via `--squash-dir` without building or pulling.

## Usage

```bash
# build + migrate (from an salloc CPU node)
./deploy/perlmutter-container/build.sh
# ...or migrate into the shared project store:
SQUASH_DIR=/global/cfs/cdirs/m3739/shared_images ./deploy/perlmutter-container/build.sh

# run the FUSE REPL (per-user image)
podman-hpc run --rm -it fuse:v1.1.3

# run from the shared image (any m3739 member)
podman-hpc --squash-dir /global/cfs/cdirs/m3739/shared_images run --rm -it fuse:v1.1.3

# install the Jupyter kernel (add SQUASH_DIR to use the shared image)
FUSE_ENVIRONMENT=v1.1.3 ./deploy/perlmutter-container/install_kernel.sh
SQUASH_DIR=/global/cfs/cdirs/m3739/shared_images \
  FUSE_ENVIRONMENT=v1.1.3 ./deploy/perlmutter-container/install_kernel.sh