### PR TITLE
(refac): Widen `IMAS.dd` to `IMAS.DD`

### DIFF
--- a/ext/WeaveExt.jl
+++ b/ext/WeaveExt.jl
@@ -6,7 +6,7 @@ import Weave
 using Logging
 
 """
-    weave_digest(::WeaveBackend, dd::IMAS.dd, title::AbstractString, description::AbstractString=""; 
+    weave_digest(::WeaveBackend, dd::IMAS.DD, title::AbstractString, description::AbstractString=""; 
                 ini::Union{Nothing,ParametersAllInits}=nothing,
                 act::Union{Nothing,ParametersAllActors}=nothing)
 
@@ -14,7 +14,7 @@ Generate PDF digest using Weave. This method is only available when Weave.jl is 
 
 # Arguments
 - `::WeaveBackend`: Dispatch type indicating Weave functionality is available
-- `dd::IMAS.dd`: IMAS data structure containing simulation results
+- `dd::IMAS.DD`: IMAS data structure containing simulation results
 - `title::AbstractString`: Title for the PDF report
 - `description::AbstractString=""`: Optional description for the report
 - `ini::Union{Nothing,ParametersAllInits}=nothing`: Optional initialization parameters
@@ -27,7 +27,7 @@ Generate PDF digest using Weave. This method is only available when Weave.jl is 
 This function processes the Weave template files (`digest.jmd` and `digest.tpl`) located
 in the same directory as this extension to generate a comprehensive PDF report.
 """
