### PR TITLE
Autodiff GPU TJLFEP solver + ActorFINN actor-category fix

### DIFF
--- a/src/actors/transport/finn_actor.jl
+++ b/src/actors/transport/finn_actor.jl
@@ -37,7 +37,7 @@ import GACODE
     )
 end
 
-mutable struct ActorFINN{D,P} <: SingleAbstractActor{D,P}
+mutable struct ActorFINN{D,P} <: CompoundAbstractActor{D,P}
     dd::IMAS.dd{D}
     par::OverrideParameters{P,FUSEparameters__ActorFINN{P}}
     finn_results::NamedTuple

--- a/src/actors/transport/tglfep_actor.jl
+++ b/src/actors/transport/tglfep_actor.jl
@@ -10,6 +10,8 @@ import TurbulentTransport
         Entry{AbstractVector{T}}("-", "rho_tor_norm radii at which TGLF-EP finds the critical EP-density scale SFmin"; default=[0.01, 0.21, 0.41, 0.61, 0.81, 0.95])
     is_ep::Entry{Int} = Entry{Int}("-", "ion index of the energetic-particle (EP) driver species in dd.core_profiles.ion"; default=3)
     process_in::Entry{Int} = Entry{Int}("-", "TGLF-EP PROCESS_IN (4 or 5: critical-EP-density-gradient scan)"; default=5)
+    solver::Switch{Symbol} =
+        Switch{Symbol}([:grid, :ad], "-", "critical-factor engine: :grid (Fortran-equivalent kwscale_scan sweep; SFmin matches Fortran) or :ad (autodiff AE-onset Newton + IFT (kyhat,width) descent; grid-independent so SFmin can differ from/be more accurate than :grid, and is much faster on GPU)"; default=:grid)
     threshold_flag::Entry{Int} = Entry{Int}("-", "TGLF-EP THRESHOLD_FLAG"; default=0)
     scan_method::Entry{Int} = Entry{Int}("-", "TGLF-EP SCAN_METHOD"; default=1)
     n_basis::Entry{Int} = Entry{Int}("-", "TGLF-EP N_BASIS (number of Hermite basis functions)"; default=2)
@@ -34,8 +36,8 @@ import TurbulentTransport
     E_alpha::Entry{T} = Entry{T}("MeV", "EP birth energy (3.5 MeV for fusion alphas)"; default=3.5)
     use_gpu::Entry{Bool} = Entry{Bool}("-", "run TJLF on GPU when available"; default=false)
     inner::Switch{Symbol} =
-        Switch{Symbol}([:threads, :mps_team], "-", "within-radius parallelism: :threads (serial-per-GPU baseline) or :mps_team (MPS clients sharing each GPU)"; default=:threads)
-    mps_team::Entry{Int} = Entry{Int}("-", "MPS-team size per GPU when inner=:mps_team (0 disables)"; default=8)
+        Switch{Symbol}([:threads, :mps_team], "-", "within-radius parallelism (SPMD per-radius layout only; the in-process actor run always uses :threads): :threads (serial-per-GPU baseline; fastest for solver=:ad) or :mps_team (MPS clients sharing each GPU; fastest for solver=:grid)"; default=:threads)
+    mps_team::Entry{Int} = Entry{Int}("-", "MPS-team size per GPU when inner=:mps_team (0 disables); recommended only for solver=:grid (the :ad path is faster with :threads)"; default=8)
 end
 
 mutable struct ActorTJLFEP{D,P} <: SingleAbstractActor{D,P}
@@ -113,10 +115,15 @@ function _step(actor::ActorTJLFEP{D,P}) where {D<:Real,P<:Real}
     rho_scan = collect(Float64, par.rho_scan)
     OptionsDict = _optionsdict(par)
 
-    use_ql = par.alpha_use_ql && par.alpha_solver == :stiff
+    # The AD solver returns the critical factor/marking only (no per-mode QL buffers),
+    # so QL-diffusivity coupling is unavailable on that path.
+    if par.alpha_use_ql && par.alpha_solver == :stiff && par.solver == :ad
+        @warn "ActorTJLFEP: alpha_use_ql is not supported with solver=:ad (no QL buffers from the AD path); falling back to non-QL stiff-CGM."
+    end
+    use_ql = par.alpha_use_ql && par.alpha_solver == :stiff && par.solver == :grid
     width, kymark_out, SFmin, dpdr_crit_out, dndr_crit_out, marginal_ql =
         TJLFEP.runTHD(dd, rho_scan, OptionsDict; use_gpu=par.use_gpu, ql_flux_scan=use_ql,
-            inner=par.inner, mps_team=par.mps_team)
+            inner=par.inner, mps_team=par.mps_team, solver=par.solver)
 
     actor.rho_grid = D.(dd.core_profiles.profiles_1d[].grid.rho_tor_norm)
     actor.SFmin = D.(SFmin)


