### PR TITLE
Improve install timing estimates and fix fusebot --help (#7)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ifndef NO_FUSE_EXTENSION
 endif
 FUSE_PACKAGES := $(shell echo '$(FUSE_PACKAGES_MAKEFILE)' | awk '{printf("[\"%s\"", $$1); for (i=2; i<=NF; i++) printf(", \"%s\"", $$i); print "]"}')
 FUSE_PACKAGES_ALL := $(shell echo '$(FUSE_PACKAGES_MAKEFILE_ALL)' | awk '{printf("[\"%s\"", $$1); for (i=2; i<=NF; i++) printf(", \"%s\"", $$i); print "]"}')
-DEV_PACKAGES_MAKEFILE := $(shell find ../*/.git/config -exec grep ProjectTorreyPines \{\} /dev/null \; | cut -d'/' -f 2)
+DEV_PACKAGES_MAKEFILE := $(shell find .. -mindepth 2 -maxdepth 2 -name config -path '*/.git/config' 2>/dev/null -exec grep -l ProjectTorreyPines {} \; 2>/dev/null | cut -d'/' -f 2)
 
 # ANSI color codes
 RESET=\033[0m

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -29,7 +29,8 @@ See [On NERSC (Perlmutter)](@ref nersc-install) for depot layout, `fusebot`, and
 FUSE and related packages are registered at the [FuseRegistry](https://github.com/ProjectTorreyPines/FuseRegistry.jl/).
 Start Julia (`julia` at the terminal), then:
 
-1. Add the `FuseRegistry` and the `FUSE` package (a fresh install can take 5+ minutes):
+1. Add the `FuseRegistry` and the `FUSE` package (a fresh install typically takes **15–30 minutes** to
+   download and precompile dependencies):
 
    ```julia
    using Pkg
@@ -45,12 +46,16 @@ Start Julia (`julia` at the terminal), then:
    ```
 
    !!! note "First import is slow"
-       The first `using FUSE` (and your first simulation run) triggers precompilation that can take
-       several minutes. This is normal and happens only once per Julia/FUSE version, not on every startup.
+       `Pkg.add("FUSE")` already precompiles most dependencies. The first `using FUSE` and your first
+       `FUSE.init(...)` smoke test can still take **5–15 minutes** extra while remaining packages and
+       actor code compile. This is normal and happens only once per Julia/FUSE version, not on every
+       startup.
 
 1. Install the `fusebot` helper (optional but recommended). `fusebot` is a small command-line tool
    bundled with FUSE; its main job is to install the Julia Jupyter kernels (`fusebot install_IJulia`),
-   plus a few related utilities. Install directory is picked by `install_fusebot()` automatically - the juliaup `bin` directory on a laptop, or `~/.local/bin` under `module load julia` on HPC:
+   plus a few related utilities. Run `fusebot --help` for the list of user commands. Install directory
+   is picked by `install_fusebot()` automatically - the juliaup `bin` directory on a laptop, or
+   `~/.local/bin` under `module load julia` on HPC:
 
    ```julia
    FUSE.install_fusebot()                                  # auto: juliaup bin, or ~/.local/bin on HPC

--- a/fusebot
+++ b/fusebot
@@ -40,10 +40,15 @@ if fuse_dir === nothing
     exit(1)
 end
 
-# Handle the --get-dir argument
+# Handle special arguments before delegating to make
 if !isempty(ARGS)
-    if ARGS[1] == "--get-dir"
+    arg = ARGS[1]
+    if arg == "--get-dir"
         println(fuse_dir)
+        exit(0)
+    elseif arg in ("--help", "-h")
+        cd(fuse_dir)
+        run(`make header help_info help_user`)
         exit(0)
     end
 end


### PR DESCRIPTION
Improve install timing estimates and fix fusebot --help

- Update docs/src/install.md with realistic first-install durations (15-30 min for Pkg.add) based on stress-test measurements
- Route fusebot --help and -h to make header/help_info/help_user instead of GNU make --help; mention fusebot --help in the install guide
- Silence DEV_PACKAGES_MAKEFILE find when FUSE has no sibling dev checkouts