### PR TITLE
Improvements to blanket calculation

### DIFF
--- a/src/actors/build/cx_actor.jl
+++ b/src/actors/build/cx_actor.jl
@@ -514,6 +514,22 @@ function blanket_regions!(bd::IMAS.build, eqt::IMAS.equilibrium__time_slice)
         ring_poly = LibGEOS.difference(ring_poly, structure_poly)
     end
 
+    # Sever the blanket at magnetic axis so HFS and LFS are optimized in blanket actor
+    ZA = eqt.global_quantities.magnetic_axis.z
+    rmin, rmax = extrema(layer.outline.r)
+    zmin, zmax = extrema(layer.outline.z)
+    dr = rmax - rmin
+    dz = zmax - zmin
+    divertor_zc = [sum(s.outline.z) / length(s.outline.z) for s in bd.structure if s.type == Int(_divertor_)]
+    if !any(>(ZA), divertor_zc) # no upper divertor: sever over the top
+        slot = xy_polygon(rectangle_shape(RA - 0.005 * dr, RA + 0.005 * dr, ZA, zmax + dz)...)
+        ring_poly = LibGEOS.difference(ring_poly, slot)
+    end
+    if !any(<(ZA), divertor_zc) # no lower divertor: sever under the bottom
+        slot = xy_polygon(rectangle_shape(RA - 0.005 * dr, RA + 0.005 * dr, zmin - dz, ZA)...)
+        ring_poly = LibGEOS.difference(ring_poly, slot)
+    end
+
     geometries = LibGEOS.getGeometries(ring_poly)
 
     # The boolean subtraction of the divertor polygons from the blanket ring can leave
@@ -523,19 +539,23 @@ function blanket_regions!(bd::IMAS.build, eqt::IMAS.equilibrium__time_slice)
     total_area = sum(areas)
     geometries = [poly for (poly, area) in zip(geometries, areas) if area > 0.01 * total_area]
 
-    for (kpoly, poly) in enumerate(geometries)
+    # classify each fragment as HFS/LFS by the side of the magnetic axis its centroid falls on
+    sides = [sum(v[1] for v in GeoInterface.coordinates(poly)[1]) / length(GeoInterface.coordinates(poly)[1]) > RA ? "LFS" : "HFS" for poly in geometries]
+    n_hfs = count(==("HFS"), sides)
+    n_lfs = count(==("LFS"), sides)
+    counters = Dict("HFS" => 0, "LFS" => 0)
+
+    for (poly, side) in zip(geometries, sides)
         coords = GeoInterface.coordinates(poly)
         pr = [v[1] for v in coords[1]]
         pz = [v[2] for v in coords[1]]
 
-        # assign to build structure (unique names so multiple segments don't overwrite each other)
-        side = sum(pr) / length(pr) > RA ? "LFS" : "HFS"
-        if length(geometries) == 1
-            name = "blanket"
-        elseif length(geometries) == 2
+        # unique names so multiple segments on a side don't overwrite each other
+        if (side == "HFS" ? n_hfs : n_lfs) == 1
             name = "$side blanket"
         else
-            name = "$side blanket $kpoly"
+            counters[side] += 1
+            name = "$side blanket $(counters[side])"
         end
 
         structure = resize!(bd.structure, "type" => Int(_blanket_), "name" => name)

--- a/src/actors/nuclear/blanket_actor.jl
+++ b/src/actors/nuclear/blanket_actor.jl
@@ -218,9 +218,10 @@ function _step(actor::ActorBlanket)
                 ed2 = modules_effective_thickness[ibm][k, 2] * x2
                 ed3 = modules_effective_thickness[ibm][k, 3] * x3
                 module_tritium_breeding_ratio += (NNeutronics.TBR(blanket_model, ed1, ed2, ed3, Li6) * modules_wall_loading_power[ibm][k] / module_wall_loading_power)
-                #NOTE: leakeage_energy is total number of neutrons in each energy bin, so just a sum is correct
+                # NOTE: leakeage_energy is total number of neutrons in each energy bin, so need to sum times energy grid
                 LE = NNeutronics.leakeage_energy(blanket_model, ed1, ed2, ed3, Li6, energy_grid)::Vector{Float64}
-                escape_flux = sum(LE) * modules_wall_loading_power[ibm][k] * modules_flux_geometric_scale[ibm][k]
+                escape_power_fraction = sum(LE .* energy_grid) / 14.1
+                escape_flux = escape_power_fraction * modules_wall_loading_power[ibm][k] * modules_flux_geometric_scale[ibm][k]
                 if escape_flux > modules_peak_escape_flux[ibm]
                     modules_peak_escape_flux[ibm] = escape_flux
                 end

--- a/src/actors/nuclear/blanket_actor.jl
+++ b/src/actors/nuclear/blanket_actor.jl
@@ -242,7 +242,8 @@ function _step(actor::ActorBlanket)
         else
             cost = norm((
                 (total_tritium_breeding_ratio - target) / target,
-                exp(Li6) / exp(100.0),
+                1e-6*maximum(modules_peak_escape_flux) / (sum(modules_peak_wall_flux) / length(modules_peak_wall_flux)),
+                1e-6*exp(0.01*Li6) / exp(1.0),
                 extra_cost
             ))
             return cost

--- a/src/parameters/parameters_inits.jl
+++ b/src/parameters/parameters_inits.jl
@@ -248,6 +248,7 @@ Base.@kwdef mutable struct FUSEparameters__requirements{T} <: ParametersInit{T}
     log10_flattop_duration::Entry{T} =
         Entry{T}("log10(s)", "Log10 value of the duration of the flattop (use Inf for steady-state). Preferred over `flattop_duration` for optimization studies.")
     tritium_breeding_ratio::Entry{T} = Entry{T}(IMAS.requirements, :tritium_breeding_ratio; check=x -> @assert x >= 0.0 "must be: tritium_breeding_ratio >= 0.0")
+    peak_escape_flux::Entry{T} = Entry{T}(IMAS.requirements, :peak_escape_flux; check=x -> @assert x >= 0.0 "must be: peak_escape_flux >= 0.0")
     cost::Entry{T} = Entry{T}(IMAS.requirements, :cost; check=x -> @assert x >= 0.0 "must be: cost >= 0.0")
     ne_peaking::Entry{T} = Entry{T}(IMAS.requirements, :ne_peaking; check=x -> @assert x >= 0.0 "must be: ne_peaking >= 0.0")
     q_pol_omp::Entry{T} = Entry{T}(IMAS.requirements, :q_pol_omp; check=x -> @assert x >= 0.0 "must be: q_pol_omp >= 0.0")


### PR DESCRIPTION
Split the blanket into two parts even if single null, so that both HFS and LFS can be optimized.
Fix the energy leakage calculation.