-function FUSE.weave_digest(::WeaveBackend, dd::IMAS.dd,
+function FUSE.weave_digest(::WeaveBackend, dd::IMAS.DD,
     title::AbstractString,
     description::AbstractString="";
     ini::Union{Nothing,ParametersAllInits}=nothing,

--- a/src/actors/balance_plant/balance_of_plant_actor.jl
+++ b/src/actors/balance_plant/balance_of_plant_actor.jl
@@ -5,7 +5,7 @@
 end
 
 mutable struct ActorBalanceOfPlant{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorBalanceOfPlant{P}}
     act::ParametersAllActors{P}
     thermal_plant_actor::ActorThermalPlant{D}
@@ -13,7 +13,7 @@ mutable struct ActorBalanceOfPlant{D,P} <: CompoundAbstractActor{D,P}
 end
 
 """
-    ActorBalanceOfPlant(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorBalanceOfPlant(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Orchestrates the complete balance of plant analysis by coordinating thermal plant efficiency calculations
 and electrical power needs assessment. Collects heat loads from various tokamak sources (blanket, 
@@ -40,14 +40,14 @@ and determines net electrical power output.
 
     Stores data in `dd.balance_of_plant`
 """
-function ActorBalanceOfPlant(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorBalanceOfPlant(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorBalanceOfPlant(dd, act.ActorBalanceOfPlant, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorBalanceOfPlant(dd::IMAS.dd, par::FUSEparameters__ActorBalanceOfPlant, act::ParametersAllActors; kw...)
+function ActorBalanceOfPlant(dd::IMAS.DD, par::FUSEparameters__ActorBalanceOfPlant, act::ParametersAllActors; kw...)
     logging_actor_init(ActorBalanceOfPlant)
     par = OverrideParameters(par; kw...)
 

--- a/src/actors/balance_plant/thermal_plant_actor.jl
+++ b/src/actors/balance_plant/thermal_plant_actor.jl
@@ -18,13 +18,13 @@ end
 end
 
 mutable struct ActorThermalPlant{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorThermalPlant{P}}
     act::ParametersAllActors{P}
     plant_actor::Union{ActorNoOperation{D,P}, AbstractActorThermalPlant{D,P}}
 end
 
-function ActorThermalPlant(dd::IMAS.dd{D}, par::FUSEparameters__ActorThermalPlant{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
+function ActorThermalPlant(dd::IMAS.DD{D}, par::FUSEparameters__ActorThermalPlant{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorThermalPlant)
     par = OverrideParameters(par; kw...)
     noop = ActorNoOperation(dd,act.ActorNoOperation)
@@ -32,7 +32,7 @@ function ActorThermalPlant(dd::IMAS.dd{D}, par::FUSEparameters__ActorThermalPlan
 end
 
 """
-    ActorThermalPlant(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorThermalPlant(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Calculates thermal plant efficiency and electrical power generation based on heat loads from the tokamak.
 Uses different models to convert thermal power from blanket, divertor, and wall heat loads into electrical power.
@@ -57,7 +57,7 @@ Acts as a dispatcher to different thermal plant models based on the `model` para
 
     Stores data in `dd.balance_of_plant`
 """
-function ActorThermalPlant(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorThermalPlant(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorThermalPlant(dd, act.ActorThermalPlant, act; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/balance_plant/thermal_system_models_ext.jl
+++ b/src/actors/balance_plant/thermal_system_models_ext.jl
@@ -16,7 +16,7 @@ import SimulationParameters: OverrideParameters
 MTK.@independent_variables t
 
 mutable struct ActorThermalSystemModels{D,P} <: AbstractActorThermalPlant{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorThermalSystemModels{P}}
     components::Vector{MTK.ODESystem}           # Vector of type ODESystem
     connections::Vector{MTK.Equation}           # Connection equations
@@ -35,7 +35,7 @@ mutable struct ActorThermalSystemModels{D,P} <: AbstractActorThermalPlant{D,P}
     u                                           # Load vector
 end
 
-function ActorThermalSystemModels(dd::IMAS.dd{D}, par::FUSEparameters__ActorThermalSystemModels{P}; kw...) where {D<:Real,P<:Real}
+function ActorThermalSystemModels(dd::IMAS.DD{D}, par::FUSEparameters__ActorThermalSystemModels{P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorThermalSystemModels)
     par = OverrideParameters(par; kw...)
     return ActorThermalSystemModels(
@@ -59,13 +59,13 @@ function ActorThermalSystemModels(dd::IMAS.dd{D}, par::FUSEparameters__ActorTher
 end
 
 """
-    ActorThermalSystemModels(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorThermalSystemModels(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 !!! note
 
     Stores data in `dd.balance_of_plant`
 """
-function ActorThermalSystemModels(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorThermalSystemModels(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorThermalSystemModels(dd, act.ActorThermalSystemModels; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/build/cx_actor.jl
+++ b/src/actors/build/cx_actor.jl
@@ -22,10 +22,10 @@ import GeoInterface
 end
 
 mutable struct ActorCXbuild{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorCXbuild{P}}
     act::ParametersAllActors{P}
-    function ActorCXbuild(dd::IMAS.dd{D}, par::FUSEparameters__ActorCXbuild{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
+    function ActorCXbuild(dd::IMAS.DD{D}, par::FUSEparameters__ActorCXbuild{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorCXbuild)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par, act)
@@ -33,7 +33,7 @@ mutable struct ActorCXbuild{D,P} <: CompoundAbstractActor{D,P}
 end
 
 """
-    ActorCXbuild(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorCXbuild(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Generates 2D cross-sectional geometry of the tokamak build by converting the 1D radial build 
 layers into full poloidal cross-sections. Creates detailed outlines for all build layers,
@@ -64,7 +64,7 @@ and engineering requirements.
 
     Manipulates data in `dd.build`
 """
-function ActorCXbuild(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorCXbuild(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorCXbuild(dd, act.ActorCXbuild, act; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/build/fluxswing_actor.jl
+++ b/src/actors/build/fluxswing_actor.jl
@@ -13,9 +13,9 @@ If dd.requirements.flattop_duration is not set, then operate_oh_at_j_crit is ass
 end
 
 mutable struct ActorFluxSwing{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorFluxSwing{P}}
-    function ActorFluxSwing(dd::IMAS.dd{D}, par::FUSEparameters__ActorFluxSwing{P}; kw...) where {D<:Real,P<:Real}
+    function ActorFluxSwing(dd::IMAS.DD{D}, par::FUSEparameters__ActorFluxSwing{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorFluxSwing)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par)
@@ -23,7 +23,7 @@ mutable struct ActorFluxSwing{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorFluxSwing(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorFluxSwing(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Analyzes OH coil flux swing capability and determines operating limits based on current density constraints
 and flattop duration requirements. Calculates flux consumption during different operational phases
@@ -53,7 +53,7 @@ and determines maximum achievable flattop duration or required current levels.
 
     Stores data in `dd.build.flux_swing`, `dd.build.tf`, and `dd.build.oh`
 """
-function ActorFluxSwing(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorFluxSwing(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorFluxSwing(dd, act.ActorFluxSwing; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/build/hfs_actor.jl
+++ b/src/actors/build/hfs_actor.jl
@@ -9,7 +9,7 @@
 end
 
 mutable struct ActorHFSsizing{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorHFSsizing{P}}
     act::ParametersAllActors{P}
     stresses_actor::ActorStresses{D,P}
@@ -17,7 +17,7 @@ mutable struct ActorHFSsizing{D,P} <: CompoundAbstractActor{D,P}
 end
 
 """
-    ActorHFSsizing(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorHFSsizing(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Optimizes the High Field Side (HFS) radial build dimensions to satisfy engineering constraints
 and performance requirements. Uses metaheuristic optimization to find the optimal thicknesses
@@ -47,7 +47,7 @@ stress limits, current density limits, magnetic field requirements, and flattop 
 
     Manipulates radial build information in `dd.build.layer`
 """
-function ActorHFSsizing(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorHFSsizing(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorHFSsizing(dd, act.ActorHFSsizing, act; kw...)
     if actor.par.do_plot
         p = plot(dd.build.layer)
@@ -61,7 +61,7 @@ function ActorHFSsizing(dd::IMAS.dd, act::ParametersAllActors; kw...)
     return actor
 end
 
-function ActorHFSsizing(dd::IMAS.dd, par::FUSEparameters__ActorHFSsizing, act::ParametersAllActors; kw...)
+function ActorHFSsizing(dd::IMAS.DD, par::FUSEparameters__ActorHFSsizing, act::ParametersAllActors; kw...)
     logging_actor_init(ActorHFSsizing)
     par = OverrideParameters(par; kw...)
     fluxswing_actor = ActorFluxSwing(dd, act.ActorFluxSwing)

--- a/src/actors/build/lfs_actor.jl
+++ b/src/actors/build/lfs_actor.jl
@@ -12,9 +12,9 @@
 end
 
 mutable struct ActorLFSsizing{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorLFSsizing{P}}
-    function ActorLFSsizing(dd::IMAS.dd{D}, par::FUSEparameters__ActorLFSsizing{P}; kw...) where {D<:Real,P<:Real}
+    function ActorLFSsizing(dd::IMAS.DD{D}, par::FUSEparameters__ActorLFSsizing{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorLFSsizing)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par)
@@ -22,7 +22,7 @@ mutable struct ActorLFSsizing{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorLFSsizing(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorLFSsizing(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Optimizes the low-field-side (LFS) radial build layout for toroidal field ripple and maintenance requirements.
 
@@ -50,7 +50,7 @@ the required TF coil repositioning while maintaining geometric consistency.
     Reads and modifies radial build information in `dd.build.layer`, using TF coil specifications 
     from `dd.build.tf` (ripple tolerance, coil count)
 """
-function ActorLFSsizing(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorLFSsizing(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorLFSsizing(dd, act.ActorLFSsizing; kw...)
     if actor.par.do_plot
         plot(dd.build.layer)

--- a/src/actors/build/stresses_actor.jl
+++ b/src/actors/build/stresses_actor.jl
@@ -7,9 +7,9 @@
 end
 
 mutable struct ActorStresses{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorStresses{P}}
-    function ActorStresses(dd::IMAS.dd{D}, par::FUSEparameters__ActorStresses{P}; kw...) where {D<:Real,P<:Real}
+    function ActorStresses(dd::IMAS.DD{D}, par::FUSEparameters__ActorStresses{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorStresses)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par)
@@ -17,7 +17,7 @@ mutable struct ActorStresses{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorStresses(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorStresses(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Calculates mechanical stresses in the tokamak center stack (TF coils, OH coils, and plug) using
 1D analytical solutions based on Leuer's solid mechanics equations. Analyzes both scenarios
@@ -45,7 +45,7 @@ with OH coils on and off to find the worst-case stress conditions for structural
 
     Stores data in `dd.solid_mechanics`
 """
-function ActorStresses(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorStresses(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorStresses(dd, act.ActorStresses; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/compound/dynamic_plasma_actor.jl
+++ b/src/actors/compound/dynamic_plasma_actor.jl
@@ -18,7 +18,7 @@
 end
 
 mutable struct ActorDynamicPlasma{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorDynamicPlasma{P}}
     act::ParametersAllActors{P}
     actor_tr::ActorCoreTransport{D,P}
@@ -32,7 +32,7 @@ mutable struct ActorDynamicPlasma{D,P} <: CompoundAbstractActor{D,P}
 end
 
 """
-    ActorDynamicPlasma(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorDynamicPlasma(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Evolves plasma profiles forward in time using coupled physics models.
 
@@ -78,14 +78,14 @@ Control options:
   - Individual physics component enable/disable switches
   - Configurable time step size and number of steps
 """
-function ActorDynamicPlasma(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorDynamicPlasma(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorDynamicPlasma(dd, act.ActorDynamicPlasma, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorDynamicPlasma(dd::IMAS.dd, par::FUSEparameters__ActorDynamicPlasma, act::ParametersAllActors; kw...)
+function ActorDynamicPlasma(dd::IMAS.DD, par::FUSEparameters__ActorDynamicPlasma, act::ParametersAllActors; kw...)
     logging_actor_init(ActorDynamicPlasma)
     par = OverrideParameters(par; kw...)
 
@@ -443,7 +443,7 @@ function progress_ActorDynamicPlasma(t0::Float64, t1::Float64, actor::AbstractAc
 end
 
 """
-    plot_plasma_overview(dd::IMAS.dd, time0::Float64)
+    plot_plasma_overview(dd::IMAS.DD, time0::Float64)
 
 Plot layout useful to get an overview of a (time dependent) plasma simulation.
 
@@ -462,7 +462,7 @@ Inclusinon in BEAMER presentation can then be done with:
 
     \\animategraphics[loop,autoplay,controls,poster=0,width=\\linewidth]{24}{frame_}{0000}{0120}
 """
-function plot_plasma_overview(dd::IMAS.dd, time0::Float64=dd.global_time;
+function plot_plasma_overview(dd::IMAS.DD, time0::Float64=dd.global_time;
     min_power::Float64=0.0,
     aggregate_radiation::Bool=true,
     aggregate_hcd::Bool=true,

--- a/src/actors/compound/stationary_plasma_actor.jl
+++ b/src/actors/compound/stationary_plasma_actor.jl
@@ -10,7 +10,7 @@
 end
 
 mutable struct ActorStationaryPlasma{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorStationaryPlasma{P}}
     act::ParametersAllActors{P}
     actor_tr::ActorCoreTransport{D,P}
@@ -22,7 +22,7 @@ mutable struct ActorStationaryPlasma{D,P} <: CompoundAbstractActor{D,P}
 end
 
 """
-    ActorStationaryPlasma(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorStationaryPlasma(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Iteratively solves for self-consistent stationary plasma equilibrium and transport.
 
@@ -61,14 +61,14 @@ Actors coordinated:
     Stores converged plasma state in `dd.equilibrium`, `dd.core_profiles`,
     `dd.core_sources`, `dd.core_transport`
 """
-function ActorStationaryPlasma(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorStationaryPlasma(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorStationaryPlasma(dd, act.ActorStationaryPlasma, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorStationaryPlasma(dd::IMAS.dd, par::FUSEparameters__ActorStationaryPlasma, act::ParametersAllActors; kw...)
+function ActorStationaryPlasma(dd::IMAS.DD, par::FUSEparameters__ActorStationaryPlasma, act::ParametersAllActors; kw...)
     logging_actor_init(ActorStationaryPlasma)
     par = OverrideParameters(par; kw...)
 

--- a/src/actors/compound/whole_facility_actor.jl
+++ b/src/actors/compound/whole_facility_actor.jl
@@ -7,7 +7,7 @@
 end
 
 mutable struct ActorWholeFacility{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorWholeFacility{P}}
     act::ParametersAllActors
     StationaryPlasma::Union{Nothing,ActorStationaryPlasma{D,P}}
@@ -29,7 +29,7 @@ mutable struct ActorWholeFacility{D,P} <: CompoundAbstractActor{D,P}
 end
 
 """
-    ActorWholeFacility(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorWholeFacility(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Integrates all physics, engineering, and economic models for complete tokamak facility design.
 
@@ -72,14 +72,14 @@ based on the final equilibrium solution.
 
     Stores comprehensive facility design data across all `dd` structures
 """
-function ActorWholeFacility(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorWholeFacility(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorWholeFacility(dd, act.ActorWholeFacility, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorWholeFacility(dd::IMAS.dd, par::FUSEparameters__ActorWholeFacility, act::ParametersAllActors; kw...)
+function ActorWholeFacility(dd::IMAS.DD, par::FUSEparameters__ActorWholeFacility, act::ParametersAllActors; kw...)
     logging_actor_init(ActorWholeFacility)
     par = OverrideParameters(par; kw...)
 

--- a/src/actors/control/ip_control.jl
+++ b/src/actors/control/ip_control.jl
@@ -7,19 +7,19 @@
 end
 
 mutable struct ActorControllerIp{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorControllerIp{P}}
     controller::Union{Nothing,IMAS.controllers__linear_controller{<:D},IMAS.controllers__nonlinear_controller{<:D}}
 end
 
-function ActorControllerIp(dd::IMAS.dd{D}, par::FUSEparameters__ActorControllerIp{P}; kw...) where {D<:Real,P<:Real}
+function ActorControllerIp(dd::IMAS.DD{D}, par::FUSEparameters__ActorControllerIp{P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorControllerIp)
     par = OverrideParameters(par; kw...)
     return ActorControllerIp{D,P}(dd, par, nothing)
 end
 
 """
-    ActorControllerIp(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorControllerIp(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Controls the loop voltage Vloop to obtain the target plasma cuurent Ip pulse_schedule
 
@@ -39,7 +39,7 @@ Algorithm names that have "PID" in their name will be considered linear and oper
             ...
         end
 """
-function ActorControllerIp(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorControllerIp(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorControllerIp(dd, act.ActorControllerIp; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/costing/aries_costing_actor.jl
+++ b/src/actors/costing/aries_costing_actor.jl
@@ -12,9 +12,9 @@
 end
 
 mutable struct ActorCostingARIES{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorCostingARIES{P}}
-    function ActorCostingARIES(dd::IMAS.dd{D}, par::FUSEparameters__ActorCostingARIES{P}; kw...) where {D<:Real,P<:Real}
+    function ActorCostingARIES(dd::IMAS.DD{D}, par::FUSEparameters__ActorCostingARIES{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorCostingARIES)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par)
@@ -22,7 +22,7 @@ mutable struct ActorCostingARIES{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorCostingARIES(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorCostingARIES(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Estimates fusion power plant costs using the ARIES (Advanced Reactor Innovation and Evaluation Study) methodology.
 
@@ -57,7 +57,7 @@ realistic cost estimates for commercial-scale fusion power plants.
 
     Results stored in `dd.costing` following ARIES cost account documentation (UCSD-CER-13-01)
 """
-function ActorCostingARIES(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorCostingARIES(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorCostingARIES(dd, act.ActorCostingARIES; kw...)
     step(actor)
     finalize(actor)
@@ -448,7 +448,7 @@ function cost_direct_capital_ARIES(::Val{:heat_transfer_loop_materials}, power_t
 end
 
 """
-    cost_direct_capital_ARIES(::Val{:balance_of_plant_equipment}, power_thermal::Real, power_electric_generated::Real, da::DollarAdjust, dd::IMAS.dd)
+    cost_direct_capital_ARIES(::Val{:balance_of_plant_equipment}, power_thermal::Real, power_electric_generated::Real, da::DollarAdjust, dd::IMAS.DD)
 
 NOTE: ARIES https://cer.ucsd.edu/_files/publications/UCSD-CER-13-01.pdf
 """

--- a/src/actors/costing/costing_actor.jl
+++ b/src/actors/costing/costing_actor.jl
@@ -25,14 +25,14 @@ using DataFrames
 end
 
 mutable struct ActorCosting{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorCosting{P}}
     act::ParametersAllActors{P}
     cst_actor::Union{ActorCostingSheffield{Measurement{Float64},P},ActorCostingARIES{Measurement{Float64},P}}
 end
 
 """
-    ActorCosting(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorCosting(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Estimates the comprehensive cost of building, operating, and decommissioning a fusion power plant.
 
@@ -54,14 +54,14 @@ Key economic outputs include levelized cost of electricity (LCOE) and lifetime p
 
     Results are stored in `dd.costing` with detailed breakdown by system and subsystem
 """
-function ActorCosting(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorCosting(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorCosting(dd, act.ActorCosting, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorCosting(dd::IMAS.dd, par::FUSEparameters__ActorCosting, act::ParametersAllActors; kw...)
+function ActorCosting(dd::IMAS.DD, par::FUSEparameters__ActorCosting, act::ParametersAllActors; kw...)
     logging_actor_init(ActorCosting)
     par = OverrideParameters(par; kw...)
 

--- a/src/actors/costing/sheffield_costing_actor.jl
+++ b/src/actors/costing/sheffield_costing_actor.jl
@@ -12,9 +12,9 @@
 end
 
 mutable struct ActorCostingSheffield{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorCostingSheffield{P}}
-    function ActorCostingSheffield(dd::IMAS.dd{D}, par::FUSEparameters__ActorCostingSheffield{P}; kw...) where {D<:Real,P<:Real}
+    function ActorCostingSheffield(dd::IMAS.DD{D}, par::FUSEparameters__ActorCostingSheffield{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorCostingSheffield)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par)
@@ -22,7 +22,7 @@ mutable struct ActorCostingSheffield{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorCostingSheffield(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorCostingSheffield(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Estimates fusion power plant costs using the Sheffield and Milora methodology from Fusion Science & Technology 70 (2016).
 
@@ -52,7 +52,7 @@ realistic assumptions about component lifetimes, availability, and economic para
 
     Results are stored in `dd.costing` with costs referenced to Sheffield & Milora (2016)
 """
-function ActorCostingSheffield(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorCostingSheffield(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorCostingSheffield(dd, act.ActorCostingSheffield; kw...)
     step(actor)
     finalize(actor)
@@ -347,7 +347,7 @@ function cost_direct_capital_Sheffield(::Val{:buildings}, bd::IMAS.build, da::Do
     return future_dollars(cost, da)
 end
 
-function cost_direct_capital_Sheffield(::Val{:blanket}, cap::Bool, dd::IMAS.dd, da::DollarAdjust{T}) where {T<:Real}
+function cost_direct_capital_Sheffield(::Val{:blanket}, cap::Bool, dd::IMAS.DD, da::DollarAdjust{T}) where {T<:Real}
     da.year_assessed = 2016
 
     cost = 0.0
@@ -367,7 +367,7 @@ function cost_direct_capital_Sheffield(::Val{:blanket}, cap::Bool, dd::IMAS.dd, 
     return future_dollars(cost, da)
 end
 
-function cost_direct_capital_Sheffield(::Val{:divertor}, cap::Bool, dd::IMAS.dd, da::DollarAdjust{T}) where {T<:Real}
+function cost_direct_capital_Sheffield(::Val{:divertor}, cap::Bool, dd::IMAS.DD, da::DollarAdjust{T}) where {T<:Real}
     da.year_assessed = 2016
 
     if cap == false
@@ -389,7 +389,7 @@ end
 function cost_fuel_Sheffield(
     ::Val{:blanket},
     cap::Bool,
-    dd::IMAS.dd,
+    dd::IMAS.DD,
     fixed_charge_rate::Real,
     availability::Real,
     plant_lifetime::Real,
@@ -428,7 +428,7 @@ end
 function cost_fuel_Sheffield(
     ::Val{:divertor},
     cap::Bool,
-    dd::IMAS.dd,
+    dd::IMAS.DD,
     fixed_charge_rate::Real,
     availability::Real,
     plant_lifetime::Real,

--- a/src/actors/current/current_actor.jl
+++ b/src/actors/current/current_actor.jl
@@ -9,14 +9,14 @@
 end
 
 mutable struct ActorCurrent{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorCurrent{P}}
     act::ParametersAllActors{P}
     jt_actor::Union{ActorSteadyStateCurrent{D,P},ActorQED{D,P},ActorReplay{D,P},ActorNoOperation{D,P}}
 end
 
 """
-    ActorCurrent(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorCurrent(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Provides a unified interface for current evolution using different current diffusion models.
 
@@ -38,14 +38,14 @@ Updates to the data structure:
 
     The fundamental quantitiy being solved is `j_total` in `dd.core_profiles.profiles_1d[]`
 """
-function ActorCurrent(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorCurrent(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorCurrent(dd, act.ActorCurrent, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorCurrent(dd::IMAS.dd, par::FUSEparameters__ActorCurrent, act::ParametersAllActors; kw...)
+function ActorCurrent(dd::IMAS.DD, par::FUSEparameters__ActorCurrent, act::ParametersAllActors; kw...)
     logging_actor_init(ActorCurrent)
     par = OverrideParameters(par; kw...)
 
@@ -126,7 +126,7 @@ function _finalize(actor::ActorCurrent)
     return actor
 end
 
-function _step(replay_actor::ActorReplay, actor::ActorCurrent, replay_dd::IMAS.dd)
+function _step(replay_actor::ActorReplay, actor::ActorCurrent, replay_dd::IMAS.DD)
     dd = actor.dd
 
     time0 = dd.global_time

--- a/src/actors/current/qed_actor.jl
+++ b/src/actors/current/qed_actor.jl
@@ -14,7 +14,7 @@ import QED
 end
 
 mutable struct ActorQED{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorQED{P}}
     act::ParametersAllActors{P}
     ip_controller::ActorControllerIp{D,P}
@@ -22,7 +22,7 @@ mutable struct ActorQED{D,P} <: CompoundAbstractActor{D,P}
 end
 
 """
-    ActorQED(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorQED(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Evolves plasma current using the QED (quasi-steady-state equilibrium diffusion) solver for realistic current diffusion.
 
@@ -53,14 +53,14 @@ current drive scenarios including bootstrap current, ECCD, NBCD, and other sourc
 
     The fundamental quantitiy being solved is `j_total` in `dd.core_profiles.profiles_1d[]`
 """
-function ActorQED(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorQED(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorQED(dd, act.ActorQED, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorQED(dd::IMAS.dd, par::FUSEparameters__ActorQED, act::ParametersAllActors; kw...)
+function ActorQED(dd::IMAS.DD, par::FUSEparameters__ActorQED, act::ParametersAllActors; kw...)
     logging_actor_init(ActorQED)
     par = OverrideParameters(par; kw...)
     ip_controller = ActorControllerIp(dd, act.ActorControllerIp)

--- a/src/actors/current/steadycurrent_actor.jl
+++ b/src/actors/current/steadycurrent_actor.jl
@@ -14,9 +14,9 @@
 end
 
 mutable struct ActorSteadyStateCurrent{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorSteadyStateCurrent{P}}
-    function ActorSteadyStateCurrent(dd::IMAS.dd{D}, par::FUSEparameters__ActorSteadyStateCurrent{P}; kw...) where {D<:Real,P<:Real}
+    function ActorSteadyStateCurrent(dd::IMAS.DD{D}, par::FUSEparameters__ActorSteadyStateCurrent{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorSteadyStateCurrent)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par)
@@ -24,7 +24,7 @@ mutable struct ActorSteadyStateCurrent{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorSteadyStateCurrent(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorSteadyStateCurrent(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Computes the steady-state ohmic current distribution using plasma conductivity and target plasma current.
 
@@ -43,7 +43,7 @@ Key features:
 
     The fundamental quantitiy being solved is `j_total` in `dd.core_profiles.profiles_1d[]`
 """
-function ActorSteadyStateCurrent(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorSteadyStateCurrent(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorSteadyStateCurrent(dd, act.ActorSteadyStateCurrent; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/diagnostics/fits_actor.jl
+++ b/src/actors/diagnostics/fits_actor.jl
@@ -12,10 +12,10 @@
 end
 
 mutable struct ActorFitProfiles{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorFitProfiles{P}}
     act::ParametersAllActors{P}
-    function ActorFitProfiles(dd::IMAS.dd{D}, par::FUSEparameters__ActorFitProfiles{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
+    function ActorFitProfiles(dd::IMAS.DD{D}, par::FUSEparameters__ActorFitProfiles{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorFitProfiles)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par, act)
@@ -23,7 +23,7 @@ mutable struct ActorFitProfiles{D,P} <: CompoundAbstractActor{D,P}
 end
 
 """
-    ActorFitProfiles(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorFitProfiles(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Fits experimental diagnostic data from Thomson scattering and charge exchange recombination spectroscopy to create smooth plasma profiles.
 
@@ -37,7 +37,7 @@ This actor performs several key operations:
 
 The resulting fitted profiles are stored in `dd.core_profiles.profiles_1d[]` and provide the foundation for physics modeling.
 """
-function ActorFitProfiles(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorFitProfiles(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorFitProfiles(dd, act.ActorFitProfiles, act; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/diagnostics/interferometer_actor.jl
+++ b/src/actors/diagnostics/interferometer_actor.jl
@@ -9,12 +9,12 @@
 end
 
 mutable struct ActorInterferometer{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorInterferometer{P}}
 end
 
 """
-    ActorInterferometer(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorInterferometer(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Calculates synthetic interferometer measurements from equilibrium and core profiles.
 
@@ -45,14 +45,14 @@ Parameters:
     The `dd.interferometer` must have channels defined with `line_of_sight` geometry.
     Results are stored in `dd.interferometer.channel[:].n_e_line_average`.
 """
-function ActorInterferometer(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorInterferometer(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorInterferometer(dd, act.ActorInterferometer; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorInterferometer(dd::IMAS.dd, par::FUSEparameters__ActorInterferometer; kw...)
+function ActorInterferometer(dd::IMAS.DD, par::FUSEparameters__ActorInterferometer; kw...)
     logging_actor_init(ActorInterferometer)
     par = OverrideParameters(par; kw...)
     return ActorInterferometer(dd, par)

--- a/src/actors/diagnostics/magnetics_actor.jl
+++ b/src/actors/diagnostics/magnetics_actor.jl
@@ -8,12 +8,12 @@
 end
 
 mutable struct ActorMagnetics{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorMagnetics{P}}
 end
 
 """
-    ActorMagnetics(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorMagnetics(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Calculates magnetic field diagnostics from equilibrium data.
 
@@ -36,14 +36,14 @@ Key outputs:
     Requires `dd.equilibrium` to be populated with equilibrium data.
     Results are stored in `dd.magnetics`.
 """
-function ActorMagnetics(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorMagnetics(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorMagnetics(dd, act.ActorMagnetics; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorMagnetics(dd::IMAS.dd, par::FUSEparameters__ActorMagnetics; kw...)
+function ActorMagnetics(dd::IMAS.DD, par::FUSEparameters__ActorMagnetics; kw...)
     logging_actor_init(ActorMagnetics)
     par = OverrideParameters(par; kw...)
     return ActorMagnetics(dd, par)

--- a/src/actors/divertors/divertors_actor.jl
+++ b/src/actors/divertors/divertors_actor.jl
@@ -16,13 +16,13 @@ Base.@kwdef mutable struct FUSEparameters__ActorDivertors{T<:Real} <: Parameters
 end
 
 mutable struct ActorDivertors{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorDivertors{P}}
     boundary_plasma_models::Vector{BoundaryPlasmaModels.SOLBoundaryModel}
 end
 
 """
-    ActorDivertors(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorDivertors(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Calculates divertor heat fluxes and power loads using reduced SOL boundary models.
 
@@ -45,14 +45,14 @@ Key parameters:
 
     Stores results in `dd.divertors`. Requires `dd.equilibrium` and `dd.core_sources`.
 """
-function ActorDivertors(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorDivertors(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorDivertors(dd, act.ActorDivertors; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorDivertors(dd::IMAS.dd, par::FUSEparameters__ActorDivertors; kw...)
+function ActorDivertors(dd::IMAS.DD, par::FUSEparameters__ActorDivertors; kw...)
     logging_actor_init(ActorDivertors)
     par = OverrideParameters(par; kw...)
     return ActorDivertors(dd, par, Vector{BoundaryPlasmaModels.SOLBoundaryModel}())

--- a/src/actors/equilibrium/chease_actor.jl
+++ b/src/actors/equilibrium/chease_actor.jl
@@ -11,14 +11,14 @@ import CHEASE
 end
 
 mutable struct ActorCHEASE{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorCHEASE{P}}
     act::ParametersAllActors{P}
     chease::Union{Nothing,CHEASE.Chease}
 end
 
 """
-    ActorCHEASE(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorCHEASE(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Runs the CHEASE fixed-boundary equilibrium solver to compute a 2D equilibrium from the plasma boundary,
 pressure profile, and current density profile. The solver takes the R-Z boundary coordinates from
@@ -43,14 +43,14 @@ to find PF coil currents that reproduce the same plasma shape and flux surfaces.
     
     Stores data in `dd.equilibrium`
 """
-function ActorCHEASE(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorCHEASE(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorCHEASE(dd, act.ActorCHEASE, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorCHEASE(dd::IMAS.dd{D}, par::FUSEparameters__ActorCHEASE{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
+function ActorCHEASE(dd::IMAS.DD{D}, par::FUSEparameters__ActorCHEASE{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorCHEASE)
     par = OverrideParameters(par; kw...)
     return ActorCHEASE(dd, par, act, nothing)

--- a/src/actors/equilibrium/eggo_actor.jl
+++ b/src/actors/equilibrium/eggo_actor.jl
@@ -18,7 +18,7 @@ end
 
 
 mutable struct ActorEGGO{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorEGGO{P}}
     act::ParametersAllActors{P}
     green::EGGO.GreenFunctionTables{Float64}
@@ -30,7 +30,7 @@ mutable struct ActorEGGO{D,P} <: CompoundAbstractActor{D,P}
 end
 
 """
-    ActorEGGO(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorEGGO(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Solves free-boundary tokamak MHD equilibria using the EGGO machine learning-based equilibrium reconstruction code.
 
@@ -66,14 +66,14 @@ while maintaining good accuracy for scenarios within the training data domain.
     `dd.pulse_schedule.position_control`, and wall geometry from `dd.wall`. 
     Updates `dd.equilibrium` with ML-predicted equilibrium solution.
 """
-function ActorEGGO(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorEGGO(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorEGGO(dd, act.ActorEGGO, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorEGGO(dd::IMAS.dd{D}, par::FUSEparameters__ActorEGGO{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
+function ActorEGGO(dd::IMAS.DD{D}, par::FUSEparameters__ActorEGGO{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorEGGO)
     par = OverrideParameters(par; kw...)
     model_name = :d3d_efit01efit02cake02

--- a/src/actors/equilibrium/equilibrium_actor.jl
+++ b/src/actors/equilibrium/equilibrium_actor.jl
@@ -14,14 +14,14 @@
 end
 
 mutable struct ActorEquilibrium{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorEquilibrium{P}}
     act::ParametersAllActors{P}
     eq_actor::Union{Nothing,ActorTEQUILA{D,P},ActorFRESCO{D,P},ActorEGGO{D,P},ActorCHEASE{D,P},ActorReplay{D,P},ActorNoOperation{D,P}}
 end
 
 """
-    ActorEquilibrium(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorEquilibrium(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Unified interface for tokamak MHD equilibrium solvers with automatic data preparation and postprocessing.
 
@@ -56,14 +56,14 @@ flux surface reconstruction → validation and visualization.
     Reads from `dd.core_profiles`, `dd.pulse_schedule.position_control`, and optionally `dd.wall`, 
     `dd.pf_active`. Updates `dd.equilibrium` with the solved MHD equilibrium.
 """
-function ActorEquilibrium(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorEquilibrium(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorEquilibrium(dd, act.ActorEquilibrium, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorEquilibrium(dd::IMAS.dd, par::FUSEparameters__ActorEquilibrium, act::ParametersAllActors; kw...)
+function ActorEquilibrium(dd::IMAS.DD, par::FUSEparameters__ActorEquilibrium, act::ParametersAllActors; kw...)
     logging_actor_init(ActorEquilibrium)
     par = OverrideParameters(par; kw...)
 
@@ -368,7 +368,7 @@ when iterating between equilibrium and other actors.
 
 See: IMAS/src/expressions/onetime.jl
 """
-function latest_equilibrium_grids!(dd::IMAS.dd)
+function latest_equilibrium_grids!(dd::IMAS.DD)
     # core_profiles
     old_rho_tor_norm = dd.core_profiles.profiles_1d[].grid.rho_tor_norm
     empty!(dd.core_profiles.profiles_1d[].grid)
@@ -418,7 +418,7 @@ function IMAS2Equilibrium(eqt::IMAS.equilibrium__time_slice)
     )
 end
 
-function _step(replay_actor::ActorReplay, actor::ActorEquilibrium, replay_dd::IMAS.dd)
+function _step(replay_actor::ActorReplay, actor::ActorEquilibrium, replay_dd::IMAS.DD)
     IMAS.copy_timeslice!(actor.dd.equilibrium, replay_dd.equilibrium, actor.dd.global_time)
     return replay_actor
 end

--- a/src/actors/equilibrium/fresco_actor.jl
+++ b/src/actors/equilibrium/fresco_actor.jl
@@ -18,7 +18,7 @@ import FRESCO
 end
 
 mutable struct ActorFRESCO{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorFRESCO{P}}
     act::ParametersAllActors{P}
     canvas::Union{Nothing,FRESCO.Canvas}
@@ -26,7 +26,7 @@ mutable struct ActorFRESCO{D,P} <: CompoundAbstractActor{D,P}
 end
 
 """
-    ActorFRESCO(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorFRESCO(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Solves the tokamak MHD equilibrium using the FRESCO free-boundary equilibrium solver.
 
@@ -54,14 +54,14 @@ The solver supports:
     Reads data from `dd.equilibrium`, `dd.core_profiles`, `dd.pf_active`, and `dd.wall`,
     and updates `dd.equilibrium` and `dd.pf_active` with the solved equilibrium
 """
-function ActorFRESCO(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorFRESCO(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorFRESCO(dd, act.ActorFRESCO, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorFRESCO(dd::IMAS.dd{D}, par::FUSEparameters__ActorFRESCO{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
+function ActorFRESCO(dd::IMAS.DD{D}, par::FUSEparameters__ActorFRESCO{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorFRESCO)
     par = OverrideParameters(par; kw...)
     return ActorFRESCO(dd, par, act, nothing, nothing)

--- a/src/actors/equilibrium/tequila_actor.jl
+++ b/src/actors/equilibrium/tequila_actor.jl
@@ -21,7 +21,7 @@ import TEQUILA
 end
 
 mutable struct ActorTEQUILA{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorTEQUILA{P}}
     act::ParametersAllActors{P}
     shot::Union{Nothing,TEQUILA.Shot}
@@ -31,7 +31,7 @@ mutable struct ActorTEQUILA{D,P} <: CompoundAbstractActor{D,P}
 end
 
 """
-    ActorTEQUILA(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorTEQUILA(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Solves tokamak MHD equilibria using the TEQUILA fixed-boundary equilibrium solver with MXH flux surface representation.
 
@@ -63,14 +63,14 @@ Grid options:
     `dd.pulse_schedule.position_control`, and PF coil setup from `dd.pf_active`. 
     Updates `dd.equilibrium` with solved equilibrium and coil currents.
 """
-function ActorTEQUILA(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorTEQUILA(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorTEQUILA(dd, act.ActorTEQUILA, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorTEQUILA(dd::IMAS.dd{D}, par::FUSEparameters__ActorTEQUILA{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
+function ActorTEQUILA(dd::IMAS.DD{D}, par::FUSEparameters__ActorTEQUILA{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorTEQUILA)
     par = OverrideParameters(par; kw...)
     return ActorTEQUILA(dd, par, act, nothing, D(0.0), D[], D[])

--- a/src/actors/hcd/ec/ec_simple_actor.jl
+++ b/src/actors/hcd/ec/ec_simple_actor.jl
@@ -12,9 +12,9 @@ end
 end
 
 mutable struct ActorSimpleEC{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorSimpleEC{P}}
-    function ActorSimpleEC(dd::IMAS.dd{D}, par::FUSEparameters__ActorSimpleEC{P}; kw...) where {D<:Real,P<:Real}
+    function ActorSimpleEC(dd::IMAS.DD{D}, par::FUSEparameters__ActorSimpleEC{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorSimpleEC)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par)
@@ -22,7 +22,7 @@ mutable struct ActorSimpleEC{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorSimpleEC(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorSimpleEC(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Calculates electron cyclotron (EC) heating and current drive using simplified Gaussian 
 deposition profiles. The actor performs vacuum ray tracing to determine beam paths and
@@ -41,7 +41,7 @@ Current drive efficiency is calculated using the formula from G. Tonon's work on
 
     Reads data in `dd.ec_launchers`, `dd.pulse_schedule` and stores data in `dd.waves` and `dd.core_sources`
 """
-function ActorSimpleEC(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorSimpleEC(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorSimpleEC(dd, act.ActorSimpleEC; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/hcd/ec/torbeam_actor.jl
+++ b/src/actors/hcd/ec/torbeam_actor.jl
@@ -8,19 +8,19 @@ using Plots
 end
 
 mutable struct ActorTORBEAM{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorTORBEAM{P}}
     torbeam_params::TORBEAM.TorbeamParams
 end
 
-function ActorTORBEAM(dd::IMAS.dd, par::FUSEparameters__ActorTORBEAM; kw...)
+function ActorTORBEAM(dd::IMAS.DD, par::FUSEparameters__ActorTORBEAM; kw...)
     logging_actor_init(ActorTORBEAM)
     par = OverrideParameters(par; kw...)
     return ActorTORBEAM(dd, par, TORBEAM.TorbeamParams())
 end
 
 """
-    ActorTORBEAM(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorTORBEAM(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Performs electron cyclotron (EC) heating and current drive calculations using the 
 TORBEAM ray-tracing code. TORBEAM provides detailed 3D beam propagation modeling
@@ -35,7 +35,7 @@ and realistic wave-plasma interactions.
     Requires TORBEAM external code. Reads data from `dd.ec_launchers` and 
     equilibrium data, stores results in appropriate IMAS data structures.
 """
-function ActorTORBEAM(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorTORBEAM(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorTORBEAM(dd, act.ActorTORBEAM; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/hcd/ic_simple_actor.jl
+++ b/src/actors/hcd/ic_simple_actor.jl
@@ -12,9 +12,9 @@ end
 end
 
 mutable struct ActorSimpleIC{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorSimpleIC{P}}
-    function ActorSimpleIC(dd::IMAS.dd{D}, par::FUSEparameters__ActorSimpleIC{P}; kw...) where {D<:Real,P<:Real}
+    function ActorSimpleIC(dd::IMAS.DD{D}, par::FUSEparameters__ActorSimpleIC{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorSimpleIC)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par)
@@ -22,7 +22,7 @@ mutable struct ActorSimpleIC{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorSimpleIC(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorSimpleIC(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Calculates ion cyclotron (IC) heating and current drive using simplified Gaussian 
 deposition profiles. The actor models IC wave absorption with configurable power
@@ -42,7 +42,7 @@ suitable for reactor-relevant conditions with significant beta_toroidal.
 
     Reads data in `dd.ic_antennas`, `dd.pulse_schedule` and stores data in `dd.waves` and `dd.core_sources`
 """
-function ActorSimpleIC(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorSimpleIC(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorSimpleIC(dd, act.ActorSimpleIC; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/hcd/lh_simple_actor.jl
+++ b/src/actors/hcd/lh_simple_actor.jl
@@ -12,9 +12,9 @@ end
 end
 
 mutable struct ActorSimpleLH{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorSimpleLH{P}}
-    function ActorSimpleLH(dd::IMAS.dd{D}, par::FUSEparameters__ActorSimpleLH{P}; kw...) where {D<:Real,P<:Real}
+    function ActorSimpleLH(dd::IMAS.DD{D}, par::FUSEparameters__ActorSimpleLH{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorSimpleLH)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par)
@@ -22,7 +22,7 @@ mutable struct ActorSimpleLH{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorSimpleLH(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorSimpleLH(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Calculates lower hybrid (LH) wave heating and current drive using a simplified Gaussian deposition model.
 
@@ -45,7 +45,7 @@ Where the parallel current is: j_∥ = η_CD / R₀ / n_e[10²⁰] × P_launched
 
     Reads data in `dd.lh_antennas`, `dd.pulse_schedule` and stores results in `dd.waves` and `dd.core_sources`
 """
-function ActorSimpleLH(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorSimpleLH(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorSimpleLH(dd, act.ActorSimpleLH; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/hcd/nbi/nb_simple_actor.jl
+++ b/src/actors/hcd/nbi/nb_simple_actor.jl
@@ -11,9 +11,9 @@ end
 end
 
 mutable struct ActorSimpleNB{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorSimpleNB{P}}
-    function ActorSimpleNB(dd::IMAS.dd{D}, par::FUSEparameters__ActorSimpleNB{P}; kw...) where {D<:Real,P<:Real}
+    function ActorSimpleNB(dd::IMAS.DD{D}, par::FUSEparameters__ActorSimpleNB{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorSimpleNB)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par)
@@ -21,7 +21,7 @@ mutable struct ActorSimpleNB{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorSimpleNB(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorSimpleNB(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Calculates neutral beam injection (NBI) heating and current drive using a simplified pencil beam model.
 
@@ -42,7 +42,7 @@ The model includes:
 
     Reads data in `dd.nbi`, `dd.pulse_schedule` and stores results in `dd.core_sources` and `dd.waves.coherent_wave`
 """
-function ActorSimpleNB(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorSimpleNB(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorSimpleNB(dd, act.ActorSimpleNB; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/hcd/nbi/rabbit_actor.jl
+++ b/src/actors/hcd/nbi/rabbit_actor.jl
@@ -10,19 +10,19 @@ using Plots
 end
 
 mutable struct ActorRABBIT{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorRABBIT{P}}
     outputs::Union{RABBIT.RABBIToutput,Vector{<:RABBIT.RABBIToutput}}
 end
 
-function ActorRABBIT(dd::IMAS.dd, par::FUSEparameters__ActorRABBIT; kw...)
+function ActorRABBIT(dd::IMAS.DD, par::FUSEparameters__ActorRABBIT; kw...)
     logging_actor_init(ActorRABBIT)
     par = OverrideParameters(par; kw...)
     return ActorRABBIT(dd, par, RABBIT.RABBIToutput[])
 end
 
 """
-    ActorRABBIT(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorRABBIT(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Calculates neutral beam injection (NBI) heating, current drive, and fast ion physics
 using the RABBIT Monte Carlo code. RABBIT provides detailed modeling of beam-plasma
@@ -43,7 +43,7 @@ physics and requires equilibrium data over the specified time window.
     Requires RABBIT external code. Reads data from `dd.nbi`, `dd.pulse_schedule` 
     and equilibrium data, stores results in `dd.core_sources`
 """
-function ActorRABBIT(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorRABBIT(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorRABBIT(dd, act.ActorRABBIT; kw...)
     step(actor)
     finalize(actor)
@@ -128,7 +128,7 @@ function _finalize(actor::ActorRABBIT)
     return actor
 end
 
-function FUSEtoRABBITinput(dd::IMAS.dd, Δt_history::Float64)
+function FUSEtoRABBITinput(dd::IMAS.DD, Δt_history::Float64)
     eV_to_keV = 1e-3
     cm3_to_m3 = 1e-6
 
@@ -206,7 +206,7 @@ function FUSEtoRABBITinput(dd::IMAS.dd, Δt_history::Float64)
         push!(all_inputs, inp)
     end
 
-    function gather_beams(dd::IMAS.dd)
+    function gather_beams(dd::IMAS.DD)
         nbeams = length(dd.nbi.unit)
         nv = 3
 
@@ -263,7 +263,7 @@ function FUSEtoRABBITinput(dd::IMAS.dd, Δt_history::Float64)
         return nbeams, nv, xyz_src, xyz_vec, beamwidthpoly, Einj, part_frac, abeam
     end
 
-    function get_pnbi(dd::IMAS.dd, selected_equilibrium_times::Vector{Float64})
+    function get_pnbi(dd::IMAS.DD, selected_equilibrium_times::Vector{Float64})
         pnbis = Vector{Float64}[]
         if length(selected_equilibrium_times) == 1
             for ps in dd.pulse_schedule.nbi.unit

--- a/src/actors/hcd/neutral_fueling_actor.jl
+++ b/src/actors/hcd/neutral_fueling_actor.jl
@@ -7,9 +7,9 @@
 end
 
 mutable struct ActorNeutralFueling{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorNeutralFueling{P}}
-    function ActorNeutralFueling(dd::IMAS.dd{D}, par::FUSEparameters__ActorNeutralFueling{P}; kw...) where {D<:Real,P<:Real}
+    function ActorNeutralFueling(dd::IMAS.DD{D}, par::FUSEparameters__ActorNeutralFueling{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorNeutralFueling)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par)
@@ -17,7 +17,7 @@ mutable struct ActorNeutralFueling{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorNeutralFueling(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorNeutralFueling(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Calculates neutral gas fueling particle source using the neucg model for wall recycling.
 
@@ -48,7 +48,7 @@ The solver uses:
     Reads data from `dd.equilibrium`, `dd.core_profiles` and stores results in 
     `dd.core_profiles.profiles_1d.neutral` and `dd.core_sources`
 """
-function ActorNeutralFueling(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorNeutralFueling(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorNeutralFueling(dd, act.ActorNeutralFueling; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/hcd/pam_actor.jl
+++ b/src/actors/hcd/pam_actor.jl
@@ -16,10 +16,10 @@ Base.@kwdef mutable struct FUSEparameters__ActorPAM{T<:Real} <: ParametersActor{
 end
 
 mutable struct ActorPAM{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorPAM{P}}
     outputs::Union{Nothing,PAM.Pellet}
-    function ActorPAM(dd::IMAS.dd{D}, par::FUSEparameters__ActorPAM{P}; kw...) where {D<:Real,P<:Real}
+    function ActorPAM(dd::IMAS.DD{D}, par::FUSEparameters__ActorPAM{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorPAM)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par, nothing)
@@ -28,7 +28,7 @@ end
 
 
 """
-    ActorPAM(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorPAM(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Estimates the Pellet particle direction, ablation rate, density source deposition
 
@@ -36,7 +36,7 @@ Estimates the Pellet particle direction, ablation rate, density source depositio
 
     Reads data in `pellet`, `pulse_schedule`, `equilibrium`, and stores data in `pellet`
 """
-function ActorPAM(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorPAM(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorPAM(dd, act.ActorPAM; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/hcd/pl_simple_actor.jl
+++ b/src/actors/hcd/pl_simple_actor.jl
@@ -11,9 +11,9 @@ end
 end
 
 mutable struct ActorSimplePL{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorSimplePL{P}}
-    function ActorSimplePL(dd::IMAS.dd{D}, par::FUSEparameters__ActorSimplePL{P}; kw...) where {D<:Real,P<:Real}
+    function ActorSimplePL(dd::IMAS.DD{D}, par::FUSEparameters__ActorSimplePL{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorSimplePL)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par)
@@ -21,7 +21,7 @@ mutable struct ActorSimplePL{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorSimplePL(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorSimplePL(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Calculates pellet fueling particle deposition using a simplified deposition model.
 
@@ -45,7 +45,7 @@ The deposition profile uses a beta function with parameters tuned for pellet-lik
 
     Reads data in `dd.pellets.launcher`, `dd.pulse_schedule` and stores results in `dd.core_sources`
 """
-function ActorSimplePL(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorSimplePL(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorSimplePL(dd, act.ActorSimplePL; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/hcd/sawteeth_source_actor.jl
+++ b/src/actors/hcd/sawteeth_source_actor.jl
@@ -9,9 +9,9 @@
 end
 
 mutable struct ActorSawteethSource{D,P} <: AbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorSawteethSource{P}}
-    function ActorSawteethSource(dd::IMAS.dd{D}, par::FUSEparameters__ActorSawteethSource{P}; kw...) where {D<:Real,P<:Real}
+    function ActorSawteethSource(dd::IMAS.DD{D}, par::FUSEparameters__ActorSawteethSource{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorSawteethSource)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par)
@@ -19,7 +19,7 @@ mutable struct ActorSawteethSource{D,P} <: AbstractActor{D,P}
 end
 
 """
-    ActorSawteethSource(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorSawteethSource(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Applies sawtooth reconnection effects to plasma sources when the safety factor q < 1.0.
 
@@ -39,14 +39,14 @@ during sawtooth crashes in tokamak plasmas.
 - `ignore_before_time`: Ignore sawteeth diagnostics at times <= this value. If `-Inf` (default),
     considers entire history. Only non-zero `rho_tor_norm_inversion` values are considered as sawteeth events.
 """
-function ActorSawteethSource(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorSawteethSource(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorSawteethSource(dd, act.ActorSawteethSource; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function _last_sawteeth_event(dd::IMAS.dd, ignore_before_time::Float64)
+function _last_sawteeth_event(dd::IMAS.DD, ignore_before_time::Float64)
     diag = dd.sawteeth.diagnostics
     if ismissing(dd.sawteeth, :time) || ismissing(diag, :rho_tor_norm_inversion) || isempty(diag.rho_tor_norm_inversion)
         return nothing, nothing

--- a/src/actors/hcd/sources_actor.jl
+++ b/src/actors/hcd/sources_actor.jl
@@ -11,7 +11,7 @@
 end
 
 mutable struct ActorSources{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorSources{P}}
     act::ParametersAllActors{P}
     ec_actor::Union{ActorSimpleEC{D,P},ActorTORBEAM{D,P},ActorReplay{D,P},ActorNoOperation{D,P}}
@@ -23,7 +23,7 @@ mutable struct ActorSources{D,P} <: CompoundAbstractActor{D,P}
 end
 
 """
-    ActorSources(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorSources(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Unified heating, current drive, and fueling system coordinator for all auxiliary power systems.
 
@@ -59,14 +59,14 @@ Execution order:
     Reads from hardware descriptions (`dd.ec_launchers`, `dd.ic_antennas`, etc.) and
     pulse schedules (`dd.pulse_schedule`), and coordinates updates to `dd.core_sources`, `dd.waves`, etc.
 """
-function ActorSources(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorSources(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorSources(dd, act.ActorSources, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorSources(dd::IMAS.dd, par::FUSEparameters__ActorSources, act::ParametersAllActors; kw...)
+function ActorSources(dd::IMAS.DD, par::FUSEparameters__ActorSources, act::ParametersAllActors; kw...)
     logging_actor_init(ActorSources)
     par = OverrideParameters(par; kw...)
 
@@ -202,44 +202,44 @@ end
 
 # ==========
 
-function _step(replay_actor::ActorReplay, actor::ActorSimpleEC, replay_dd::IMAS.dd)
+function _step(replay_actor::ActorReplay, actor::ActorSimpleEC, replay_dd::IMAS.DD)
     IMAS.copy_timeslice!(actor.dd.ec_launcher, replay_dd.ec_launcher, actor.dd.global_time)
     copy_source_timeslice!(actor.dd, replay_dd, :ec)
     return replay_actor
 end
 
-function _step(replay_actor::ActorReplay, actor::ActorSimpleIC, replay_dd::IMAS.dd)
+function _step(replay_actor::ActorReplay, actor::ActorSimpleIC, replay_dd::IMAS.DD)
     IMAS.copy_timeslice!(actor.dd.ic_antenna, replay_dd.ic_antenna, actor.dd.global_time)
     copy_source_timeslice!(actor.dd, replay_dd, :ic)
     return replay_actor
 end
 
-function _step(replay_actor::ActorReplay, actor::ActorSimpleLH, replay_dd::IMAS.dd)
+function _step(replay_actor::ActorReplay, actor::ActorSimpleLH, replay_dd::IMAS.DD)
     IMAS.copy_timeslice!(actor.dd.lh_antenna, replay_dd.lh_antenna, actor.dd.global_time)
     copy_source_timeslice!(actor.dd, replay_dd, :lh)
     return replay_actor
 end
 
-function _step(replay_actor::ActorReplay, actor::ActorSimpleNB, replay_dd::IMAS.dd)
+function _step(replay_actor::ActorReplay, actor::ActorSimpleNB, replay_dd::IMAS.DD)
     IMAS.copy_timeslice!(actor.dd.nbi, replay_dd.nbi, actor.dd.global_time)
     copy_source_timeslice!(actor.dd, replay_dd, :nbi)
     return replay_actor
 end
 
-function _step(replay_actor::ActorReplay, actor::ActorSimplePL, replay_dd::IMAS.dd)
+function _step(replay_actor::ActorReplay, actor::ActorSimplePL, replay_dd::IMAS.DD)
     IMAS.copy_timeslice!(actor.dd.pellet, replay_dd.pellet, actor.dd.global_time)
     copy_source_timeslice!(actor.dd, replay_dd, :pellet)
     return replay_actor
 end
 
-function _step(replay_actor::ActorReplay, actor::ActorNeutralFueling, replay_dd::IMAS.dd)
+function _step(replay_actor::ActorReplay, actor::ActorNeutralFueling, replay_dd::IMAS.DD)
     copy_source_timeslice!(actor.dd, replay_dd, :gas_puff)
     return replay_actor
 end
 
 # ==========
 
-function copy_source_timeslice!(dd::IMAS.dd, replay_dd::IMAS.dd, identifier::Symbol)
+function copy_source_timeslice!(dd::IMAS.DD, replay_dd::IMAS.DD, identifier::Symbol)
     for replay_source in findall(identifier, replay_dd.core_sources.source)
         source = resize!(dd.core_sources.source, :identifier, "identifier.name" => replay_source.name; wipe=false)
         IMAS.copy_timeslice!(source, replay_source, actor.dd.global_time)

--- a/src/actors/noop_actor.jl
+++ b/src/actors/noop_actor.jl
@@ -5,9 +5,9 @@
 end
 
 mutable struct ActorNoOperation{D,P} <: AbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorNoOperation{P}}
-    function ActorNoOperation(dd::IMAS.dd{D}, par::FUSEparameters__ActorNoOperation{P}; kw...) where {D<:Real,P<:Real}
+    function ActorNoOperation(dd::IMAS.DD{D}, par::FUSEparameters__ActorNoOperation{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorNoOperation)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par)
@@ -15,7 +15,7 @@ mutable struct ActorNoOperation{D,P} <: AbstractActor{D,P}
 end
 
 """
-    ActorNoOperation(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorNoOperation(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 A no-operation actor that performs no calculations or modifications.
 
@@ -30,7 +30,7 @@ in compound actors or actor workflows. It implements the standard actor interfac
 
 The actor simply returns itself from both `_step()` and `_finalize()` methods.
 """
-function ActorNoOperation(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorNoOperation(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorNoOperation(dd, act.ActorNoOperation; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/nuclear/blanket_actor.jl
+++ b/src/actors/nuclear/blanket_actor.jl
@@ -14,10 +14,10 @@ import NNeutronics
 end
 
 mutable struct ActorBlanket{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorBlanket{P}}
     act::ParametersAllActors{P}
-    function ActorBlanket(dd::IMAS.dd{D}, par::FUSEparameters__ActorBlanket{P}, act::ParametersAllActors; kw...) where {D<:Real,P<:Real}
+    function ActorBlanket(dd::IMAS.DD{D}, par::FUSEparameters__ActorBlanket{P}, act::ParametersAllActors; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorBlanket)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par, act)
@@ -25,7 +25,7 @@ mutable struct ActorBlanket{D,P} <: CompoundAbstractActor{D,P}
 end
 
 """
-    ActorBlanket(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorBlanket(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Calculates blanket performance including tritium breeding ratio (TBR), thermal power
 generation, and neutron leakage using 1D neutronics models. The actor optimizes
@@ -46,7 +46,7 @@ geometric and material configurations.
 
     Stores data in `dd.blanket`
 """
-function ActorBlanket(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorBlanket(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorBlanket(dd, act.ActorBlanket, act; kw...)
     step(actor)
     finalize(actor)
@@ -183,7 +183,7 @@ function _step(actor::ActorBlanket)
         blanket_model::NNeutronics.Blanket,
         modules_relative_thickness13::Vector{<:Real},
         Li6::Real,
-        dd::IMAS.dd,
+        dd::IMAS.DD,
         modules_effective_thickness::Vector{Matrix{Float64}},
         modules_wall_loading_power::Vector{<:Any},
         total_power_neutrons::Real,

--- a/src/actors/nuclear/neutronics_actor.jl
+++ b/src/actors/nuclear/neutronics_actor.jl
@@ -7,9 +7,9 @@
 end
 
 mutable struct ActorNeutronics{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorNeutronics{P}}
-    function ActorNeutronics(dd::IMAS.dd{D}, par::FUSEparameters__ActorNeutronics{P}; kw...) where {D<:Real,P<:Real}
+    function ActorNeutronics(dd::IMAS.DD{D}, par::FUSEparameters__ActorNeutronics{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorNeutronics)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par)
@@ -17,7 +17,7 @@ mutable struct ActorNeutronics{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorNeutronics(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorNeutronics(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Calculates neutron wall loading on the first wall using Monte Carlo particle tracing.
 The actor defines neutron sources from fusion reactions, traces their paths to the 
@@ -33,7 +33,7 @@ The calculation includes:
 
     Stores data in `dd.neutronics`
 """
-function ActorNeutronics(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorNeutronics(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorNeutronics(dd, act.ActorNeutronics; kw...)
     step(actor)
     finalize(actor)
@@ -85,7 +85,7 @@ function define_neutrons(actor::ActorNeutronics; N::Int=actor.par.N)
     return define_neutrons(actor.dd, N)
 end
 
-function define_neutrons(dd::IMAS.dd, N::Int)
+function define_neutrons(dd::IMAS.DD, N::Int)
     cp1d = dd.core_profiles.profiles_1d[]
     eqt = dd.equilibrium.time_slice[]
     source_1d = IMAS.D_T_to_He4_heating(cp1d) .* 4.0 .+ IMAS.D_D_to_He3_heating(cp1d) .* 3.0

--- a/src/actors/pedestal/EPED_actor.jl
+++ b/src/actors/pedestal/EPED_actor.jl
@@ -22,7 +22,7 @@ import EPEDNN
 end
 
 mutable struct ActorEPED{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorEPED{P}}
     epedmod::EPEDNN.EPEDmodel
     inputs::EPEDNN.InputEPED
@@ -31,7 +31,7 @@ mutable struct ActorEPED{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorEPED(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorEPED(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Predicts pedestal pressure and width using the EPED neural network model.
 
@@ -55,7 +55,7 @@ Outputs:
 - Pedestal width as fraction of normalized poloidal flux (wped)
 - Automatic fallback to edge pressure + 10% if EPED prediction is too low
 """
-function ActorEPED(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorEPED(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorEPED(dd, act.ActorEPED; kw...)
     step(actor)
     finalize(actor)
@@ -63,7 +63,7 @@ function ActorEPED(dd::IMAS.dd, act::ParametersAllActors; kw...)
 end
 
 
-function ActorEPED(dd::IMAS.dd, par::FUSEparameters__ActorEPED; kw...)
+function ActorEPED(dd::IMAS.DD, par::FUSEparameters__ActorEPED; kw...)
     logging_actor_init(ActorEPED)
     par = OverrideParameters(par; kw...)
     epedmod = EPEDNN.loadmodelonce("EPED1NNmodel.bson")
@@ -160,7 +160,7 @@ function __finalize(actor::Union{ActorEPED,ActorAnalyticPedestal})
 end
 
 function run_EPED(
-    dd::IMAS.dd;
+    dd::IMAS.DD;
     ne_from::Symbol,
     zeff_from::Symbol,
     βn_from::Symbol,
@@ -175,7 +175,7 @@ end
 
 """
     run_EPED!(
-        dd::IMAS.dd,
+        dd::IMAS.DD,
         eped_inputs::EPEDNN.InputEPED,
         epedmod::EPEDNN.EPED1NNmodel;
         ne_from::Symbol,
@@ -188,7 +188,7 @@ end
 Runs EPED from dd and outputs the EPED solution as the sol struct
 """
 function run_EPED!(
-    dd::IMAS.dd,
+    dd::IMAS.DD,
     eped_inputs::EPEDNN.InputEPED,
     epedmod::EPEDNN.EPED1NNmodel;
     ne_from::Symbol,

--- a/src/actors/pedestal/WPED_actor.jl
+++ b/src/actors/pedestal/WPED_actor.jl
@@ -25,13 +25,13 @@ mutable struct OptimizationWPED
 end
 
 mutable struct ActorWPED{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorWPED{P}}
     optimization_guesses::OptimizationWPED
 end
 
 """
-    ActorWPED(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorWPED(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Adjusts pedestal temperature profiles to match a target energy ratio between pedestal and core regions.
 
@@ -46,14 +46,14 @@ Key operations:
 - Preserves separatrix temperature boundary conditions
 - Updates temperature profiles through H-mode blending functions
 """
-function ActorWPED(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorWPED(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorWPED(dd, act.ActorWPED; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorWPED(dd::IMAS.dd, par::FUSEparameters__ActorWPED; kw...)
+function ActorWPED(dd::IMAS.DD, par::FUSEparameters__ActorWPED; kw...)
     logging_actor_init(ActorWPED)
     par = OverrideParameters(par; kw...)
     return ActorWPED(dd, par, OptimizationWPED(0.0, 0.0, 3e3))

--- a/src/actors/pedestal/analytic_pedestal_actor.jl
+++ b/src/actors/pedestal/analytic_pedestal_actor.jl
@@ -22,7 +22,7 @@ import EPEDNN
 end
 
 mutable struct ActorAnalyticPedestal{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorAnalyticPedestal{P}}
     inputs::EPEDNN.InputEPED
     wped::Union{Missing,Real}
@@ -30,7 +30,7 @@ mutable struct ActorAnalyticPedestal{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorAnalyticPedestal(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorAnalyticPedestal(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Calculates pedestal pressure and width using analytic scaling laws for spherical tokamaks.
 
@@ -48,14 +48,14 @@ Key outputs:
 - Pedestal width (wped) as half-width fraction of ψ_norm
 - Scaling coefficients can be customized via height_coefficient and width_coefficient parameters
 """
-function ActorAnalyticPedestal(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorAnalyticPedestal(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorAnalyticPedestal(dd, act.ActorAnalyticPedestal; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorAnalyticPedestal(dd::IMAS.dd, par::FUSEparameters__ActorAnalyticPedestal; kw...)
+function ActorAnalyticPedestal(dd::IMAS.DD, par::FUSEparameters__ActorAnalyticPedestal; kw...)
     logging_actor_init(ActorAnalyticPedestal)
     par = OverrideParameters(par; kw...)
     return ActorAnalyticPedestal(dd, par, EPEDNN.InputEPED(), missing, missing)
@@ -155,13 +155,13 @@ function pedestal_poloidal_βn_scaling_from_βn(βn::Float64)
 end
 
 """
-    pedestal_poloidal_βn(dd::IMAS.dd)
+    pedestal_poloidal_βn(dd::IMAS.DD)
 
 Scaling law to obtain the pedestal pressure for STs according to:
 Figure 1d from Parisi, J. F., et al. "HIPED: Machine Learning Framework for Spherical Tokamak Pedestal Prediction and Optimization." arXiv preprint arXiv:2504.19861 (2025).
 Expression is a refit of that plot
 """
-function pedestal_poloidal_βn(dd::IMAS.dd)
+function pedestal_poloidal_βn(dd::IMAS.DD)
     eqt = dd.equilibrium.time_slice[]
     ip = eqt.global_quantities.ip
 

--- a/src/actors/pedestal/pedestal_actor.jl
+++ b/src/actors/pedestal/pedestal_actor.jl
@@ -36,7 +36,7 @@
 end
 
 mutable struct ActorPedestal{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorPedestal{P}}
     act::ParametersAllActors{P}
     ped_actor::Union{ActorWPED{D,P},ActorEPED{D,P},ActorAnalyticPedestal{D,P},ActorReplay{D,P},ActorNoOperation{D,P}}
@@ -55,7 +55,7 @@ mutable struct ActorPedestal{D,P} <: CompoundAbstractActor{D,P}
 end
 
 """
-    ActorPedestal(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorPedestal(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Comprehensive pedestal modeling with support for multiple models and L-H mode transitions.
 
@@ -84,14 +84,14 @@ Mode transition physics:
 - Separate evolution times for temperature and density transitions
 - Configurable density and Zeff ratios between L-mode and H-mode
 """
-function ActorPedestal(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorPedestal(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorPedestal(dd, act.ActorPedestal, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorPedestal(dd::IMAS.dd{D}, par::FUSEparameters__ActorPedestal{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
+function ActorPedestal(dd::IMAS.DD{D}, par::FUSEparameters__ActorPedestal{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorPedestal)
     par = OverrideParameters(par; kw...)
     eped_actor =
@@ -354,13 +354,13 @@ function LH_dynamics(τ::Float64, t_LH::Float64, t_now::Float64)
 end
 
 """
-    pedestal_density_tanh(dd::IMAS.dd, par::OverrideParameters{P,FUSEparameters__ActorPedestal{P}}; density_factor::Float64, zeff_factor::Float64) where {P<:Real}
+    pedestal_density_tanh(dd::IMAS.DD, par::OverrideParameters{P,FUSEparameters__ActorPedestal{P}}; density_factor::Float64, zeff_factor::Float64) where {P<:Real}
 
 The edge density must be defined independently of the pedestal model
 
 The EPED and WPED models only operate on the temperature profiles
 """
-function pedestal_density_tanh(dd::IMAS.dd, par::OverrideParameters{P,FUSEparameters__ActorPedestal{P}};
+function pedestal_density_tanh(dd::IMAS.DD, par::OverrideParameters{P,FUSEparameters__ActorPedestal{P}};
                                density_factor::Float64, zeff_factor::Float64,
                                nn_prediction::Union{Nothing,NamedTuple}=nothing) where {P<:Real}
     cp1d = dd.core_profiles.profiles_1d[]
@@ -407,7 +407,7 @@ function pedestal_density_tanh(dd::IMAS.dd, par::OverrideParameters{P,FUSEparame
 end
 
 """
-    build_fpe_sequences_from_aux(nn::PedestalNN, dd::IMAS.dd; T::Integer=200) -> (Matrix{Float32}, Vector{Float32})
+    build_fpe_sequences_from_aux(nn::PedestalNN, dd::IMAS.DD; T::Integer=200) -> (Matrix{Float32}, Vector{Float32})
 
 Build a `(T, 32)` raw-physical FPE input matrix and a length-32 `signal_mask`
 from the live ZMQ signals stored in `dd._aux` (populated by `ActorZMQ.receive!`)
@@ -457,7 +457,7 @@ Returns:
 - `sequences::Matrix{Float32}` — `(T, 32)`, raw physical units, broadcast across time.
 - `signal_mask::Vector{Float32}` — length 32, 1.0 where a live value was found, 0.0 otherwise.
 """
-function build_fpe_sequences_from_aux(nn::PedestalNN, dd::IMAS.dd; T::Integer=200, use_dd::Bool=false)
+function build_fpe_sequences_from_aux(nn::PedestalNN, dd::IMAS.DD; T::Integer=200, use_dd::Bool=false)
     # Initialize every channel to its training mean so an un-mapped channel
     # z-scores to exactly zero (matching mean_normalized_history's convention).
     sequences = repeat(reshape(nn.signal_means, 1, 32), T, 1)
@@ -764,7 +764,7 @@ function ti_te_ratio(cp1d, T_ratio_pedestal, rho_nml, rho_ped)
     end
 end
 
-function _step(replay_actor::ActorReplay, actor::ActorPedestal, replay_dd::IMAS.dd)
+function _step(replay_actor::ActorReplay, actor::ActorPedestal, replay_dd::IMAS.DD)
     dd = actor.dd
     par = actor.par
 

--- a/src/actors/pf/pf_active_actor.jl
+++ b/src/actors/pf/pf_active_actor.jl
@@ -19,7 +19,7 @@ import VacuumFields: GS_IMAS_pf_active__coil
 end
 
 mutable struct ActorPFactive{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorPFactive{P}}
     eqt_out::IMAS.equilibrium__time_slice{D}
     iso_control_points::Vector{VacuumFields.IsoControlPoint{D}}
@@ -32,7 +32,7 @@ mutable struct ActorPFactive{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorPFactive(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorPFactive(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Optimizes poloidal field coil currents to match target equilibrium constraints.
 
@@ -60,13 +60,13 @@ Control points:
 
     Manipulates data in `dd.pf_active`
 """
-function ActorPFactive(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorPFactive(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorPFactive(dd, act.ActorPFactive; kw...)
     finalize(step(actor))
     return actor
 end
 
-function ActorPFactive(dd::IMAS.dd, par::FUSEparameters__ActorPFactive; kw...)
+function ActorPFactive(dd::IMAS.DD, par::FUSEparameters__ActorPFactive; kw...)
     logging_actor_init(ActorPFactive)
     par = OverrideParameters(par; kw...)
 

--- a/src/actors/pf/pf_design_actor.jl
+++ b/src/actors/pf/pf_design_actor.jl
@@ -11,14 +11,14 @@
 end
 
 mutable struct ActorPFdesign{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorPFdesign{P}}
     act::ParametersAllActors{P}
     actor_pf::ActorPFactive{D,P}
 end
 
 """
-    ActorPFdesign(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorPFdesign(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Optimizes poloidal field (PF) coil placement and sizing to achieve target equilibrium configurations.
 Uses optimization algorithms to find coil positions that minimize current requirements while satisfying
@@ -51,13 +51,13 @@ magnetic flux and force balance constraints for plasma control.
 
     Manupulates data in `dd.pf_active`
 """
-function ActorPFdesign(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorPFdesign(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorPFdesign(dd, act.ActorPFdesign, act; kw...)
     finalize(step(actor))
     return actor
 end
 
-function ActorPFdesign(dd::IMAS.dd, par::FUSEparameters__ActorPFdesign, act::ParametersAllActors; kw...)
+function ActorPFdesign(dd::IMAS.DD, par::FUSEparameters__ActorPFdesign, act::ParametersAllActors; kw...)
     logging_actor_init(ActorPFdesign)
     par = OverrideParameters(par; kw...)
     actor_pf = ActorPFactive(dd, act.ActorPFactive; par.update_equilibrium)

--- a/src/actors/pf/pf_passive_actor.jl
+++ b/src/actors/pf/pf_passive_actor.jl
@@ -10,9 +10,9 @@
 end
 
 mutable struct ActorPassiveStructures{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorPassiveStructures{P}}
-    function ActorPassiveStructures(dd::IMAS.dd{D}, par::FUSEparameters__ActorPassiveStructures{P}; kw...) where {D<:Real,P<:Real}
+    function ActorPassiveStructures(dd::IMAS.DD{D}, par::FUSEparameters__ActorPassiveStructures{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorPassiveStructures)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par)
@@ -20,7 +20,7 @@ mutable struct ActorPassiveStructures{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorPassiveStructures(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorPassiveStructures(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Generates passive conducting structure models for electromagnetic analysis by discretizing
 vacuum vessel layers into quadrilateral current loops. These passive elements are essential
@@ -53,7 +53,7 @@ conducting structures that interact with changing magnetic fields.
 
     Populates `dd.pf_passive` based on vacuum vessel layer(s)
 """
-function ActorPassiveStructures(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorPassiveStructures(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorPassiveStructures(dd, act.ActorPassiveStructures; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/replay_actor.jl
+++ b/src/actors/replay_actor.jl
@@ -6,13 +6,13 @@
 end
 
 mutable struct ActorReplay{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorReplay{P}}
-    replay_dd::IMAS.dd{D}
+    replay_dd::IMAS.DD{D}
     base_actor::AbstractActor{D,P}
 end
 
-function ActorReplay(dd::IMAS.dd{D}, par::FUSEparameters__ActorReplay{P}, base_actor::AbstractActor{D,P}; kw...) where {D<:Real,P<:Real}
+function ActorReplay(dd::IMAS.DD{D}, par::FUSEparameters__ActorReplay{P}, base_actor::AbstractActor{D,P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorReplay)
     par = OverrideParameters(par; kw...)
     if ismissing(par, :replay_dd)
@@ -26,14 +26,14 @@ function ActorReplay(dd::IMAS.dd{D}, par::FUSEparameters__ActorReplay{P}, base_a
     return ActorReplay{D,P}(dd, par, replay_dd, base_actor)
 end
 
-function ActorReplay(dd::IMAS.dd{D}, par::FUSEparameters__ActorReplay{P}; kw...) where {D<:Real,P<:Real}
+function ActorReplay(dd::IMAS.DD{D}, par::FUSEparameters__ActorReplay{P}; kw...) where {D<:Real,P<:Real}
     # This constructor is only used to conform with the standard SingleAbstractActor call signature
     # which is necessary to not break the generation of the FUSE documentation.
     ActorReplay(dd, par, ActorNoOperation(dd, ParametersAllActors{D,P}()))
 end
 
 """
-    ActorReplay(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorReplay(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Replays plasma profiles and behavior from experimental data or previous simulation results.
 
@@ -43,8 +43,8 @@ and applies it to the current simulation state.
 
 The specific replay behavior depends on the context where this actor is used, defined by
 specialized dispatch methods:
-- `_step(::ActorReplay, actor::Actor???, replay_dd::IMAS.dd)` - defines what data to replay
-- `_finalize(::ActorReplay, actor::Actor???, replay_dd::IMAS.dd)` - handles post-processing
+- `_step(::ActorReplay, actor::Actor???, replay_dd::IMAS.DD)` - defines what data to replay
+- `_finalize(::ActorReplay, actor::Actor???, replay_dd::IMAS.DD)` - handles post-processing
 
 Common use cases:
 - Replaying experimental temperature/density profiles in flux matching
@@ -55,7 +55,7 @@ Common use cases:
 The replay data source is specified via the `replay_dd` parameter, which can be
 an experimental shot, previous simulation, or synthetic data.
 """
-function ActorReplay(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorReplay(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorReplay(dd, act.ActorReplay; kw...)
     step(actor)
     finalize(actor)
@@ -70,10 +70,10 @@ function _finalize(actor::ActorReplay)
     return _finalize(actor, actor.base_actor, actor.replay_dd)
 end
 
-function _step(replay_actor::ActorReplay, actor::AbstractActor, replay_dd::IMAS.dd)
+function _step(replay_actor::ActorReplay, actor::AbstractActor, replay_dd::IMAS.DD)
     return replay_actor
 end
 
-function _finalize(replay_actor::ActorReplay, actor::AbstractActor, replay_dd::IMAS.dd)
+function _finalize(replay_actor::ActorReplay, actor::AbstractActor, replay_dd::IMAS.DD)
     return replay_actor
 end

--- a/src/actors/sol/sol_actor.jl
+++ b/src/actors/sol/sol_actor.jl
@@ -6,14 +6,14 @@
 end
 
 mutable struct ActorSOL{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorSOL{P}}
     act::ParametersAllActors{P}
     SOL_actor::Union{Nothing,ActorSOLBox{D,P},ActorReplay{D,P},ActorNoOperation{D,P}}
 end
 
 """
-    ActorSOL(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorSOL(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Provides a unified interface for different scrape-off layer (SOL) physics models.
 This compound actor selects and runs one of several available SOL models based on
@@ -30,14 +30,14 @@ regardless of the underlying model complexity.
 
     Delegates to the selected SOL model actor based on configuration
 """
-function ActorSOL(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorSOL(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorSOL(dd, act.ActorSOL, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorSOL(dd::IMAS.dd, par::FUSEparameters__ActorSOL, act::ParametersAllActors; kw...)
+function ActorSOL(dd::IMAS.DD, par::FUSEparameters__ActorSOL, act::ParametersAllActors; kw...)
     logging_actor_init(ActorSOL)
     par = OverrideParameters(par; kw...)
 

--- a/src/actors/sol/sol_box_actor.jl
+++ b/src/actors/sol/sol_box_actor.jl
@@ -83,19 +83,19 @@ function Base.show(io::IO, ::MIME"text/plain", solbox::SOLBox)
 end
 
 mutable struct ActorSOLBox{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorSOLBox{P}}
     solbox::SOLBox{D}
 end
 
-function ActorSOLBox(dd::IMAS.dd{D}, par::FUSEparameters__ActorSOLBox{P}; kw...) where {D<:Real,P<:Real}
+function ActorSOLBox(dd::IMAS.DD{D}, par::FUSEparameters__ActorSOLBox{P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorSOLBox)
     par = OverrideParameters(par; kw...)
     return ActorSOLBox(dd, par, SOLBox{D}())
 end
 
 """
-    ActorSOLBox(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorSOLBox(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Implements a 0D box model for scrape-off layer (SOL) physics to calculate upstream 
 plasma conditions at the separatrix from target boundary conditions. Based on the 
@@ -115,7 +115,7 @@ magnetic balance assessment.
     Reads data from `dd.equilibrium`, `dd.core_sources`, `dd.wall` and stores 
     results in `dd.edge_profiles`
 """
-function ActorSOLBox(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorSOLBox(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorSOLBox(dd, act.ActorSOLBox; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/stability/limit_models.jl
+++ b/src/actors/stability/limit_models.jl
@@ -3,7 +3,7 @@ const default_limit_models = Symbol[]
 
 ##### VERTICAL STABILITY #####
 
-function vertical_stability(dd::IMAS.dd, act::ParametersAllActors)
+function vertical_stability(dd::IMAS.DD, act::ParametersAllActors)
     ActorVerticalStability(dd, act)
     mhd = dd.mhd_linear.time_slice[]
 
@@ -38,7 +38,7 @@ push!(default_limit_models, :vertical_stability)
 
 ##### BETA LIMIT MODELS #####
 
-function beta_troyon_nn(dd::IMAS.dd, act::ParametersAllActors)
+function beta_troyon_nn(dd::IMAS.DD, act::ParametersAllActors)
     ActorTroyonBetaNN(dd, act)
     mhd = dd.mhd_linear.time_slice[]
     for n in 1:3
@@ -61,7 +61,7 @@ push!(supported_limit_models, :beta_troyon_nn)
 push!(default_limit_models, :beta_troyon_nn)
 
 """
-    beta_troyon_1984(dd::IMAS.dd, act::ParametersAllActors)
+    beta_troyon_1984(dd::IMAS.DD, act::ParametersAllActors)
 
 Limit in normalized beta using Troyon scaling
 
@@ -69,7 +69,7 @@ Model formulation: `βn < 3.5`
 
 Citation:  F Troyon et al 1984 Plasma Phys. Control. Fusion 26 209
 """
-function beta_troyon_1984(dd::IMAS.dd, act::ParametersAllActors)
+function beta_troyon_1984(dd::IMAS.DD, act::ParametersAllActors)
     model = resize!(dd.limits.model, "identifier.name" => "Troyon 1984")
     model.identifier.description = "βn < 3.5"
 
@@ -82,7 +82,7 @@ end
 push!(supported_limit_models, :beta_troyon_1984)
 
 """
-    beta_troyon_1985(dd::IMAS.dd, act::ParametersAllActors)
+    beta_troyon_1985(dd::IMAS.DD, act::ParametersAllActors)
 
 Limit in normalized beta using classical scaling using combined kink and ballooning stability
 
@@ -90,7 +90,7 @@ Model formulation: `βn < 2.8`
 
 Citation:
 """
-function beta_troyon_1985(dd::IMAS.dd, act::ParametersAllActors)
+function beta_troyon_1985(dd::IMAS.DD, act::ParametersAllActors)
     model = resize!(dd.limits.model, "identifier.name" => "Troyon 1985")
     model.identifier.description = "βn < 2.8"
 
@@ -103,7 +103,7 @@ end
 push!(supported_limit_models, :beta_troyon_1985)
 
 """
-    beta_tuda_1985(dd::IMAS.dd, act::ParametersAllActors)
+    beta_tuda_1985(dd::IMAS.DD, act::ParametersAllActors)
 
 Limit in beta_normal using classical scaling using only kink stability
 
@@ -111,7 +111,7 @@ Model formulation: `βn < 3.2`
 
 Citation:
 """
-function beta_tuda_1985(dd::IMAS.dd, act::ParametersAllActors)
+function beta_tuda_1985(dd::IMAS.DD, act::ParametersAllActors)
     model = resize!(dd.limits.model, "identifier.name" => "Tuda 1985")
     model.identifier.description = "βn < 3.2"
 
@@ -124,7 +124,7 @@ end
 push!(supported_limit_models, :beta_tuda_1985)
 
 """
-    beta_bernard1983(dd::IMAS.dd, act::ParametersAllActors)
+    beta_bernard1983(dd::IMAS.DD, act::ParametersAllActors)
 
 Limit in normalized beta using classical scaling using only ballooning stability
 
@@ -132,7 +132,7 @@ Model formulation: `βn < 2.8`
 
 Citation:
 """
-function beta_bernard_1983(dd::IMAS.dd, act::ParametersAllActors)
+function beta_bernard_1983(dd::IMAS.DD, act::ParametersAllActors)
     model = resize!(dd.limits.model, "identifier.name" => "Bernard 1983")
     model.identifier.description = "βn < 2.8"
 
@@ -145,7 +145,7 @@ end
 push!(supported_limit_models, :beta_bernard_1983)
 
 """
-    beta_betali_a(dd::IMAS.dd, act::ParametersAllActors)
+    beta_betali_a(dd::IMAS.DD, act::ParametersAllActors)
 
 Modern limit in normlaized beta normalized by plasma inductance
 
@@ -153,7 +153,7 @@ Model formulation: `βn / li < C_{beta}`
 
 Citation:
 """
-function beta_betali_a(dd::IMAS.dd, act::ParametersAllActors)
+function beta_betali_a(dd::IMAS.DD, act::ParametersAllActors)
     model = resize!(dd.limits.model, "identifier.name" => "BetaLi::Troyon")
     model.identifier.description = "βn / Li < 4.4"
 
@@ -171,7 +171,7 @@ push!(supported_limit_models, :beta_betali_a)
 ##### CURRENT LIMIT MODELS #####
 
 """
-    q95_gt_2(dd::IMAS.dd, act::ParametersAllActors)
+    q95_gt_2(dd::IMAS.DD, act::ParametersAllActors)
 
 Standard limit in edge current via the safety factor
 
@@ -179,7 +179,7 @@ Model formulation: `q95 > 2.0`
 
 Citation:
 """
-function q95_gt_2(dd::IMAS.dd, act::ParametersAllActors)
+function q95_gt_2(dd::IMAS.DD, act::ParametersAllActors)
     model = resize!(dd.limits.model, "identifier.name" => "q95 > 2.0")
     model.identifier.description = "q(rho=0.95) > 2.0"
 
@@ -193,13 +193,13 @@ push!(supported_limit_models, :q95_gt_2)
 push!(default_limit_models, :q95_gt_2)
 
 """
-    q80_gt_2(dd::IMAS.dd, act::ParametersAllActors)
+    q80_gt_2(dd::IMAS.DD, act::ParametersAllActors)
 
 Limit in edge current via the safety factor `q(rho=0.8) > 2.0`
 
 Model formulation: `q(rho=0.8) > 2.0`
 """
-function q80_gt_2(dd::IMAS.dd, act::ParametersAllActors)
+function q80_gt_2(dd::IMAS.DD, act::ParametersAllActors)
     model = resize!(dd.limits.model, "identifier.name" => "q80 > 2.0")
     model.identifier.description = "q(rho=0.8) > 2.0"
 
@@ -216,7 +216,7 @@ push!(supported_limit_models, :q80_gt_2)
 ##### DENSITY LIMIT MODELS #####
 
 """
-    gw_density(dd::IMAS.dd, act::ParametersAllActors)
+    gw_density(dd::IMAS.DD, act::ParametersAllActors)
 
 Standard limit in density using IMAS greenwald fraction
 
@@ -224,7 +224,7 @@ Model formulation: `f_{GW,IMAS} < 1.0`
 
 Citation:
 """
-function gw_density(dd::IMAS.dd, act::ParametersAllActors)
+function gw_density(dd::IMAS.DD, act::ParametersAllActors)
     model = resize!(dd.limits.model, "identifier.name" => "greenwald_fraction < 1.0")
     model.identifier.description = "greenwald_fraction < 1.0"
 
@@ -241,7 +241,7 @@ push!(default_limit_models, :gw_density)
 
 ##### SHAPE LIMIT MODELS #####
 
-function κ_controllability(dd::IMAS.dd, act::ParametersAllActors)
+function κ_controllability(dd::IMAS.DD, act::ParametersAllActors)
     model = resize!(dd.limits.model, "identifier.name" => "κ < elongation_limit")
     model.identifier.description = "elongation < IMAS.elongation_limit"
 

--- a/src/actors/stability/limits_actor.jl
+++ b/src/actors/stability/limits_actor.jl
@@ -10,10 +10,10 @@
 end
 
 mutable struct ActorPlasmaLimits{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorPlasmaLimits{P}}
     act::ParametersAllActors{P}
-    function ActorPlasmaLimits(dd::IMAS.dd{D}, par::FUSEparameters__ActorPlasmaLimits{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
+    function ActorPlasmaLimits(dd::IMAS.DD{D}, par::FUSEparameters__ActorPlasmaLimits{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorPlasmaLimits)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par, act)
@@ -21,7 +21,7 @@ mutable struct ActorPlasmaLimits{D,P} <: CompoundAbstractActor{D,P}
 end
 
 """
-    ActorPlasmaLimits(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorPlasmaLimits(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Evaluates plasma operational limits by running all selected limit models and checking 
 for violations. The actor executes various stability and operational limit assessments
@@ -35,7 +35,7 @@ of each limit threshold reached.
 
     Reads data from various sources and stores results in `dd.limits`
 """
-function ActorPlasmaLimits(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorPlasmaLimits(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorPlasmaLimits(dd, act.ActorPlasmaLimits, act; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/stability/mars_actor.jl
+++ b/src/actors/stability/mars_actor.jl
@@ -235,14 +235,14 @@ end
 
 
 mutable struct ActorMars{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorMars{P}}
     chease_inputs::Union{Nothing,CHEASE.CHEASEnamelist}
     mars_inputs::Union{Nothing,MARSnamelist}
     mars_outputs::Union{Nothing,MarsOutputs}
 
     function ActorMars(
-        dd::IMAS.dd{D}, 
+        dd::IMAS.DD{D}, 
         par::FUSEparameters__ActorMars{P}; 
         chease_overrides = NamedTuple(),
         mars_overrides = MarsOverrides(),
@@ -286,10 +286,10 @@ end
 
 
 """
-    ActorMars(dd::IMAS.dd, act::ParametersAllActors; kw...) 
+    ActorMars(dd::IMAS.DD, act::ParametersAllActors; kw...) 
 
 """
-function ActorMars(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorMars(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorMars(dd, act.ActorMars; kw...)
     step(actor)
     finalize(actor)
@@ -453,13 +453,13 @@ end
 
 
 """
-    chease_normalization(dd::IMAS.dd) -> (B0, R0)
+    chease_normalization(dd::IMAS.DD) -> (B0, R0)
 
 CHEASE/MARS normalization extracted from the equilibrium: `B0 = |B₀|` (vacuum toroidal
 field at `R0`) and `R0` (vacuum toroidal field reference major radius). Used for both clean
 and restart CHEASE runs so the equilibrium normalization is preserved across restarts.
 """
-function chease_normalization(dd::IMAS.dd)
+function chease_normalization(dd::IMAS.DD)
     time_slice = dd.equilibrium.time_slice[]
     B0 = abs(time_slice.global_quantities.vacuum_toroidal_field.b0)
     R0 = dd.equilibrium.vacuum_toroidal_field.r0
@@ -467,7 +467,7 @@ function chease_normalization(dd::IMAS.dd)
 end
 
 
-function run_CHEASE(dd::IMAS.dd, par, chease_namelist)
+function run_CHEASE(dd::IMAS.DD, par, chease_namelist)
 
     chease_exec = par.chease_exec
     @assert chease_namelist !== nothing "CHEASE namelist not initialized"
@@ -542,7 +542,7 @@ No_wall. Please specify a valid wall_type or set number_surfaces to 1.")
     return nothing
 end
 
-function run_MARS(dd::IMAS.dd, par, mars_namelist)
+function run_MARS(dd::IMAS.DD, par, mars_namelist)
 
     core_profiles = dd.core_profiles.profiles_1d[]
     
@@ -985,7 +985,7 @@ function parse_MARS_results(filename::AbstractString)
     return iter, growth, freq
 end
 
-function run_PARTICLE_TRACING(dd::IMAS.dd, par)
+function run_PARTICLE_TRACING(dd::IMAS.DD, par)
     # Placeholder function to run particle tracing simulations
     @info "Running particle tracing with tracer_type=$(par.tracer_type)."
 
@@ -999,7 +999,7 @@ end
         NWBPS: Number of wall boundary points
         NSTTP: Number of steps in pressure and current profiles
 """
-function write_EXPEQ_file(dd::IMAS.dd, par)
+function write_EXPEQ_file(dd::IMAS.DD, par)
 
     offset = par.offset  # offset for first wall (RW) in meters
     n_points = par.n_points  # number of points for first wall (RW)

--- a/src/actors/stability/troyon_actor.jl
+++ b/src/actors/stability/troyon_actor.jl
@@ -9,12 +9,12 @@ import TroyonBetaNN
 end
 
 mutable struct ActorTroyonBetaNN{D,P} <: AbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorTroyonBetaNN{P}}
     TD::TroyonBetaNN.Troyon_Data
 end
 
-function ActorTroyonBetaNN(dd::IMAS.dd{D}, par::FUSEparameters__ActorTroyonBetaNN{P}; kw...) where {D<:Real,P<:Real}
+function ActorTroyonBetaNN(dd::IMAS.DD{D}, par::FUSEparameters__ActorTroyonBetaNN{P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorTroyonBetaNN)
     par = OverrideParameters(par; kw...)
     TD = TroyonBetaNN.load_predefined_Troyon_NN_Models()
@@ -22,7 +22,7 @@ function ActorTroyonBetaNN(dd::IMAS.dd{D}, par::FUSEparameters__ActorTroyonBetaN
 end
 
 """
-    ActorTroyonBetaNN(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorTroyonBetaNN(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Evaluates ideal MHD stability limits using neural network models for low-n no-wall modes.
 The actor calculates the Troyon beta limit (βN) for different toroidal mode numbers using 
@@ -35,7 +35,7 @@ The calculation is disabled for negative triangularity plasmas. Results are stor
 
     Stores data in `dd.mhd_linear`
 """
-function ActorTroyonBetaNN(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorTroyonBetaNN(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorTroyonBetaNN(dd, act.ActorTroyonBetaNN; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/stability/vertical_actor.jl
+++ b/src/actors/stability/vertical_actor.jl
@@ -11,7 +11,7 @@ import VacuumFields
 end
 
 mutable struct ActorVerticalStability{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorVerticalStability{P}}
     act::ParametersAllActors{P}
     stability_margin::D
@@ -20,7 +20,7 @@ mutable struct ActorVerticalStability{D,P} <: CompoundAbstractActor{D,P}
 end
 
 """
-    ActorVerticalStability(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorVerticalStability(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Computes vertical stability metrics for tokamak plasmas using the equilibrium and coil configuration.
 
@@ -31,14 +31,14 @@ This actor calculates two key stability metrics:
 The analysis considers both active PF coils and passive conducting structures. Results are stored in
 `dd.mhd_linear.time_slice[].toroidal_mode` where stability margin > 0.15 and γτ < 10 indicate stability.
 """
-function ActorVerticalStability(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorVerticalStability(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorVerticalStability(dd, act.ActorVerticalStability, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorVerticalStability(dd::IMAS.dd{D}, par::FUSEparameters__ActorVerticalStability{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
+function ActorVerticalStability(dd::IMAS.DD{D}, par::FUSEparameters__ActorVerticalStability{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorVerticalStability)
     par = OverrideParameters(par; kw...)
     return ActorVerticalStability(dd, par, act, D(NaN), D(NaN), VacuumFields.MultiCoil[])

--- a/src/actors/transport/analytic_turbulence_actor.jl
+++ b/src/actors/transport/analytic_turbulence_actor.jl
@@ -16,13 +16,13 @@ import IMAS
 end
 
 mutable struct ActorAnalyticTurbulence{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorAnalyticTurbulence{P}}
     flux_solutions::Vector{GACODE.FluxSolution{D}}
 end
 
 """
-    ActorAnalyticTurbulence(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorAnalyticTurbulence(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Evaluates analytic turbulent transport models including GyroBohm and Bohm+gyro-Bohm (BgB) models.
 
@@ -37,14 +37,14 @@ The BgB model computes transport coefficients using local temperature and densit
 safety factor profiles, and magnetic field geometry. Results are normalized to gyro-Bohm
 and stored in `dd.core_transport` as anomalous transport fluxes.
 """
-function ActorAnalyticTurbulence(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorAnalyticTurbulence(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorAnalyticTurbulence(dd, act.ActorAnalyticTurbulence; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorAnalyticTurbulence(dd::IMAS.dd{D}, par::FUSEparameters__ActorAnalyticTurbulence{P}; kw...) where {D<:Real,P<:Real}
+function ActorAnalyticTurbulence(dd::IMAS.DD{D}, par::FUSEparameters__ActorAnalyticTurbulence{P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorAnalyticTurbulence)
     par = OverrideParameters(par; kw...)
     return ActorAnalyticTurbulence(dd, par, GACODE.FluxSolution{D}[])

--- a/src/actors/transport/core_transport_actor.jl
+++ b/src/actors/transport/core_transport_actor.jl
@@ -6,14 +6,14 @@
 end
 
 mutable struct ActorCoreTransport{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorCoreTransport{P}}
     act::ParametersAllActors{P}
     tr_actor::Union{ActorFluxMatcher{D,P},ActorFINN{D,P},ActorEPEDprofiles{D,P},ActorReplay{D,P},ActorNoOperation{D,P}}
 end
 
 """
-    ActorCoreTransport(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorCoreTransport(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Provides a unified interface to run core transport evolution models.
 
@@ -31,14 +31,14 @@ Transport model options:
 The selected model determines how the core plasma profiles (temperature, density, rotation)
 evolve in response to heating, particle sources, and transport processes.
 """
-function ActorCoreTransport(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorCoreTransport(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorCoreTransport(dd, act.ActorCoreTransport, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorCoreTransport(dd::IMAS.dd, par::FUSEparameters__ActorCoreTransport, act::ParametersAllActors; kw...)
+function ActorCoreTransport(dd::IMAS.DD, par::FUSEparameters__ActorCoreTransport, act::ParametersAllActors; kw...)
     logging_actor_init(ActorCoreTransport)
     par = OverrideParameters(par; kw...)
 
@@ -78,7 +78,7 @@ function _finalize(actor::ActorCoreTransport)
     return actor
 end
 
-function _step(replay_actor::ActorReplay, actor::ActorCoreTransport, replay_dd::IMAS.dd)
+function _step(replay_actor::ActorReplay, actor::ActorCoreTransport, replay_dd::IMAS.DD)
     dd = actor.dd
 
     time0 = dd.global_time

--- a/src/actors/transport/eped_profiles_actor.jl
+++ b/src/actors/transport/eped_profiles_actor.jl
@@ -9,10 +9,10 @@
 end
 
 mutable struct ActorEPEDprofiles{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorEPEDprofiles{P}}
     act::ParametersAllActors{P}
-    function ActorEPEDprofiles(dd::IMAS.dd{D}, par::FUSEparameters__ActorEPEDprofiles{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
+    function ActorEPEDprofiles(dd::IMAS.DD{D}, par::FUSEparameters__ActorEPEDprofiles{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
         logging_actor_init(ActorEPEDprofiles)
         par = OverrideParameters(par; kw...)
         return new{D,P}(dd, par, act)
@@ -20,7 +20,7 @@ mutable struct ActorEPEDprofiles{D,P} <: CompoundAbstractActor{D,P}
 end
 
 """
-    ActorEPEDprofiles(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorEPEDprofiles(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Constructs complete plasma profiles by blending EPED pedestal predictions with shaped core profiles.
 
@@ -55,7 +55,7 @@ to match both EPED pedestal predictions and prescribed core-pedestal transitions
 
     Does not modify on-axis values of plasma profiles, only shapes and pedestal conditions
 """
-function ActorEPEDprofiles(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorEPEDprofiles(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorEPEDprofiles(dd, act.ActorEPEDprofiles, act; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/transport/finn_actor.jl
+++ b/src/actors/transport/finn_actor.jl
@@ -38,14 +38,14 @@ import GACODE
 end
 
 mutable struct ActorFINN{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorFINN{P}}
     finn_results::NamedTuple
     actor_replay::ActorReplay{D,P}
 end
 
 """
-    ActorFINN(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorFINN(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Predicts flux-matched plasma profiles using the FINN (Flux-matcher Inversion Neural Network).
 
@@ -67,20 +67,20 @@ Unpredicted channels (retain experimental/initialized values):
 - Individual ion densities (Deuterium, Tritium, impurities)
 - Any profiles outside the `rho_transport` grid (edge/pedestal region)
 """
-function ActorFINN(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorFINN(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorFINN(dd, act.ActorFINN, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorFINN(dd::IMAS.dd{D}, par::FUSEparameters__ActorFINN{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
+function ActorFINN(dd::IMAS.DD{D}, par::FUSEparameters__ActorFINN{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorFINN)
     par = OverrideParameters(par; kw...)
     empty_results = (RLTS_1=Float64[], RLTS_2=Float64[], RLNS_1=Float64[], VEXB_SHEAR=Float64[], rho=Float64[])
     # Build a placeholder ActorReplay so the parent struct can be constructed,
     # then reassign with the parent-actor reference so dispatch reaches
-    # `_step(::ActorReplay, ::ActorFINN, ::IMAS.dd)` (mirrors ActorFluxMatcher).
+    # `_step(::ActorReplay, ::ActorFINN, ::IMAS.DD)` (mirrors ActorFluxMatcher).
     actor_replay = ActorReplay(dd, act.ActorReplay, ActorNoOperation(dd, act.ActorNoOperation))
     actor = ActorFINN(dd, par, empty_results, actor_replay)
     actor.actor_replay = ActorReplay(dd, act.ActorReplay, actor)
@@ -244,7 +244,7 @@ function _finalize(actor::ActorFINN)
 end
 
 """
-    _step(replay_actor::ActorReplay, actor::ActorFINN, replay_dd::IMAS.dd)
+    _step(replay_actor::ActorReplay, actor::ActorFINN, replay_dd::IMAS.DD)
 
 Replay rotation profile from `replay_dd` into the current `dd` when
 `actor.par.evolve_rotation == :replay`. Mirrors the rotation block of
@@ -254,7 +254,7 @@ and per-ion `rotation_frequency_tor` are copied — the latter is the measured
 quantity, and copying only sonic rotation would let it get recomputed from
 simulated pressure gradients via the IMAS expression.
 """
-function _step(replay_actor::ActorReplay, actor::ActorFINN, replay_dd::IMAS.dd)
+function _step(replay_actor::ActorReplay, actor::ActorFINN, replay_dd::IMAS.DD)
     par = actor.par
     par.evolve_rotation == :replay || return replay_actor
 

--- a/src/actors/transport/flux_calculator_actor.jl
+++ b/src/actors/transport/flux_calculator_actor.jl
@@ -8,7 +8,7 @@
 end
 
 mutable struct ActorFluxCalculator{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorFluxCalculator{P}}
     act::ParametersAllActors{P}
     actor_turb::Union{ActorTGLF{D,P},ActorQLGYRO{D,P},ActorAnalyticTurbulence{D,P},ActorNoOperation{D,P}}
@@ -16,7 +16,7 @@ mutable struct ActorFluxCalculator{D,P} <: CompoundAbstractActor{D,P}
 end
 
 """
-    ActorFluxCalculator(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorFluxCalculator(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Provides a unified interface to run turbulent and neoclassical transport model actors.
 
@@ -35,14 +35,14 @@ Neoclassical model options:
 - `:neoclassical`: Collisional transport (Chang-Hinton, NEO, Hirshman-Sigmar)
 - `:none`: No neoclassical transport
 """
-function ActorFluxCalculator(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorFluxCalculator(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorFluxCalculator(dd, act.ActorFluxCalculator, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorFluxCalculator(dd::IMAS.dd, par::FUSEparameters__ActorFluxCalculator, act::ParametersAllActors; kw...)
+function ActorFluxCalculator(dd::IMAS.DD, par::FUSEparameters__ActorFluxCalculator, act::ParametersAllActors; kw...)
     logging_actor_init(ActorFluxCalculator)
     par = OverrideParameters(par; kw...)
 

--- a/src/actors/transport/flux_matcher_actor.jl
+++ b/src/actors/transport/flux_matcher_actor.jl
@@ -90,7 +90,7 @@ import NonlinearSolve, FixedPointAcceleration
 end
 
 mutable struct ActorFluxMatcher{D,P} <: CompoundAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorFluxMatcher{P}}
     act::ParametersAllActors{P}
     actor_ct::ActorFluxCalculator{D,P}
@@ -102,7 +102,7 @@ mutable struct ActorFluxMatcher{D,P} <: CompoundAbstractActor{D,P}
 end
 
 """
-    ActorFluxMatcher(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorFluxMatcher(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Performs self-consistent transport evolution by matching turbulent/neoclassical transport fluxes to source fluxes.
 
@@ -130,14 +130,14 @@ time-dependent evolution with ∂/∂t terms, and the `z_max` parameter to cap n
 gradient (inverse scale lengths) during the iteration — either as a uniform scalar or
 as a spatially varying `NamedTuple(core, edge, rho_transition)`.
 """
-function ActorFluxMatcher(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorFluxMatcher(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorFluxMatcher(dd, act.ActorFluxMatcher, act; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorFluxMatcher(dd::IMAS.dd{D}, par::FUSEparameters__ActorFluxMatcher{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
+function ActorFluxMatcher(dd::IMAS.DD{D}, par::FUSEparameters__ActorFluxMatcher{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorFluxMatcher)
     par = OverrideParameters(par; kw...)
     actor_ct = ActorFluxCalculator(dd, act.ActorFluxCalculator, act; par.rho_transport)
@@ -724,13 +724,13 @@ function norm_transformation(norm_source::Vector{T}, norm_transp::Vector{T}) whe
 end
 
 """
-    flux_match_targets(dd::IMAS.dd, par::OverrideParameters{P,FUSEparameters__ActorFluxMatcher{P}}) where {P<:Real}
+    flux_match_targets(dd::IMAS.DD, par::OverrideParameters{P,FUSEparameters__ActorFluxMatcher{P}}) where {P<:Real}
 
 Evaluates the flux_matching targets for the :flux_match species and channels
 
 NOTE: flux matching is done in physical units
 """
-function flux_match_targets(dd::IMAS.dd{D}, par::OverrideParameters{P,FUSEparameters__ActorFluxMatcher{P}}) where {D<:Real,P<:Real}
+function flux_match_targets(dd::IMAS.DD{D}, par::OverrideParameters{P,FUSEparameters__ActorFluxMatcher{P}}) where {D<:Real,P<:Real}
     cp1d = dd.core_profiles.profiles_1d[]
 
     total_source = resize!(dd.core_sources.source, :total; wipe=false)
@@ -773,13 +773,13 @@ function flux_match_targets(dd::IMAS.dd{D}, par::OverrideParameters{P,FUSEparame
 end
 
 """
-    flux_match_fluxes(dd::IMAS.dd{D}, par::OverrideParameters{P,FUSEparameters__ActorFluxMatcher{P}}) where {D<:Real, P<:Real}
+    flux_match_fluxes(dd::IMAS.DD{D}, par::OverrideParameters{P,FUSEparameters__ActorFluxMatcher{P}}) where {D<:Real, P<:Real}
 
 Evaluates the flux_matching fluxes for the :flux_match species and channels
 
 NOTE: flux matching is done in physical units
 """
-function flux_match_fluxes(dd::IMAS.dd{D}, par::OverrideParameters{P,FUSEparameters__ActorFluxMatcher{P}}) where {D<:Real,P<:Real}
+function flux_match_fluxes(dd::IMAS.DD{D}, par::OverrideParameters{P,FUSEparameters__ActorFluxMatcher{P}}) where {D<:Real,P<:Real}
     cp1d = dd.core_profiles.profiles_1d[]
 
     total_flux = resize!(dd.core_transport.model, :combined; wipe=false)
@@ -894,7 +894,7 @@ function flux_match_simple(
     return (zero=z_scaled_history[argmin(map(norm, err_history))],)
 end
 
-function progress_ActorFluxMatcher(dd::IMAS.dd, error::Real)
+function progress_ActorFluxMatcher(dd::IMAS.DD, error::Real)
     cp1d = dd.core_profiles.profiles_1d[]
     out = Tuple{String,Float64}[]
     push!(out, ("         error", IMAS.force_float64(error)))
@@ -1356,11 +1356,11 @@ function calculate_w0_norm(Te_axis)
 end
 
 """
-    _step(replay_actor::ActorReplay, actor::ActorFluxMatcher, replay_dd::IMAS.dd)
+    _step(replay_actor::ActorReplay, actor::ActorFluxMatcher, replay_dd::IMAS.DD)
 
 Replay profiles from replay_dd to current dd for channels set to :replay
 """
-function _step(replay_actor::ActorReplay, actor::ActorFluxMatcher, replay_dd::IMAS.dd)
+function _step(replay_actor::ActorReplay, actor::ActorFluxMatcher, replay_dd::IMAS.DD)
     dd = actor.dd
     par = actor.par
 
@@ -1496,7 +1496,7 @@ function copy_ids_data!(dst::IMAS.IDS{T}, src::IMAS.IDS) where {T<:Real}
 end
 
 """
-    prepare_dd_for_ad(dd_float::IMAS.dd{D}, initial_cp1d::IMAS.core_profiles__profiles_1d, ::Type{T}) where {D<:Real, T<:Real}
+    prepare_dd_for_ad(dd_float::IMAS.DD{D}, initial_cp1d::IMAS.core_profiles__profiles_1d, ::Type{T}) where {D<:Real, T<:Real}
 
 Create a lightweight `dd{T}` populated with only the data needed for flux matching:
 - `equilibrium.time_slice[1]` — full geometry (promoted to T with zero partials)
@@ -1506,7 +1506,7 @@ Create a lightweight `dd{T}` populated with only the data needed for flux matchi
 This avoids copying the entire dd while providing all data needed by
 `intrinsic_sources!`, `InputTGLF`, `flux_gacode_to_imas`, `total_fluxes!`, and `total_sources!`.
 """
-function prepare_dd_for_ad(dd_float::IMAS.dd{D}, initial_cp1d::IMAS.core_profiles__profiles_1d, ::Type{T}) where {D<:Real,T<:Real}
+function prepare_dd_for_ad(dd_float::IMAS.DD{D}, initial_cp1d::IMAS.core_profiles__profiles_1d, ::Type{T}) where {D<:Real,T<:Real}
     dd_ad = IMAS.dd{T}()
     dd_ad.global_time = dd_float.global_time
 

--- a/src/actors/transport/mode_id_actor.jl
+++ b/src/actors/transport/mode_id_actor.jl
@@ -21,14 +21,14 @@ using LaTeXStrings
 end
 
 mutable struct ActorModeID{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorModeID{P}}
     labeled_dds::Vector{Pair{String,IMAS.dd{D}}}
     results::Vector{Pair{String,Vector{<:AbstractModeIdentification{D}}}}
 end
 
 """
-    ActorModeID(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorModeID(dd::IMAS.DD, act::ParametersAllActors; kw...)
     ActorModeID(labeled_dds::AbstractVector{<:Pair{String,<:IMAS.dd}}, act::ParametersAllActors; kw...)
 
 Identifies the dominant turbulence mode (ITG, TEM, KBM, ETG, MTM) driving heat flux
@@ -71,7 +71,7 @@ actor = ActorModeID(dd, act)
 actor = ActorModeID(["initial" => dd, "flux-matched" => dd_tjlf], act)
 ```
 """
-function ActorModeID(dd::IMAS.dd{D}, act::ParametersAllActors; kw...) where {D<:Real}
+function ActorModeID(dd::IMAS.DD{D}, act::ParametersAllActors; kw...) where {D<:Real}
     actor = ActorModeID(dd, act.ActorModeID; kw...)
     step(actor)
     finalize(actor)
@@ -89,7 +89,7 @@ function ActorModeID(labeled_dds::AbstractVector{<:Pair{String,<:IMAS.dd{D}}}, a
     return actor
 end
 
-function ActorModeID(dd::IMAS.dd{D}, par::FUSEparameters__ActorModeID; kw...) where {D<:Real}
+function ActorModeID(dd::IMAS.DD{D}, par::FUSEparameters__ActorModeID; kw...) where {D<:Real}
     logging_actor_init(ActorModeID)
     par = OverrideParameters(par; kw...)
     entries = Pair{String,IMAS.dd{D}}["" => dd]

--- a/src/actors/transport/neoclassical_actor.jl
+++ b/src/actors/transport/neoclassical_actor.jl
@@ -10,7 +10,7 @@ import GACODE
 end
 
 mutable struct ActorNeoclassical{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorNeoclassical{P}}
     input_neos::Vector{<:NeoclassicalTransport.InputNEO}
     flux_solutions::Vector{GACODE.FluxSolution{D}}
@@ -18,7 +18,7 @@ mutable struct ActorNeoclassical{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorNeoclassical(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorNeoclassical(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Evaluates neoclassical (collisional) transport fluxes using established theoretical models.
 
@@ -33,14 +33,14 @@ The models account for collisional effects, magnetic geometry, and trapped parti
 to calculate transport coefficients. Results are stored in `dd.core_transport.model[:neoclassical]`
 and include contributions to bootstrap current, thermal transport, and particle transport.
 """
-function ActorNeoclassical(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorNeoclassical(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorNeoclassical(dd, act.ActorNeoclassical; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorNeoclassical(dd::IMAS.dd{D}, par::FUSEparameters__ActorNeoclassical{P}; kw...) where {D<:Real,P<:Real}
+function ActorNeoclassical(dd::IMAS.DD{D}, par::FUSEparameters__ActorNeoclassical{P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorNeoclassical)
     par = OverrideParameters(par; kw...)
     return ActorNeoclassical(dd, par, NeoclassicalTransport.InputNEO[], GACODE.FluxSolution{D}[], missing)

--- a/src/actors/transport/qlgyro_actor.jl
+++ b/src/actors/transport/qlgyro_actor.jl
@@ -20,7 +20,7 @@ import GACODE
 end
 
 mutable struct ActorQLGYRO{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorQLGYRO{P}}
     input_qlgyros::Vector{InputQLGYRO}
     input_cgyros::Vector{InputCGYRO}
@@ -28,7 +28,7 @@ mutable struct ActorQLGYRO{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorQLGYRO(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorQLGYRO(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Evaluates turbulent transport using the QLGYRO quasi-linear gyrokinetic model.
 
@@ -44,14 +44,14 @@ vs electromagnetic), simulation time parameters, and saturation rules. The model
 comprehensive electron/ion energy, particle, and momentum fluxes with gyrokinetic fidelity
 while being more computationally efficient than full nonlinear simulations.
 """
-function ActorQLGYRO(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorQLGYRO(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorQLGYRO(dd, act.ActorQLGYRO; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorQLGYRO(dd::IMAS.dd{D}, par::FUSEparameters__ActorQLGYRO{P}; kw...) where {D<:Real,P<:Real}
+function ActorQLGYRO(dd::IMAS.DD{D}, par::FUSEparameters__ActorQLGYRO{P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorQLGYRO)
     par = OverrideParameters(par; kw...)
     input_QLGYROs = Vector{InputQLGYRO}(undef, length(par.rho_transport))

--- a/src/actors/transport/tglf_actor.jl
+++ b/src/actors/transport/tglf_actor.jl
@@ -26,14 +26,14 @@ import GACODE
 end
 
 mutable struct ActorTGLF{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorTGLF{P}}
     input_tglfs::Union{Vector{InputTGLF{D}},Vector{InputTJLF{D}}}
     flux_solutions::Vector{GACODE.FluxSolution{D}}
 end
 
 """
-    ActorTGLF(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorTGLF(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Evaluates turbulent transport fluxes using TGLF-based models including TGLF, TGLFNN, GKNN, and TJLF.
 
@@ -48,14 +48,14 @@ runs the transport calculation, and stores results as FluxSolution objects conta
 electron/ion energy fluxes, particle fluxes, and momentum flux. Results are normalized
 in gyro-Bohm units and written to `dd.core_transport` as anomalous transport.
 """
-function ActorTGLF(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorTGLF(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorTGLF(dd, act.ActorTGLF; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorTGLF(dd::IMAS.dd{D}, par::FUSEparameters__ActorTGLF; kw...) where {D<:Real}
+function ActorTGLF(dd::IMAS.DD{D}, par::FUSEparameters__ActorTGLF; kw...) where {D<:Real}
     logging_actor_init(ActorTGLF)
     par = OverrideParameters(par; kw...)
     # `:QLNN` reuses the InputTJLF path so the saturation rule (SAT_RULE,

--- a/src/actors/transport/tglfep_actor.jl
+++ b/src/actors/transport/tglfep_actor.jl
@@ -49,7 +49,7 @@ import TurbulentTransport
 end
 
 mutable struct ActorTJLFEP{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorTJLFEP{P}}
     rho_grid::Vector{D}            # full rho_tor_norm grid the critical gradients live on
     SFmin::Vector{D}               # critical EP-density scalefactor per scan radius (stability metric)
@@ -61,7 +61,7 @@ mutable struct ActorTJLFEP{D,P} <: SingleAbstractActor{D,P}
 end
 
 """
-    ActorTJLFEP(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorTJLFEP(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Energetic-particle (EP) transport actor combining TGLF-EP and ALPHA.
 
@@ -76,14 +76,14 @@ obtain the EP radial profiles: density `n_EP`, pressure `p_EP`, temperature
 population on the EP species and the EP flux to `dd.core_transport`. AE-stability
 metrics (`SFmin`, `width`, `kymark`) are kept on the actor struct.
 """
-function ActorTJLFEP(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorTJLFEP(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorTJLFEP(dd, act.ActorTJLFEP; kw...)
     step(actor)
     finalize(actor)
     return actor
 end
 
-function ActorTJLFEP(dd::IMAS.dd{D}, par::FUSEparameters__ActorTJLFEP; kw...) where {D<:Real}
+function ActorTJLFEP(dd::IMAS.DD{D}, par::FUSEparameters__ActorTJLFEP; kw...) where {D<:Real}
     logging_actor_init(ActorTJLFEP)
     par = OverrideParameters(par; kw...)
     return ActorTJLFEP(dd, par, D[], D[], D[], D[], D[], D[], nothing)

--- a/src/actors/wall_loading/corerad_hf_actor.jl
+++ b/src/actors/wall_loading/corerad_hf_actor.jl
@@ -13,19 +13,19 @@
 end
 
 mutable struct ActorCoreRadHeatFlux{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorCoreRadHeatFlux{P}}
     wall_heat_flux::Union{Nothing,IMAS.WallHeatFlux}
 end
 
-function ActorCoreRadHeatFlux(dd::IMAS.dd{D}, par::FUSEparameters__ActorCoreRadHeatFlux{P}; kw...) where {D<:Real,P<:Real}
+function ActorCoreRadHeatFlux(dd::IMAS.DD{D}, par::FUSEparameters__ActorCoreRadHeatFlux{P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorCoreRadHeatFlux)
     par = OverrideParameters(par; kw...)
     return ActorCoreRadHeatFlux(dd, par, nothing)
 end
 
 """
-    ActorCoreRadHeatFlux(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorCoreRadHeatFlux(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Computes wall heat flux from core plasma radiation using Monte Carlo photon transport.
 
@@ -60,7 +60,7 @@ wall loading and cooling requirements.
 This calculation provides essential data for first wall and blanket thermal design,
 complementing particle heat flux calculations for comprehensive wall loading analysis.
 """
-function ActorCoreRadHeatFlux(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorCoreRadHeatFlux(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorCoreRadHeatFlux(dd, act.ActorCoreRadHeatFlux; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/wall_loading/particle_hf_actor.jl
+++ b/src/actors/wall_loading/particle_hf_actor.jl
@@ -13,19 +13,19 @@
 end
 
 mutable struct ActorParticleHeatFlux{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorParticleHeatFlux{P}}
     wall_heat_flux::Union{Nothing,IMAS.WallHeatFlux}
 end
 
-function ActorParticleHeatFlux(dd::IMAS.dd{D}, par::FUSEparameters__ActorParticleHeatFlux{P}; kw...) where {D<:Real,P<:Real}
+function ActorParticleHeatFlux(dd::IMAS.DD{D}, par::FUSEparameters__ActorParticleHeatFlux{P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorParticleHeatFlux)
     par = OverrideParameters(par; kw...)
     return ActorParticleHeatFlux(dd, par, nothing)
 end
 
 """
-    ActorParticleHeatFlux(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorParticleHeatFlux(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Computes wall heat flux from charged particle transport across the scrape-off layer (SOL).
 
@@ -53,7 +53,7 @@ The calculation accounts for:
 The results provide essential input for material design, cooling system requirements,
 and component lifetime assessments in tokamak reactor studies.
 """
-function ActorParticleHeatFlux(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorParticleHeatFlux(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorParticleHeatFlux(dd, act.ActorParticleHeatFlux; kw...)
     step(actor)
     finalize(actor)

--- a/src/actors/zmq_actor.jl
+++ b/src/actors/zmq_actor.jl
@@ -47,7 +47,7 @@ end
 end
 
 mutable struct ActorZMQ{D,P} <: SingleAbstractActor{D,P}
-    dd::IMAS.dd{D}
+    dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorZMQ{P}}
     context::Union{Nothing,ZMQ.Context}
     socket::Union{Nothing,ZMQ.Socket}
@@ -62,14 +62,14 @@ mutable struct ActorZMQ{D,P} <: SingleAbstractActor{D,P}
     prev_co2::Vector{Float64}  # last valid CO2 density values (fallback if computation fails)
 end
 
-function ActorZMQ(dd::IMAS.dd{D}, par::FUSEparameters__ActorZMQ{P}; kw...) where {D<:Real,P<:Real}
+function ActorZMQ(dd::IMAS.DD{D}, par::FUSEparameters__ActorZMQ{P}; kw...) where {D<:Real,P<:Real}
     logging_actor_init(ActorZMQ)
     par = OverrideParameters(par; kw...)
     return ActorZMQ{D,P}(dd, par, nothing, nothing, false, false, NaN, NaN, NaN, NaN, NaN, Float64[])
 end
 
 """
-    ActorZMQ(dd::IMAS.dd, act::ParametersAllActors; kw...)
+    ActorZMQ(dd::IMAS.DD, act::ParametersAllActors; kw...)
 
 Coupling actor for exchanging data with external codes (e.g., GSLite/GSEvolve) via ZeroMQ.
 
@@ -89,7 +89,7 @@ run with a loud error (no negotiation). GSLite must reply with `Ack.ok = true` o
 accepted steps; `ok = false` (e.g. NaN input, solver divergence) likewise terminates
 the run, surfacing `Ack.error`.
 """
-function ActorZMQ(dd::IMAS.dd, act::ParametersAllActors; kw...)
+function ActorZMQ(dd::IMAS.DD, act::ParametersAllActors; kw...)
     actor = ActorZMQ(dd, act.ActorZMQ; kw...)
     if actor.par.enabled
         connect!(actor)

--- a/src/cases/D3D.jl
+++ b/src/cases/D3D.jl
@@ -292,11 +292,11 @@ function case_parameters(::Val{:D3D}, ods_file::AbstractString)
 end
 
 """
-    case_parameters(::Val{:D3D}, dd::IMAS.dd)
+    case_parameters(::Val{:D3D}, dd::IMAS.DD)
 
 DIII-D from dd file
 """
-function case_parameters(::Val{:D3D}, dd::IMAS.dd)
+function case_parameters(::Val{:D3D}, dd::IMAS.DD)
     ini, act = case_parameters(Val(:D3D_machine))
 
     ini.general.casename = "D3D from dd"

--- a/src/cases/MASTU.jl
+++ b/src/cases/MASTU.jl
@@ -137,11 +137,11 @@ function case_parameters(::Val{:MASTU}, scenario::Symbol)
 end
 
 """
-    case_parameters(:MASTU, ods::IMAS.dd)
+    case_parameters(:MASTU, ods::IMAS.DD)
 
 MAST-U from ODS/dd object with experimental data
 """
-function case_parameters(::Val{:MASTU}, dd::IMAS.dd)
+function case_parameters(::Val{:MASTU}, dd::IMAS.DD)
     # Get base MASTU machine parameters
     ini, act = case_parameters(Val(:MASTU); init_from=:ods)
 

--- a/src/cases/_toksys.jl
+++ b/src/cases/_toksys.jl
@@ -1,4 +1,4 @@
-function from_TokSys(dd::IMAS.dd, mat::Dict; what...)
+function from_TokSys(dd::IMAS.DD, mat::Dict; what...)
     # ================
     # parse TokSys mat
     # ================

--- a/src/ddinit/init.jl
+++ b/src/ddinit/init.jl
@@ -1,9 +1,9 @@
 """
-    init(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors; kw...)
+    init(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors; kw...)
 
 Like `init!(dd, ini, act)` function, but does not modify `ini` and `act`
 """
-function init(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors; kw...)
+function init(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors; kw...)
     ini = deepcopy(ini)
     act = deepcopy(act)
     return init!(dd, ini, act; kw...)
@@ -11,7 +11,7 @@ end
 
 """
     init!(
-        dd::IMAS.dd,
+        dd::IMAS.DD,
         ini::ParametersAllInits,
         act::ParametersAllActors;
         do_plot::Bool=false,
@@ -28,7 +28,7 @@ This function calls all other `FUSE.init...` functions in FUSE
 Modifies `ini` and `act` in place
 """
 function init!(
-    dd::IMAS.dd{T},
+    dd::IMAS.DD{T},
     ini::ParametersAllInits,
     act::ParametersAllActors;
     do_plot::Bool=false,

--- a/src/ddinit/init_build.jl
+++ b/src/ddinit/init_build.jl
@@ -5,11 +5,11 @@ import OrderedCollections
 #  init build  #
 #= ========== =#
 """
-    init_build!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+    init_build!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
 
 Initialize `dd.build` starting from `ini` and `act` parameters
 """
-function init_build!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+function init_build!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
     TimerOutputs.reset_timer!("init_build")
     TimerOutputs.@timeit timer "init_build" begin
         init_from = ini.general.init_from
@@ -212,7 +212,7 @@ function wall_radii(pr::Vector{Float64}, pz::Vector{Float64}, Z0::Real)
     return (r_hfs=r_hfs, r_lfs=r_lfs)
 end
 
-function assign_build_layers_materials(dd::IMAS.dd, ini::ParametersAllInits)
+function assign_build_layers_materials(dd::IMAS.DD, ini::ParametersAllInits)
     bd = dd.build
     for (k, layer) in enumerate(bd.layer)
         if !ismissing(layer, :material)
@@ -248,7 +248,7 @@ function assign_build_layers_materials(dd::IMAS.dd, ini::ParametersAllInits)
     end
 end
 
-function assign_technologies(dd::IMAS.dd, ini::ParametersAllInits)
+function assign_technologies(dd::IMAS.DD, ini::ParametersAllInits)
     # plug
     if ini.center_stack.plug
         IMAS.mechanical_technology(dd, :pl)

--- a/src/ddinit/init_core_profiles.jl
+++ b/src/ddinit/init_core_profiles.jl
@@ -1,9 +1,9 @@
 """
-    init_core_profiles!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+    init_core_profiles!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
 
 Initialize `dd.core_profiles` starting from `ini` and `act` parameters
 """
-function init_core_profiles!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+function init_core_profiles!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
     TimerOutputs.reset_timer!("init_core_profiles")
     TimerOutputs.@timeit timer "init_core_profiles" begin
         init_from = ini.general.init_from

--- a/src/ddinit/init_core_sources.jl
+++ b/src/ddinit/init_core_sources.jl
@@ -26,11 +26,11 @@ function unique_core_sources_names!(cs::IMAS.core_sources)
 end
 
 """
-    init_core_sources!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+    init_core_sources!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
 
 Initialize `dd.nbi`, `dd.ec_launchers`, `dd.ic_antennas`, `dd.lh_antennas` starting from `ini` and `act` parameters
 """
-function init_core_sources!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+function init_core_sources!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
     TimerOutputs.reset_timer!("init_core_sources")
     TimerOutputs.@timeit timer "init_core_sources" begin
         init_from = ini.general.init_from

--- a/src/ddinit/init_currents.jl
+++ b/src/ddinit/init_currents.jl
@@ -1,9 +1,9 @@
 """
-    init_currents!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+    init_currents!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
 
 Initialize `dd.core_profiles` and `dd.core_sources` ohmic and bootstrap currents and sources starting from `ini` and `act` parameters
 """
-function init_currents!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+function init_currents!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
     TimerOutputs.reset_timer!("init_currents")
     TimerOutputs.@timeit timer "init_currents" begin
         init_from = ini.general.init_from

--- a/src/ddinit/init_edge_profiles.jl
+++ b/src/ddinit/init_edge_profiles.jl
@@ -1,9 +1,9 @@
 """
-    init_edge_profiles!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+    init_edge_profiles!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
 
 Initialize `dd.edge_profiles` starting from `ini` and `act` parameters
 """
-function init_edge_profiles!(dd::IMAS.dd{T}, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd()) where {T<:Real}
+function init_edge_profiles!(dd::IMAS.DD{T}, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd()) where {T<:Real}
     TimerOutputs.reset_timer!("init_edge_profiles")
     TimerOutputs.@timeit timer "init_edge_profiles" begin
         init_from = ini.general.init_from

--- a/src/ddinit/init_equilibrium.jl
+++ b/src/ddinit/init_equilibrium.jl
@@ -2,11 +2,11 @@
 #  init equilibrium IDS  #
 #= ==================== =#
 """
-    init_equilibrium!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+    init_equilibrium!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
 
 Initialize `dd.equilibrium` starting from `ini` and `act` parameters
 """
-function init_equilibrium!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+function init_equilibrium!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
     TimerOutputs.reset_timer!("init_equilibrium")
     TimerOutputs.@timeit timer "init_equilibrium" begin
         init_from = ini.general.init_from

--- a/src/ddinit/init_hcd.jl
+++ b/src/ddinit/init_hcd.jl
@@ -1,9 +1,9 @@
 """
-    init_ec!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+    init_ec!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
 
 Initialize `dd.ec_launchers` starting from `ini` and `act` parameters
 """
-function init_ec!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+function init_ec!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
     eqt = dd.equilibrium.time_slice[]
     resize!(dd.ec_launchers.beam, length(ini.ec_launcher); wipe=false)
     @assert length(dd.ec_launchers.beam) == length(ini.ec_launcher) == length(dd.pulse_schedule.ec.beam)
@@ -23,11 +23,11 @@ function init_ec!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors
 end
 
 """
-    init_ic!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+    init_ic!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
 
 Initialize `dd.ic_antennas` starting from `ini` and `act` parameters
 """
-function init_ic!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+function init_ic!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
     resize!(dd.ic_antennas.antenna, length(ini.ic_antenna); wipe=false)
     @assert length(dd.ic_antennas.antenna) == length(ini.ic_antenna) == length(dd.pulse_schedule.ic.antenna)
     for (idx, (ica, ini_ica, ps_ica)) in enumerate(zip(dd.ic_antennas.antenna, ini.ic_antenna, dd.pulse_schedule.ic.antenna))
@@ -45,11 +45,11 @@ function init_ic!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors
 end
 
 """
-    init_lh!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+    init_lh!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
 
 Initialize `dd.lh_antennas` starting from `ini` and `act` parameters
 """
-function init_lh!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+function init_lh!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
     resize!(dd.lh_antennas.antenna, length(ini.lh_antenna); wipe=false)
     @assert length(dd.lh_antennas.antenna) == length(ini.lh_antenna) == length(dd.pulse_schedule.lh.antenna)
     for (idx, (lha, ini_lha, ps_lha)) in enumerate(zip(dd.lh_antennas.antenna, ini.lh_antenna, dd.pulse_schedule.lh.antenna))
@@ -67,11 +67,11 @@ function init_lh!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors
 end
 
 """
-    init_nb!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+    init_nb!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
 
 Initialize `dd.nbi` starting from `ini` and `act` parameters
 """
-function init_nb!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+function init_nb!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
     resize!(dd.nbi.unit, length(ini.nb_unit); wipe=false)
     @assert length(dd.nbi.unit) == length(ini.nb_unit) == length(dd.pulse_schedule.nbi.unit)
 
@@ -159,11 +159,11 @@ function pam_pellet_species(species::Symbol)
 end
 
 """
-    init_pl!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+    init_pl!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
 
 Initialize `dd.pellet_launcher` starting from `ini` and `act` parameters
 """
-function init_pl!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+function init_pl!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
     resize!(dd.pellets.launcher, length(ini.pellet_launcher); wipe=false)
     @assert length(dd.nbi.unit) == length(ini.nb_unit) == length(dd.pulse_schedule.nbi.unit)
 
@@ -223,11 +223,11 @@ function init_pl!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors
 end
 
 """
-    init_hcd!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+    init_hcd!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
 
 Initialize `dd.nbi`, `dd.ec_launchers`, `dd.ic_antennas`, `dd.lh_antennas` starting from `ini` and `act` parameters
 """
-function init_hcd!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+function init_hcd!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
     TimerOutputs.reset_timer!("init_hcd")
     TimerOutputs.@timeit timer "init_hcd" begin
         init_from = ini.general.init_from

--- a/src/ddinit/init_others.jl
+++ b/src/ddinit/init_others.jl
@@ -1,9 +1,9 @@
 """
-    init_missing_from_ods!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+    init_missing_from_ods!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
 
 Initialize missing IDSs from ODS, only if `ini.general.init_from == :ods`.
 """
-function init_missing_from_ods!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+function init_missing_from_ods!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
     TimerOutputs.reset_timer!("init_missing_from_ods")
     TimerOutputs.@timeit timer "init_missing_from_ods" begin
         init_from = ini.general.init_from

--- a/src/ddinit/init_pf_active.jl
+++ b/src/ddinit/init_pf_active.jl
@@ -2,11 +2,11 @@
 #  init pf_active IDS  #
 #= ================== =#
 """
-    init_pf_active!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+    init_pf_active!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
 
 Initialize `dd.pf_active` starting from `ini` and `act` parameters
 """
-function init_pf_active!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+function init_pf_active!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
     TimerOutputs.reset_timer!("init_pf_active")
     TimerOutputs.@timeit timer "init_pf_active" begin
         init_from = ini.general.init_from

--- a/src/ddinit/init_pulse_schedule.jl
+++ b/src/ddinit/init_pulse_schedule.jl
@@ -2,11 +2,11 @@
 #  init pulse_schedule IDS  #
 #= ======================= =#
 """
-    init_pulse_schedule!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+    init_pulse_schedule!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
 
 Initialize `dd.pulse_schedule` starting from `ini` and `act` parameters
 """
-function init_pulse_schedule!(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.dd=IMAS.dd())
+function init_pulse_schedule!(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors, dd1::IMAS.DD=IMAS.dd())
     TimerOutputs.reset_timer!("init_pulse_schedule")
     TimerOutputs.@timeit timer "init_pulse_schedule" begin
         init_from = ini.general.init_from

--- a/src/ddinit/write_init_expressions.jl
+++ b/src/ddinit/write_init_expressions.jl
@@ -37,11 +37,11 @@ function load_init_expressions()
 end
 
 """
-    restore_init_expressions!(dd::IMAS.dd; verbose::Bool)
+    restore_init_expressions!(dd::IMAS.DD; verbose::Bool)
 
 Turn into expressions Make fields that FUSE expects to be expressions after init
 """
-function restore_init_expressions!(dd::IMAS.dd; verbose::Bool)
+function restore_init_expressions!(dd::IMAS.DD; verbose::Bool)
     restored_expressions = Set()
     for ulocation in load_init_expressions()
         restored = IMAS.selective_delete!(dd, IMAS.i2p(ulocation))

--- a/src/experiments.jl
+++ b/src/experiments.jl
@@ -1,12 +1,12 @@
 """
-    LH_analysis(dd::IMAS.dd; scale_LH::Real=0.0, transition_start::Real=0.0, tau_n::Real=0.3, tau_t::Real=tau_n * 0.5, do_plot::Bool=true)
+    LH_analysis(dd::IMAS.DD; scale_LH::Real=0.0, transition_start::Real=0.0, tau_n::Real=0.3, tau_t::Real=tau_n * 0.5, do_plot::Bool=true)
 
 Analyze L-H mode transitions in tokamak plasma data and generate smooth time traces for electron density and effective charge (Zeff).
 
 This function processes experimental data to detect L-mode to H-mode transitions and creates smoothed time traces suitable for pulse schedule applications. It can either auto-detect transitions based on pedestal structure or power threshold scaling, or use a manually specified transition time.
 
 # Arguments
-- `dd::IMAS.dd`: IMAS data dictionary containing experimental tokamak data
+- `dd::IMAS.DD`: IMAS data dictionary containing experimental tokamak data
 - `scale_LH::Real=0.0`: L-H power threshold scaling factor. If 0.0, auto-detects based on pedestal structure. If >0.0, uses power threshold method
 - `transition_start::Real=0.0`: Manual transition start time [s]. If 0.0, uses auto-detected time. If <0.0, treats entire discharge as single mode
 - `tau_n::Real=0.3`: Duration [s] of the density transition from L-mode to H-mode
@@ -44,7 +44,7 @@ The function performs the following analysis steps:
 - Diagnostic plots show density, Zeff, temperature evolution and L-H power threshold analysis
 - The smoothing uses low-pass filtering based on the transition timescales
 """
-function LH_analysis(dd::IMAS.dd; scale_LH::Real=0.0, transition_start::Real=0.0, tau_n::Real=0.3, tau_t::Real=tau_n * 0.5, threshold::Float64=0.4, do_plot::Bool=true)
+function LH_analysis(dd::IMAS.DD; scale_LH::Real=0.0, transition_start::Real=0.0, tau_n::Real=0.3, tau_t::Real=tau_n * 0.5, threshold::Float64=0.4, do_plot::Bool=true)
     rho = dd.core_profiles.profiles_1d[1].grid.rho_tor_norm
     index09 = argmin_abs(rho, 0.9)
     time = dd.core_profiles.time

--- a/src/parameters/parameters_inits.jl
+++ b/src/parameters/parameters_inits.jl
@@ -515,7 +515,7 @@ function MXHboundary(ini::ParametersAllInits; kw...)::MXHboundary
     return MXHboundary(ini, dd; kw...)
 end
 
-function MXHboundary(ini::ParametersAllInits, dd::IMAS.dd; kw...)::MXHboundary
+function MXHboundary(ini::ParametersAllInits, dd::IMAS.DD; kw...)::MXHboundary
     boundary_from = ini.equilibrium.boundary_from
     if boundary_from == :ods
         eqt = dd.equilibrium.time_slice[ini.time.simulation_start]

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,9 +1,9 @@
 """
-    warmup(dd::IMAS.dd)
+    warmup(dd::IMAS.DD)
 
 Function used to precompile the majority of FUSE
 """
-function warmup(dd::IMAS.dd)
+function warmup(dd::IMAS.DD)
     empty!(dd)
 
     ini, act = case_parameters(:KDEMO)

--- a/src/studies/TGLF_database.jl
+++ b/src/studies/TGLF_database.jl
@@ -344,7 +344,7 @@ function run_case(filename::AbstractString, study::StudyTGLFdb, item)
     end
 end
 
-function workflow_actor(dd::IMAS.dd, act::ParametersAllActors)
+function workflow_actor(dd::IMAS.DD, act::ParametersAllActors)
     # Actors to run on the input dd
 
     actor_transport = ActorCoreTransport(dd, act)
@@ -361,7 +361,7 @@ function save_inputtglfs(actor_transport, output_dir, name, item)
     end
 end
 
-function create_data_frame_row(dd::IMAS.dd, exp_values::AbstractArray)
+function create_data_frame_row(dd::IMAS.DD, exp_values::AbstractArray)
     cp1d = dd.core_profiles.profiles_1d[]
     eqt = dd.equilibrium.time_slice[]
 
@@ -435,7 +435,7 @@ function FINN_dataframe()
         timef=Int[])
 end
 
-function create_finn_data_frame_row(dd::IMAS.dd, exp_values::AbstractArray)
+function create_finn_data_frame_row(dd::IMAS.DD, exp_values::AbstractArray)
     cp1d = dd.core_profiles.profiles_1d[]
     return (
       shot    = dd.dataset_description.data_entry.pulse,

--- a/src/studies/database_generator.jl
+++ b/src/studies/database_generator.jl
@@ -26,7 +26,7 @@ Define custom workflows in the `FUSE` module (or another module loaded on all wo
 `Distributed.pmap` can serialize them under Julia 1.12+. A `Main`-scoped `@everywhere function`
 is lost when workers are restarted by [`parallel_environment`](@ref).
 """
-function database_generator_workflow_default(dd::IMAS.dd, ini::ParametersAllInits, act::ParametersAllActors)
+function database_generator_workflow_default(dd::IMAS.DD, ini::ParametersAllInits, act::ParametersAllActors)
     init(dd, ini, act)
     return nothing
 end

--- a/src/studies/experiment_postdictive.jl
+++ b/src/studies/experiment_postdictive.jl
@@ -97,8 +97,8 @@ function run_postdictive_case(device::Symbol, shot::Int; kw_case_parameters::Dic
 end
 
 function run_postdictive_case!(
-    dd::IMAS.dd,
-    dd_exp::IMAS.dd,
+    dd::IMAS.DD,
+    dd_exp::IMAS.DD,
     device::Symbol,
     shot::Int;
     savedir::AbstractString=abspath("."),
@@ -255,7 +255,7 @@ function run_postdictive_case!(
     return nothing
 end
 
-function animated_plasma_overview(dd::IMAS.dd, dir::AbstractString, dd1::Union{IMAS.dd,Nothing}=nothing; aggregate_hcd::Bool=true, fps::Int=12)
+function animated_plasma_overview(dd::IMAS.DD, dir::AbstractString, dd1::Union{IMAS.dd,Nothing}=nothing; aggregate_hcd::Bool=true, fps::Int=12)
     fulldir = abspath(dir)
     @assert isdir(fulldir) "$fulldir directory does not exist"
     a = Plots.@animate for (k, time0) in enumerate(dd.equilibrium.time)

--- a/src/studies/experiment_predictive_rt.jl
+++ b/src/studies/experiment_predictive_rt.jl
@@ -101,8 +101,8 @@ function run_predictive_rt_case(device::Symbol, shot::Int; kw_case_parameters::D
 end
 
 function run_predictive_rt_case!(
-    dd::IMAS.dd,
-    dd_exp::IMAS.dd,
+    dd::IMAS.DD,
+    dd_exp::IMAS.DD,
     device::Symbol,
     shot::Int;
     savedir::AbstractString=abspath("."),
@@ -291,12 +291,12 @@ function run_predictive_rt_case!(
 end
 
 """
-    extract_traces(dd::IMAS.dd, dd_exp::IMAS.dd)
+    extract_traces(dd::IMAS.DD, dd_exp::IMAS.DD)
 
 Extract time traces of li and beta_pol from FUSE simulation and EFIT,
 both on FUSE's time grid (EFIT is interpolated to match).
 """
-function extract_traces(dd::IMAS.dd, dd_exp::IMAS.dd)
+function extract_traces(dd::IMAS.DD, dd_exp::IMAS.DD)
     times_sim = dd.equilibrium.time
     times_exp = dd_exp.equilibrium.time
 
@@ -322,14 +322,14 @@ function _median(x::AbstractVector)
 end
 
 """
-    compute_validation_residuals(dd::IMAS.dd, dd_exp::IMAS.dd)
+    compute_validation_residuals(dd::IMAS.DD, dd_exp::IMAS.DD)
 
 Compute validation residuals comparing time derivatives of FUSE vs EFIT.
 Residual = dq_FUSE/dt - dq_EFIT/dt at each consecutive FUSE time step.
 EFIT quantities are interpolated onto FUSE's time grid before differencing.
 Returns max_abs and median for: dli_dt, dbetap_dt. Rp is TODO.
 """
-function compute_validation_residuals(dd::IMAS.dd, dd_exp::IMAS.dd)
+function compute_validation_residuals(dd::IMAS.DD, dd_exp::IMAS.DD)
     times_sim = dd.equilibrium.time
     times_exp = dd_exp.equilibrium.time
 

--- a/src/test_cases.jl
+++ b/src/test_cases.jl
@@ -10,49 +10,49 @@ function ini_act_tests_customizations!(ini::ParametersAllInits, act::ParametersA
     return (ini=ini, act=act)
 end
 
-function test_case(::Val{:ITER_ods}, dd::IMAS.dd)
+function test_case(::Val{:ITER_ods}, dd::IMAS.DD)
     ini, act = case_parameters(:ITER; init_from=:ods)
     ini_act_tests_customizations!(ini, act)
     test_ini_act_save_load(dd, ini, act)
     return (dd=dd, ini=ini, act=act)
 end
 
-function test_case(::Val{:ITER_scalars}, dd::IMAS.dd)
+function test_case(::Val{:ITER_scalars}, dd::IMAS.DD)
     ini, act = case_parameters(:ITER; init_from=:scalars)
     ini_act_tests_customizations!(ini, act)
     test_ini_act_save_load(dd, ini, act)
     return (dd=dd, ini=ini, act=act)
 end
 
-function test_case(::Val{:D3D_Hmode}, dd::IMAS.dd)
+function test_case(::Val{:D3D_Hmode}, dd::IMAS.DD)
     ini, act = case_parameters(:D3D, :H_mode)
     ini_act_tests_customizations!(ini, act)
     test_ini_act_save_load(dd, ini, act)
     return (dd=dd, ini=ini, act=act)
 end
 
-function test_case(::Val{:D3D_Lmode}, dd::IMAS.dd)
+function test_case(::Val{:D3D_Lmode}, dd::IMAS.DD)
     ini, act = case_parameters(:D3D, :L_mode)
     ini_act_tests_customizations!(ini, act)
     test_ini_act_save_load(dd, ini, act)
     return (dd=dd, ini=ini, act=act)
 end
 
-function test_case(::Val{:D3D}, dd::IMAS.dd)
+function test_case(::Val{:D3D}, dd::IMAS.DD)
     ini, act = case_parameters(:D3D, :default)
     ini_act_tests_customizations!(ini, act)
     test_ini_act_save_load(dd, ini, act)
     return (dd=dd, ini=ini, act=act)
 end
 
-function test_case(::Val{:FPP}, dd::IMAS.dd)
+function test_case(::Val{:FPP}, dd::IMAS.DD)
     ini, act = case_parameters(:FPP)
     ini_act_tests_customizations!(ini, act)
     test_ini_act_save_load(dd, ini, act)
     return (dd=dd, ini=ini, act=act)
 end
 
-function test_case(::Val{:CAT}, dd::IMAS.dd)
+function test_case(::Val{:CAT}, dd::IMAS.DD)
     ini, act = case_parameters(:CAT)
     ini_act_tests_customizations!(ini, act)
     act.ActorStationaryPlasma.max_iterations = 1
@@ -64,14 +64,14 @@ function test_case(::Val{:CAT}, dd::IMAS.dd)
     return (dd=dd, ini=ini, act=act)
 end
 
-function test_case(::Val{:JET_HDB5}, dd::IMAS.dd)
+function test_case(::Val{:JET_HDB5}, dd::IMAS.DD)
     ini, act = case_parameters(:HDB5; tokamak=:JET, database_case=500)
     ini_act_tests_customizations!(ini, act)
     test_ini_act_save_load(dd, ini, act)
     return (dd=dd, ini=ini, act=act)
 end
 
-function test_case(::Val{:ARC}, dd::IMAS.dd)
+function test_case(::Val{:ARC}, dd::IMAS.DD)
     ini, act = case_parameters(:ARC)
     # There could be an engineering problem here but this shouldn't fail the tests
     act.ActorHFSsizing.error_on_performance = false
@@ -82,14 +82,14 @@ function test_case(::Val{:ARC}, dd::IMAS.dd)
     return (dd=dd, ini=ini, act=act)
 end
 
-function test_case(::Val{:SPARC}, dd::IMAS.dd)
+function test_case(::Val{:SPARC}, dd::IMAS.DD)
     ini, act = case_parameters(:SPARC; init_from=:ods)
     ini_act_tests_customizations!(ini, act)
     test_ini_act_save_load(dd, ini, act)
     return (dd=dd, ini=ini, act=act)
 end
 
-function test_case(::Val{:KDEMO}, dd::IMAS.dd)
+function test_case(::Val{:KDEMO}, dd::IMAS.DD)
     ini, act = case_parameters(:KDEMO)
     ini_act_tests_customizations!(ini, act)
     act.ActorFluxMatcher.max_iterations = 5
@@ -97,42 +97,42 @@ function test_case(::Val{:KDEMO}, dd::IMAS.dd)
     return (dd=dd, ini=ini, act=act)
 end
 
-function test_case(::Val{:KDEMO_compact}, dd::IMAS.dd)
+function test_case(::Val{:KDEMO_compact}, dd::IMAS.DD)
     ini, act = case_parameters(:KDEMO_compact)
     ini_act_tests_customizations!(ini, act)
     test_ini_act_save_load(dd, ini, act)
     return (dd=dd, ini=ini, act=act)
 end
 
-function test_case(::Val{:DTT}, dd::IMAS.dd)
+function test_case(::Val{:DTT}, dd::IMAS.DD)
     ini, act = case_parameters(:DTT)
     ini_act_tests_customizations!(ini, act)
     test_ini_act_save_load(dd, ini, act)
     return (dd=dd, ini=ini, act=act)
 end
 
-function test_case(::Val{:EXCITE}, dd::IMAS.dd)
+function test_case(::Val{:EXCITE}, dd::IMAS.DD)
     ini, act = case_parameters(:EXCITE)
     ini_act_tests_customizations!(ini, act)
     test_ini_act_save_load(dd, ini, act)
     return (dd=dd, ini=ini, act=act)
 end
 
-function test_case(::Val{:MANTA}, dd::IMAS.dd)
+function test_case(::Val{:MANTA}, dd::IMAS.DD)
     ini, act = case_parameters(:MANTA)
     ini_act_tests_customizations!(ini, act)
     test_ini_act_save_load(dd, ini, act)
     return (dd=dd, ini=ini, act=act)
 end
 
-function test_case(::Val{:UNIT}, dd::IMAS.dd)
+function test_case(::Val{:UNIT}, dd::IMAS.DD)
     ini, act = case_parameters(:UNIT)
     ini_act_tests_customizations!(ini, act)
     test_ini_act_save_load(dd, ini, act)
     return (dd=dd, ini=ini, act=act)
 end
 
-function test_case(::Val{:ITER_time}, dd::IMAS.dd; verbose::Bool=false)
+function test_case(::Val{:ITER_time}, dd::IMAS.DD; verbose::Bool=false)
     # ========
     # hardware setup from ODS
 
@@ -184,11 +184,11 @@ end
 
 function test_case(case::Symbol)
     dd = IMAS.dd()
-    return test_case(Val(case), dd::IMAS.dd)
+    return test_case(Val(case), dd::IMAS.DD)
 end
 
-function test_case(case::Symbol, dd::IMAS.dd)
-    dd, ini, act = test_case(Val(case), dd::IMAS.dd)
+function test_case(case::Symbol, dd::IMAS.DD)
+    dd, ini, act = test_case(Val(case), dd::IMAS.DD)
     @assert typeof(dd) <: IMAS.dd
     @assert typeof(ini) <: ParametersAllInits
     @assert typeof(act) <: ParametersAllActors

--- a/src/utils_begin.jl
+++ b/src/utils_begin.jl
@@ -91,11 +91,11 @@ end
 import FileIO, JpegTurbo
 
 """
-    dd_build_layers_to_ini(dd::IMAS.dd)
+    dd_build_layers_to_ini(dd::IMAS.DD)
 
 Utility function to convert layers in dd.build to layers in `ini.build.layers = layers = OrderedCollections.OrderedDict{Symbol,Float64}()`
 """
-function dd_build_layers_to_ini(dd::IMAS.dd)
+function dd_build_layers_to_ini(dd::IMAS.DD)
     for layer in dd.build.layer
         name = replace(layer.name, " " => "_")
         println("layers[:$name] = $(layer.thickness)")

--- a/src/utils_end.jl
+++ b/src/utils_end.jl
@@ -80,7 +80,7 @@ Base.@kwdef struct Checkpoint
     history::OrderedCollections.OrderedDict = OrderedCollections.OrderedDict()
 end
 
-function Base.setindex!(chk::Checkpoint, dd::IMAS.dd, key::Symbol)
+function Base.setindex!(chk::Checkpoint, dd::IMAS.DD, key::Symbol)
     return chk.history[key] = (dd=deepcopy(dd),)
 end
 
@@ -465,7 +465,7 @@ end
 
 """
     digest(
-        dd::IMAS.dd;
+        dd::IMAS.DD;
         terminal_width::Int=136,
         line_char::Char='─',
         section::Int=0)
@@ -478,7 +478,7 @@ NOTES:
   - this function is defined in FUSE and not IMAS because it uses Plots.jl and not BaseRecipies.jl
 """
 function digest(
-    dd::IMAS.dd;
+    dd::IMAS.DD;
     terminal_width::Int=136,
     line_char::Char='─',
     section::Int=0)
@@ -627,11 +627,11 @@ function digest(
 end
 
 """
-    weave_digest(::NoWeaveBackend, dd::IMAS.dd, title::AbstractString, description::AbstractString=""; kwargs...)
+    weave_digest(::NoWeaveBackend, dd::IMAS.DD, title::AbstractString, description::AbstractString=""; kwargs...)
 
 Fallback method when Weave.jl is not available. Provides helpful error message.
 """
-function weave_digest(::NoWeaveBackend, dd::IMAS.dd, title::AbstractString, description::AbstractString=""; 
+function weave_digest(::NoWeaveBackend, dd::IMAS.DD, title::AbstractString, description::AbstractString=""; 
                      ini::Union{Nothing,ParametersAllInits}=nothing,
                      act::Union{Nothing,ParametersAllActors}=nothing)
     error("""
@@ -647,7 +647,7 @@ function weave_digest(::NoWeaveBackend, dd::IMAS.dd, title::AbstractString, desc
 end
 
 """
-    digest(dd::IMAS.dd,
+    digest(dd::IMAS.DD,
         title::AbstractString,
         description::AbstractString="";
         ini::Union{Nothing,ParametersAllInits}=nothing,
@@ -663,7 +663,7 @@ import Pkg; Pkg.add("Weave")
 import Weave
 ```
 """
-function digest(dd::IMAS.dd,
+function digest(dd::IMAS.DD,
     title::AbstractString,
     description::AbstractString="";
     ini::Union{Nothing,ParametersAllInits}=nothing,


### PR DESCRIPTION
## Summary

Widen the concrete type signature of `IMAS.dd` in function arguments to the abstract type of `IMAS.DD`.

This is a harmless, preemptive refactoring in preparation for future use of different concrete subtypes of IMAS.DD (e.g., IFEdd, currently under development).