### PR DESCRIPTION
## Summary
Two small, independent changes:
1. **`ActorTJLFEP`** — expose a new `solver` parameter (`:grid` / `:ad`) that
   selects the critical-factor engine and is forwarded to `TJLFEP.runTHD`, plus
   the associated QL-coupling guard and docstring updates.
2. **`ActorFINN`** — reclassify from `SingleAbstractActor` to
   `CompoundAbstractActor` so its declared category matches its behavior. Fixes
   the `docs/make.jl` build failure on the latest `master`. No runtime behavior
   change.

## What changed
- **`src/actors/transport/tglfep_actor.jl`**
  - New parameter `solver::Switch{Symbol}` (`[:grid, :ad]`, default `:grid`):
    `:grid` is the Fortran-equivalent `kwscale_scan` sweep (`SFmin` matches
    Fortran); `:ad` is the autodiff AE-onset Newton + IFT `(kyhat, width)`
    descent — grid-independent (its `SFmin` can differ from / be more accurate
    than `:grid`) and overall 36x faster on GPU.
  - `_step` now forwards `solver=par.solver` to `TJLFEP.runTHD`, and gates QL
    coupling on `solver == :grid`: when `alpha_use_ql` + `alpha_solver=:stiff`
    are requested with `solver=:ad`, it warns and falls back to non-QL stiff-CGM
    (the AD path returns no per-mode QL buffers).
  - Docstring updates for `inner` / `mps_team`: `inner` applies only to the SPMD
    per-radius layout (the in-process actor run always uses `:threads`);
    `:threads` is fastest for `solver=:ad`, `:mps_team` for `solver=:grid`, which
    is also the only case where `mps_team` is recommended.
- **`src/actors/transport/finn_actor.jl`**
  - `mutable struct ActorFINN{D,P} <: SingleAbstractActor{D,P}` →
    `<: CompoundAbstractActor{D,P}`.

## Why the ActorFINN change
`ActorFINN` now builds and runs an embedded `ActorReplay` (constructed from
`act`), so its standalone constructor is `(dd, par, act)` — the compound-actor
signature. It was still tagged `SingleAbstractActor`, whose contract is "fully
constructible from `(dd, par)` alone". This mismatch broke documentation
generation:

- `docs/src/actors_docs.jl` calls `FUSE.group_name(ActorFINN)` for every actor.
- For a `SingleAbstractActor`, `group_name` does `@which ActorFINN(dd, par)`.
- `ActorFINN` has no `(dd, par)` method anymore, so `which` throws
  (`MethodError: no method matching invoke ActorFINN(::dd, ::FUSEparameters__ActorFINN)`),
  aborting `make.jl`.

Reclassifying as compound makes `group_name` use the `(dd, par, act)` branch,
which matches the existing constructor and the existing call site
(`core_transport_actor.jl`: `ActorFINN(dd, act.ActorFINN, act)`).

The `(dd, par)` vs `(dd, par, act)` split is a load-bearing contract: parents
construct single sub-actors as `Sub(dd, act.Sub)` and compound sub-actors as
`Sub(dd, act.Sub, act)`. Since `ActorFINN` composes a sub-actor built from
`act`, it is compound by definition; adding a fake `(dd, par)` constructor would
only fabricate a half-wired actor to satisfy the wrong category. `group_name`
was intentionally left unchanged so this kind of misclassification keeps failing
the docs build loudly.

## Context (ActorTJLFEP)
This wires the actor up to the new TJLF/TJLFEP autodiff-GPU `:ad` engine: it
forwards `solver` / `use_gpu` / `inner` / `mps_team` to `TJLFEP.runTHD` and
guards the AD+QL incompatibility. The default `solver=:grid` preserves the
existing Fortran-equivalent behavior, so the change is opt-in; the in-process
actor run uses the optimal `:threads` layout for AD.

## Testing
- Loaded FUSE and ran `group_name` over all 65 concrete actors: 0 failures.
- `ActorFINN <: CompoundAbstractActor` and `group_name(ActorFINN) == "transport"`.
