### PR TITLE
Add one-command install scripts for laptop and NERSC FUSE

### DIFF
--- a/.github/workflows/test_install_windows.yml
+++ b/.github/workflows/test_install_windows.yml
@@ -1,0 +1,71 @@
+name: test-install-windows
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'scripts/install_fuse_windows.ps1'
+      - 'scripts/verify_fluxmatcher_notebook.ps1'
+      - 'scripts/install_fuse_julia.jl'
+      - '.github/workflows/test_install_windows.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows-bootstrap:
+    name: Windows install script bootstrap
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1.11'
+          show-versioninfo: true
+
+      - name: Parse PowerShell install scripts
+        shell: pwsh
+        run: |
+          foreach ($script in @(
+            'scripts/install_fuse_windows.ps1',
+            'scripts/verify_fluxmatcher_notebook.ps1'
+          )) {
+            $errors = $null
+            $tokens = $null
+            [void][System.Management.Automation.Language.Parser]::ParseFile($script, [ref]$tokens, [ref]$errors)
+            if ($errors) {
+              $errors | ForEach-Object { Write-Error $_ }
+              exit 1
+            }
+            Write-Host "Parsed $script OK"
+          }
+
+      - name: Bootstrap Julia + Miniconda (Windows install script)
+        shell: pwsh
+        run: ./scripts/install_fuse_windows.ps1 -BootstrapOnly
+
+      - name: Clone FuseExamples for verify script smoke check
+        shell: pwsh
+        run: git clone --depth 1 https://github.com/ProjectTorreyPines/FuseExamples.git
+
+      - name: Verify fluxmatcher notebook structure (no FUSE import)
+        shell: pwsh
+        env:
+          FUSE_SKIP_SMOKE: '1'
+        run: |
+          $env:Path = "$env:USERPROFILE\.local\miniconda3\Scripts;$env:USERPROFILE\.local\miniconda3\condabin;$env:Path"
+          . "$env:USERPROFILE\.local\miniconda3\shell\condabin\conda-hook.ps1"
+          conda activate fuse
+          $python = @'
+          import json
+          from pathlib import Path
+          nb = json.loads(Path("FuseExamples/fluxmatcher.ipynb").read_text(encoding="utf-8"))
+          assert len(nb["cells"]) >= 2
+          assert nb["cells"][0]["cell_type"] == "code"
+          assert nb["cells"][1]["cell_type"] == "markdown"
+          print("fluxmatcher.ipynb structure OK")
+          '@
+          python -c $python

--- a/.github/workflows/test_install_windows.yml
+++ b/.github/workflows/test_install_windows.yml
@@ -47,19 +47,14 @@ jobs:
         shell: pwsh
         run: ./scripts/install_fuse_windows.ps1 -BootstrapOnly
 
-      - name: Clone FuseExamples for verify script smoke check
+      - name: Clone FuseExamples for notebook structure check
         shell: pwsh
         run: git clone --depth 1 https://github.com/ProjectTorreyPines/FuseExamples.git
 
       - name: Verify fluxmatcher notebook structure (no FUSE import)
         shell: pwsh
-        env:
-          FUSE_SKIP_SMOKE: '1'
         run: |
-          $env:Path = "$env:USERPROFILE\.local\miniconda3\Scripts;$env:USERPROFILE\.local\miniconda3\condabin;$env:Path"
-          . "$env:USERPROFILE\.local\miniconda3\shell\condabin\conda-hook.ps1"
-          conda activate fuse
-          $python = @'
+          python -c @'
           import json
           from pathlib import Path
           nb = json.loads(Path("FuseExamples/fluxmatcher.ipynb").read_text(encoding="utf-8"))
@@ -68,4 +63,3 @@ jobs:
           assert nb["cells"][1]["cell_type"] == "markdown"
           print("fluxmatcher.ipynb structure OK")
           '@
-          python -c $python

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The figure below is a sneakpeak of the models implemented in FUSE:
 
 Here are some key resources for getting started with FUSE:
 
+* 🛠️ **[Installation instructions](https://fuse.help/dev/install.html)**
 * 📨 **[Sign up for more info](https://forms.gle/iQGYKWfgeNkw2fCZ7)**
 * 📚 **[Online documentation](https://fuse.help)**
 * 🎓 **[Intro tutorial](https://fuse.help/dev/tutorial.html)**

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -2,18 +2,45 @@
 
 This guide walks you through setting up everything you need to run FUSE: the **Julia** language, the **FUSE** package, the **`fusebot`** helper, and an optional **JupyterLab** environment with Julia kernels.
 
-## Laptop one-command install
+## One-command install
 
-From any directory on a personal machine (Linux or macOS). Installs [juliaup](https://github.com/JuliaLang/juliaup) when `julia` is missing, installs [Miniconda](https://docs.anaconda.com/miniconda/) when `conda` is missing, then installs FUSE, Revise, fusebot, the Jupyter stack, IJulia kernels, and clones [`FuseExamples`](https://github.com/ProjectTorreyPines/FuseExamples). Everything runs from the shell — no Julia REPL.
+These scripts install FUSE, Revise, fusebot, the Jupyter stack, IJulia kernels, and clone [`FuseExamples`](https://github.com/ProjectTorreyPines/FuseExamples). Everything runs from the shell — no Julia REPL. A fresh install typically takes **20–45 minutes** (Julia packages + conda environment + IJulia kernels).
+
+### Laptop (Linux or macOS)
+
+From any directory on a personal machine. Installs [juliaup](https://github.com/JuliaLang/juliaup) when `julia` is missing and [Miniconda](https://docs.anaconda.com/miniconda/) when `conda` is missing.
 
 ```bash
 curl -fsSL https://install.julialang.org | sh -s -- -y && \
 bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/install_fuse_laptop.sh)
 ```
 
-From a local `FUSE.jl` clone you can use `bash scripts/install_fuse_laptop.sh` instead of the `curl` line for the install script.
+From a local `FUSE.jl` clone: `bash scripts/install_fuse_laptop.sh`
 
-A fresh install typically takes **20–45 minutes** (Julia packages + conda environment + IJulia kernels).
+### NERSC (Perlmutter)
+
+From a login node (run the depot symlink under [Home quota / memory pressure](@ref nersc-home-quota) first if `$HOME` is tight). Loads `julia/1.11.7` and `conda` by default.
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/install_fuse_nersc.sh)
+```
+
+From a local `FUSE.jl` clone: `bash scripts/install_fuse_nersc.sh`
+
+Override the Julia module with `FUSE_JULIA_MODULE=julia/1.12.0 bash scripts/install_fuse_nersc.sh` when needed. See [On NERSC (Perlmutter)](@ref nersc-install) for depot layout, `fusebot`, and Jupyter notes.
+
+### Windows
+
+From any directory in **PowerShell**. Installs Julia via [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/) (Microsoft Store) or the Julia App Installer when `julia` is missing, and Miniconda when `conda` is missing.
+
+```powershell
+winget install julia -s msstore --accept-source-agreements --accept-package-agreements --disable-interactivity; `
+irm https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/install_fuse_windows.ps1 | iex
+```
+
+From a local `FUSE.jl` clone: `.\scripts\install_fuse_windows.ps1`
+
+If `winget` is unavailable, install Julia with `Add-AppxPackage -AppInstallerFile https://install.julialang.org/Julia.appinstaller`, open a new terminal, then run the install script.
 
 ### Step 2: verify `fluxmatcher.ipynb`
 
@@ -22,15 +49,30 @@ After the install finishes, confirm you can run the **first two cells** of [`Fus
 * **Cell 0** (code): `using Revise`, `using Plots`, `using FUSE`
 * **Cell 1** (markdown): flux-matcher introduction (checked for presence, not executed)
 
+**Linux, macOS, and NERSC:**
+
 ```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/verify_fluxmatcher_notebook.sh)
 ```
 
 Or from a `FUSE.jl` clone: `bash scripts/verify_fluxmatcher_notebook.sh`
 
+**Windows:**
+
+```powershell
+irm https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/verify_fluxmatcher_notebook.ps1 | iex
+```
+
+Or from a `FUSE.jl` clone: `.\scripts\verify_fluxmatcher_notebook.ps1`
+
 Then start JupyterLab in the directory that contains `FuseExamples/`:
 
 ```bash
+conda activate fuse
+python -m jupyter lab
+```
+
+```powershell
 conda activate fuse
 python -m jupyter lab
 ```

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -2,6 +2,41 @@
 
 This guide walks you through setting up everything you need to run FUSE: the **Julia** language, the **FUSE** package, the **`fusebot`** helper, and an optional **JupyterLab** environment with Julia kernels.
 
+## Laptop one-command install
+
+From any directory on a personal machine (Linux or macOS). Installs [juliaup](https://github.com/JuliaLang/juliaup) when `julia` is missing, installs [Miniconda](https://docs.anaconda.com/miniconda/) when `conda` is missing, then installs FUSE, Revise, fusebot, the Jupyter stack, IJulia kernels, and clones [`FuseExamples`](https://github.com/ProjectTorreyPines/FuseExamples). Everything runs from the shell — no Julia REPL.
+
+```bash
+curl -fsSL https://install.julialang.org | sh -s -- -y && \
+bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/install_fuse_laptop.sh)
+```
+
+From a local `FUSE.jl` clone you can use `bash scripts/install_fuse_laptop.sh` instead of the `curl` line for the install script.
+
+A fresh install typically takes **20–45 minutes** (Julia packages + conda environment + IJulia kernels).
+
+### Step 2: verify `fluxmatcher.ipynb`
+
+After the install finishes, confirm you can run the **first two cells** of [`FuseExamples/fluxmatcher.ipynb`](https://github.com/ProjectTorreyPines/FuseExamples/blob/master/fluxmatcher.ipynb):
+
+* **Cell 0** (code): `using Revise`, `using Plots`, `using FUSE`
+* **Cell 1** (markdown): flux-matcher introduction (checked for presence, not executed)
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/verify_fluxmatcher_notebook.sh)
+```
+
+Or from a `FUSE.jl` clone: `bash scripts/verify_fluxmatcher_notebook.sh`
+
+Then start JupyterLab in the directory that contains `FuseExamples/`:
+
+```bash
+conda activate fuse
+python -m jupyter lab
+```
+
+Open `FuseExamples/fluxmatcher.ipynb` and run cells 0–1 in the notebook UI.
+
 ## Julia installation
 
 ### Desktop and laptop (juliaup)

--- a/docs/src/install_nersc.md
+++ b/docs/src/install_nersc.md
@@ -4,6 +4,33 @@ These instructions are for **personal** FUSE installs on NERSC login or compute 
 For the pre-built `module load fuse` environment maintained by the FUSE team, see the
 [Perlmutter deployment scripts](https://github.com/ProjectTorreyPines/FUSE.jl/tree/master/deploy/perlmutter).
 
+## NERSC one-command install
+
+From a login node (run the depot symlink under [Home quota / memory pressure](@ref nersc-home-quota) first if `$HOME` is tight). Loads `julia/1.11.7` and `conda`, installs FUSE, Revise, fusebot (under `~/.local/bin` or `~/.local/shared/bin` if `bin` is not writable), the Jupyter conda environment, IJulia kernels, and clones [`FuseExamples`](https://github.com/ProjectTorreyPines/FuseExamples). All steps run from the shell — no Julia REPL.
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/install_fuse_nersc.sh)
+```
+
+From a local `FUSE.jl` clone: `bash scripts/install_fuse_nersc.sh`
+
+Override the Julia module with `FUSE_JULIA_MODULE=julia/1.12.0 bash scripts/install_fuse_nersc.sh` when needed.
+
+If `fusebot` cannot be installed (for example when `~/.local/bin` does not exist), the script runs the same underlying `make` targets (`install_IJulia`, `install_examples`, …) directly from the FUSE package directory.
+
+### Step 2: verify `fluxmatcher.ipynb`
+
+Confirms **cell 0** (`using Revise`, `using Plots`, `using FUSE`) and **cell 1** (markdown) in `FuseExamples/fluxmatcher.ipynb`:
+
+```bash
+module load julia/1.11.7
+bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/verify_fluxmatcher_notebook.sh)
+```
+
+Or from a `FUSE.jl` clone: `bash scripts/verify_fluxmatcher_notebook.sh`
+
+Then start JupyterLab (with `module load conda` and `conda activate fuse`) and open `FuseExamples/fluxmatcher.ipynb`.
+
 ## Julia
 
 NERSC provides Julia through the module system. **Do not use juliaup** for a typical NERSC workflow.

--- a/scripts/install_fuse_common.sh
+++ b/scripts/install_fuse_common.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# Shared FUSE install logic for laptop and NERSC (executed, not sourced).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+INSTALL_DIR="${FUSE_WORK_DIR:-${PWD}}"
+CONDA_ENV_NAME="${FUSE_CONDA_ENV:-fuse}"
+MINICONDA_DIR="${MINICONDA_DIR:-${HOME}/.local/miniconda3}"
+JULIA_MODULE="${FUSE_JULIA_MODULE:-julia/1.11.7}"
+
+log() { echo "[install_fuse] $*"; }
+die() { echo "[install_fuse] ERROR: $*" >&2; exit 1; }
+
+need_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+ensure_julia() {
+    if command -v julia >/dev/null 2>&1; then
+        log "Julia: $(julia --version)"
+        return 0
+    fi
+    die "julia is not on PATH after setup"
+}
+
+ensure_juliaup() {
+    if command -v julia >/dev/null 2>&1; then
+        return 0
+    fi
+    if [[ -x "${HOME}/.juliaup/bin/julia" ]]; then
+        export PATH="${HOME}/.juliaup/bin:${PATH}"
+        return 0
+    fi
+    log "julia not found — installing juliaup"
+    need_cmd curl
+    curl -fsSL https://install.julialang.org | sh -s -- -y
+    export PATH="${HOME}/.juliaup/bin:${PATH}"
+}
+
+load_nersc_modules() {
+    command -v module >/dev/null 2>&1 || die "Lmod is required on NERSC (module command not found)"
+    log "Loading ${JULIA_MODULE}"
+    module load "${JULIA_MODULE}"
+    log "Loading conda"
+    module load conda
+    log "Julia: $(julia --version)"
+}
+
+miniconda_installer_url() {
+    local os arch
+    os="$(uname -s)"
+    arch="$(uname -m)"
+    case "${os}" in
+        Linux)
+            case "${arch}" in
+                x86_64)  echo "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh" ;;
+                aarch64|arm64) echo "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh" ;;
+                *) die "Unsupported Linux architecture: ${arch}" ;;
+            esac
+            ;;
+        Darwin)
+            case "${arch}" in
+                arm64)   echo "https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh" ;;
+                x86_64)  echo "https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh" ;;
+                *) die "Unsupported macOS architecture: ${arch}" ;;
+            esac
+            ;;
+        *) die "Miniconda auto-install is only supported on Linux and macOS" ;;
+    esac
+}
+
+install_miniconda() {
+    local installer helper
+    log "Installing Miniconda to ${MINICONDA_DIR}"
+    need_cmd curl
+    mkdir -p "$(dirname "${MINICONDA_DIR}")"
+    installer="$(miniconda_installer_url)"
+    helper="$(mktemp)"
+    cat > "${helper}" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+tmp="\$(mktemp)"
+curl -fsSL "${installer}" -o "\${tmp}"
+bash "\${tmp}" -b -p "${MINICONDA_DIR}"
+rm -f "\${tmp}"
+EOF
+    chmod +x "${helper}"
+    bash "${helper}"
+    rm -f "${helper}"
+    [[ -x "${MINICONDA_DIR}/bin/conda" ]] || die "Miniconda install failed (conda not found at ${MINICONDA_DIR}/bin/conda)"
+}
+
+activate_conda() {
+  # shellcheck disable=SC1091
+    if [[ -f "${MINICONDA_DIR}/etc/profile.d/conda.sh" ]]; then
+        source "${MINICONDA_DIR}/etc/profile.d/conda.sh"
+    elif command -v conda >/dev/null 2>&1; then
+        eval "$("$(command -v conda)" shell.bash hook 2>/dev/null)" || true
+    else
+        die "conda is not available (install Miniconda or module load conda)"
+    fi
+}
+
+bootstrap_conda_channels() {
+    conda config --set auto_activate_base false 2>/dev/null || true
+    conda config --add channels conda-forge 2>/dev/null || true
+    conda config --set channel_priority strict 2>/dev/null || true
+    # Non-interactive installs (Miniconda 25+) require explicit TOS acceptance.
+    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main 2>/dev/null || true
+    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r 2>/dev/null || true
+}
+
+ensure_conda() {
+    if command -v conda >/dev/null 2>&1; then
+        log "conda: $(conda --version)"
+        activate_conda
+        return 0
+    fi
+
+    if [[ -x "${MINICONDA_DIR}/bin/conda" ]]; then
+        log "Using existing Miniconda at ${MINICONDA_DIR}"
+        activate_conda
+        return 0
+    fi
+
+    if command -v module >/dev/null 2>&1; then
+        log "Trying module load conda"
+        module load conda 2>/dev/null || true
+        if command -v conda >/dev/null 2>&1; then
+            activate_conda
+            return 0
+        fi
+    fi
+
+    install_miniconda
+    activate_conda
+}
+
+fuse_jupyter_yml() {
+    julia -e '
+        try
+            using FUSE
+        catch
+            using Pkg
+            Pkg.Registry.add(RegistrySpec(url="https://github.com/ProjectTorreyPines/FuseRegistry.jl.git"))
+            Pkg.Registry.add("General")
+            Pkg.add("FUSE")
+            using FUSE
+        end
+        print(pkgdir(FUSE, "docs", "jupyter_environment.yml"))
+    '
+}
+
+ensure_fuse_conda_env() {
+    ensure_conda
+    bootstrap_conda_channels
+    local yml
+    yml="$(fuse_jupyter_yml)"
+    log "Jupyter environment file: ${yml}"
+    if conda env list | awk '{print $1}' | grep -qx "${CONDA_ENV_NAME}"; then
+        log "Conda env '${CONDA_ENV_NAME}' exists — updating"
+        conda env update -n "${CONDA_ENV_NAME}" -f "${yml}" --prune
+    else
+        log "Creating conda env '${CONDA_ENV_NAME}'"
+        conda env create -f "${yml}"
+    fi
+    conda activate "${CONDA_ENV_NAME}"
+    log "Active Python: $(python -c 'import sys; print(sys.executable)')"
+}
+
+fuse_pkg_dir() {
+    julia -e 'using FUSE; print(pkgdir(FUSE))'
+}
+
+pick_fusebot_dir() {
+    local candidates=()
+    if command -v juliaup >/dev/null 2>&1; then
+        candidates+=("$(dirname "$(command -v juliaup)")")
+    fi
+    if command -v julia >/dev/null 2>&1; then
+        local julia_dir
+        julia_dir="$(dirname "$(command -v julia)")"
+        if [[ "${julia_dir}" == *juliaup* ]] || [[ -w "${julia_dir}" ]]; then
+            candidates+=("${julia_dir}")
+        fi
+    fi
+    candidates+=("${HOME}/.local/bin" "${HOME}/.local/shared/bin")
+
+    local dir
+    for dir in "${candidates[@]}"; do
+        if mkdir -p "${dir}" 2>/dev/null && [[ -w "${dir}" ]]; then
+            echo "${dir}"
+            return 0
+        fi
+    done
+    die "Could not find a writable directory for fusebot"
+}
+
+install_fusebot_cli() {
+    local fusebot_dir
+    fusebot_dir="$(pick_fusebot_dir)"
+    log "fusebot install directory: ${fusebot_dir}"
+    export FUSE_INSTALL_DIR="${fusebot_dir}"
+    export PATH="${fusebot_dir}:${PATH}"
+    if ! julia "${SCRIPT_DIR}/install_fuse_julia.jl" fusebot; then
+        log "fusebot install via Julia failed — copying fusebot manually"
+        local fuse_dir
+        fuse_dir="$(fuse_pkg_dir)"
+        cp "${fuse_dir}/fusebot" "${fusebot_dir}/fusebot"
+        chmod +x "${fusebot_dir}/fusebot"
+        if [[ "${FUSE_SETUP_SHELL:-false}" == "true" ]]; then
+            julia -e "using FUSE; FUSE.setup_fusebot_shell!(\"${fusebot_dir}\")" || true
+        fi
+    fi
+}
+
+run_fusebot_or_make() {
+    local target="$1"
+    shift || true
+    if command -v fusebot >/dev/null 2>&1; then
+        log "fusebot ${target} $*"
+        fusebot "${target}" "$@"
+        return 0
+    fi
+
+    local fuse_dir
+    fuse_dir="$(fuse_pkg_dir)"
+    log "fusebot not on PATH — running make ${target} in ${fuse_dir}"
+    (
+        cd "${fuse_dir}"
+        export PTP_ORIGINAL_DIR="${INSTALL_DIR}"
+        make "${target}" "$@"
+    )
+}
+
+install_ijulia_kernels() {
+    run_fusebot_or_make install_IJulia
+}
+
+clone_fuse_examples() {
+    cd "${INSTALL_DIR}"
+    if [[ -d FuseExamples/.git ]]; then
+        log "Updating FuseExamples"
+        git -C FuseExamples fetch origin
+        git -C FuseExamples reset --hard origin/master
+    else
+        log "Cloning FuseExamples into ${INSTALL_DIR}"
+        git clone https://github.com/ProjectTorreyPines/FuseExamples.git
+    fi
+}
+
+run_julia_install() {
+    local step="${1:-all}"
+    julia "${SCRIPT_DIR}/install_fuse_julia.jl" "${step}"
+}
+
+install_fuse_stack() {
+    cd "${INSTALL_DIR}"
+    need_cmd git
+    need_cmd curl
+    ensure_julia
+
+    log "Working directory: ${INSTALL_DIR}"
+    run_julia_install packages
+    run_julia_install revise
+    install_fusebot_cli
+
+    ensure_fuse_conda_env
+    install_ijulia_kernels
+    clone_fuse_examples
+    run_julia_install smoke
+
+    log "FUSE install complete."
+    log "Step 2 — verify fluxmatcher.ipynb cells 0–1:"
+    log "  bash ${SCRIPT_DIR}/verify_fluxmatcher_notebook.sh"
+}
+
+platform="${1:-}"
+case "${platform}" in
+    laptop)
+        export FUSE_SETUP_SHELL="${FUSE_SETUP_SHELL:-false}"
+        ensure_juliaup
+        install_fuse_stack
+        ;;
+    nersc)
+        export FUSE_SETUP_SHELL="${FUSE_SETUP_SHELL:-true}"
+        load_nersc_modules
+        install_fuse_stack
+        ;;
+    *)
+        die "Usage: $(basename "$0") laptop|nersc"
+        ;;
+esac

--- a/scripts/install_fuse_julia.jl
+++ b/scripts/install_fuse_julia.jl
@@ -1,0 +1,112 @@
+#!/usr/bin/env julia
+"""
+Julia-side FUSE install steps (invoked from install_fuse_*.sh, not the REPL).
+
+Environment:
+  FUSE_INSTALL_DIR   optional fusebot install directory (NERSC: ~/.local/shared/bin)
+  FUSE_SETUP_SHELL   "true" to append fusebot dir to shell rc (recommended on HPC)
+"""
+
+using Pkg
+
+const FUSE_UUID = Base.UUID("e64856f0-3bb8-4376-b4b7-c03396503992")
+
+function log(msg)
+    println("[install_fuse] ", msg)
+    flush(stdout)
+end
+
+function fuse_module()
+    return Base.require(Base.PkgId(FUSE_UUID, "FUSE"))
+end
+
+function add_registries!()
+    log("Adding FuseRegistry and General")
+    Pkg.Registry.add(RegistrySpec(url="https://github.com/ProjectTorreyPines/FuseRegistry.jl.git"))
+    Pkg.Registry.add("General")
+end
+
+function install_fuse_packages!()
+    if isfile("Project.toml")
+        log("Project.toml found — instantiating environment")
+        Pkg.instantiate()
+        log("Updating project environment")
+        Pkg.update()
+    end
+
+    add_registries!()
+
+    if haskey(Pkg.dependencies(), Base.UUID("e64856f0-3bb8-4376-b4b7-c03396503992"))
+        log("FUSE already installed — resolving and updating")
+    else
+        log("Adding FUSE (15–30 minutes on first install)")
+        Pkg.add("FUSE")
+    end
+    Pkg.resolve()
+    log("Updating FUSE dependencies")
+    Pkg.update()
+    Pkg.precompile()
+end
+
+function install_revise!()
+    log("Adding Revise.jl and enabling startup hook")
+    Pkg.add("Revise")
+    julia_dir = first(DEPOT_PATH)
+    config_dir = joinpath(julia_dir, "config")
+    startup = joinpath(config_dir, "startup.jl")
+    mkpath(config_dir)
+    existing = isfile(startup) ? read(startup, String) : ""
+    if !occursin("using Revise", existing)
+        open(startup, "w") do io
+            println(io, "using Revise")
+            print(io, existing)
+        end
+        log("Wrote using Revise to $startup")
+    else
+        log("Revise already in $startup")
+    end
+end
+
+function install_fusebot!()
+    FUSE = fuse_module()
+    setup_shell = get(ENV, "FUSE_SETUP_SHELL", "false") == "true"
+    if haskey(ENV, "FUSE_INSTALL_DIR") && !isempty(ENV["FUSE_INSTALL_DIR"])
+        dir = ENV["FUSE_INSTALL_DIR"]
+        log("Installing fusebot to $dir")
+        Base.invokelatest(FUSE.install_fusebot, dir; setup_shell=setup_shell)
+    else
+        log("Installing fusebot to default location")
+        Base.invokelatest(FUSE.install_fusebot; setup_shell=setup_shell)
+    end
+    println(Base.invokelatest(FUSE.default_fusebot_dir))
+end
+
+function smoke_test!()
+    FUSE = fuse_module()
+    log("Smoke test: case_parameters(:FPP) + init")
+    ini, act = Base.invokelatest(FUSE.case_parameters, :FPP)
+    Base.invokelatest(FUSE.init, ini, act)
+    log("Smoke test passed")
+end
+
+const STEPS = Dict(
+    "packages" => install_fuse_packages!,
+    "revise" => install_revise!,
+    "fusebot" => install_fusebot!,
+    "smoke" => smoke_test!,
+    "all" => function ()
+        install_fuse_packages!()
+        install_revise!()
+        install_fusebot!()
+        smoke_test!()
+    end,
+)
+
+if isempty(ARGS)
+    STEPS["all"]()
+else
+    for step in ARGS
+        haskey(STEPS, step) || error("Unknown step: $step (choose: $(join(keys(STEPS), ", ")))")
+        STEPS[step]()
+    end
+end

--- a/scripts/install_fuse_laptop.sh
+++ b/scripts/install_fuse_laptop.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# One-shot FUSE install for laptops (juliaup + Miniconda if needed).
+#
+# Copy-paste (from any working directory):
+#   curl -fsSL https://install.julialang.org | sh -s -- -y && \
+#   bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/install_fuse_laptop.sh)
+#
+# Or, from a FUSE.jl clone:
+#   curl -fsSL https://install.julialang.org | sh -s -- -y && bash scripts/install_fuse_laptop.sh
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "${SCRIPT_DIR}/install_fuse_common.sh" laptop

--- a/scripts/install_fuse_laptop.sh
+++ b/scripts/install_fuse_laptop.sh
@@ -9,5 +9,24 @@
 #   curl -fsSL https://install.julialang.org | sh -s -- -y && bash scripts/install_fuse_laptop.sh
 
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+SCRIPT_BASE_URL="${FUSE_SCRIPT_BASE_URL:-https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts}"
+
+resolve_script_dir() {
+    local self_dir
+    self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [[ -f "${self_dir}/install_fuse_common.sh" ]]; then
+        echo "${self_dir}"
+        return 0
+    fi
+
+    local bundle_dir="${TMPDIR:-/tmp}/fuse-install-$$"
+    mkdir -p "${bundle_dir}"
+    for file in install_fuse_common.sh install_fuse_julia.jl; do
+        curl -fsSL "${SCRIPT_BASE_URL}/${file}" -o "${bundle_dir}/${file}"
+    done
+    echo "${bundle_dir}"
+}
+
+SCRIPT_DIR="$(resolve_script_dir)"
 exec bash "${SCRIPT_DIR}/install_fuse_common.sh" laptop

--- a/scripts/install_fuse_nersc.sh
+++ b/scripts/install_fuse_nersc.sh
@@ -12,5 +12,24 @@
 # and underlying make targets are used when fusebot is not on PATH.
 
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+SCRIPT_BASE_URL="${FUSE_SCRIPT_BASE_URL:-https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts}"
+
+resolve_script_dir() {
+    local self_dir
+    self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [[ -f "${self_dir}/install_fuse_common.sh" ]]; then
+        echo "${self_dir}"
+        return 0
+    fi
+
+    local bundle_dir="${TMPDIR:-/tmp}/fuse-install-$$"
+    mkdir -p "${bundle_dir}"
+    for file in install_fuse_common.sh install_fuse_julia.jl; do
+        curl -fsSL "${SCRIPT_BASE_URL}/${file}" -o "${bundle_dir}/${file}"
+    done
+    echo "${bundle_dir}"
+}
+
+SCRIPT_DIR="$(resolve_script_dir)"
 exec bash "${SCRIPT_DIR}/install_fuse_common.sh" nersc

--- a/scripts/install_fuse_nersc.sh
+++ b/scripts/install_fuse_nersc.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# One-shot FUSE install for NERSC Perlmutter login nodes.
+#
+# Copy-paste (from any working directory, e.g. $HOME or $PSCRATCH):
+#   bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/install_fuse_nersc.sh)
+#
+# Or, from a FUSE.jl clone:
+#   bash scripts/install_fuse_nersc.sh
+#
+# Uses module load julia/1.11.7 and module load conda by default.
+# If ~/.local/bin is not writable, fusebot is installed under ~/.local/shared/bin
+# and underlying make targets are used when fusebot is not on PATH.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "${SCRIPT_DIR}/install_fuse_common.sh" nersc

--- a/scripts/install_fuse_windows.ps1
+++ b/scripts/install_fuse_windows.ps1
@@ -1,0 +1,354 @@
+# One-shot FUSE install for Windows laptops (juliaup + Miniconda if needed).
+#
+# Copy-paste (PowerShell, from any working directory):
+#   winget install julia -s msstore --accept-source-agreements --accept-package-agreements --disable-interactivity; `
+#   irm https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/install_fuse_windows.ps1 | iex
+#
+# Or download and run from a FUSE.jl clone:
+#   .\scripts\install_fuse_windows.ps1
+#
+# Bootstrap-only (syntax / Julia + conda setup, no FUSE packages):
+#   .\scripts\install_fuse_windows.ps1 -BootstrapOnly
+
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+    [switch]$BootstrapOnly
+)
+
+$ErrorActionPreference = "Stop"
+
+$ScriptBaseUrl = if ($env:FUSE_SCRIPT_BASE_URL) { $env:FUSE_SCRIPT_BASE_URL } else {
+    "https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts"
+}
+
+function Resolve-ScriptDir {
+    param([string]$SelfPath = $PSCommandPath)
+    if ($selfPath) {
+        $selfDir = Split-Path -Parent $selfPath
+        if (Test-Path (Join-Path $selfDir "install_fuse_julia.jl")) {
+            return $selfDir
+        }
+    }
+
+    $bundleDir = Join-Path $env:TEMP "fuse-install-$PID"
+    New-Item -ItemType Directory -Force -Path $bundleDir | Out-Null
+    foreach ($file in @("install_fuse_julia.jl")) {
+        $dest = Join-Path $bundleDir $file
+        Invoke-WebRequest -Uri "$ScriptBaseUrl/$file" -OutFile $dest
+    }
+    return $bundleDir
+}
+
+$ScriptDir = Resolve-ScriptDir
+$RepoRoot = Split-Path -Parent $ScriptDir
+$InstallDir = if ($env:FUSE_WORK_DIR) { $env:FUSE_WORK_DIR } else { (Get-Location).Path }
+$CondaEnvName = if ($env:FUSE_CONDA_ENV) { $env:FUSE_CONDA_ENV } else { "fuse" }
+$MinicondaDir = if ($env:MINICONDA_DIR) { $env:MINICONDA_DIR } else { Join-Path $env:USERPROFILE ".local\miniconda3" }
+
+function Write-InstallLog {
+    param([string]$Message)
+    Write-Host "[install_fuse] $Message"
+}
+
+function Write-InstallError {
+    param([string]$Message)
+    Write-Error "[install_fuse] ERROR: $Message"
+}
+
+function Test-Command {
+    param([string]$Name)
+    return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Add-ToPath {
+    param([string]$Directory)
+    if (-not (Test-Path $Directory)) { return }
+    $parts = $env:Path -split ';' | Where-Object { $_ -and $_ -ne $Directory }
+    $env:Path = ($Directory, ($parts -join ';')) -join ';'
+}
+
+function Ensure-Julia {
+    if (Test-Command julia) {
+        Write-InstallLog "Julia: $(julia --version)"
+        return
+    }
+
+    $juliaupBin = Join-Path $env:USERPROFILE ".juliaup\bin"
+    $juliaupExe = Join-Path $juliaupBin "julia.exe"
+    if (Test-Path $juliaupExe) {
+        Add-ToPath $juliaupBin
+        Write-InstallLog "Julia: $(julia --version)"
+        return
+    }
+
+    Write-InstallLog "julia not found — installing via winget or Julia App Installer"
+    if (Test-Command winget) {
+        & winget install julia -s msstore --accept-source-agreements --accept-package-agreements --disable-interactivity
+    }
+    else {
+        Add-AppxPackage -AppInstallerFile "https://install.julialang.org/Julia.appinstaller"
+    }
+
+    if (Test-Path $juliaupExe) {
+        Add-ToPath $juliaupBin
+    }
+
+    # Refresh PATH from the user environment (winget / Store installs update the registry).
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($userPath) {
+        $env:Path = "$userPath;$env:Path"
+    }
+
+    if (-not (Test-Command julia)) {
+        Write-InstallError "julia is not on PATH after setup. Open a new terminal and re-run this script."
+    }
+    Write-InstallLog "Julia: $(julia --version)"
+}
+
+function Install-Miniconda {
+    Write-InstallLog "Installing Miniconda to $MinicondaDir"
+    $installer = Join-Path $env:TEMP "Miniconda3-latest-Windows-x86_64.exe"
+    Invoke-WebRequest -Uri "https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe" -OutFile $installer
+    $args = @(
+        "/InstallationType=JustMe",
+        "/RegisterPython=0",
+        "/S",
+        "/D=$MinicondaDir"
+    )
+    $proc = Start-Process -FilePath $installer -ArgumentList $args -Wait -PassThru -NoNewWindow
+    Remove-Item $installer -Force -ErrorAction SilentlyContinue
+    if ($proc.ExitCode -ne 0) {
+        Write-InstallError "Miniconda installer exited with code $($proc.ExitCode)"
+    }
+    $condaExe = Join-Path $MinicondaDir "Scripts\conda.exe"
+    if (-not (Test-Path $condaExe)) {
+        Write-InstallError "Miniconda install failed (conda not found at $condaExe)"
+    }
+}
+
+function Initialize-Conda {
+    $condaHook = Join-Path $MinicondaDir "shell\condabin\conda-hook.ps1"
+    if (Test-Path $condaHook) {
+        . $condaHook
+        return
+    }
+    if (Test-Command conda) {
+        (& (Get-Command conda).Source "shell.powershell" "hook") | Out-String | Invoke-Expression
+        return
+    }
+    Write-InstallError "conda is not available (install Miniconda or add conda to PATH)"
+}
+
+function Set-CondaChannels {
+    conda config --set auto_activate_base false 2>$null
+    conda config --add channels conda-forge 2>$null
+    conda config --set channel_priority strict 2>$null
+    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main 2>$null
+    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r 2>$null
+}
+
+function Ensure-Conda {
+    if (Test-Command conda) {
+        Write-InstallLog "conda: $(conda --version)"
+        Initialize-Conda
+        return
+    }
+
+    $condaExe = Join-Path $MinicondaDir "Scripts\conda.exe"
+    if (Test-Path $condaExe) {
+        Write-InstallLog "Using existing Miniconda at $MinicondaDir"
+        Add-ToPath (Join-Path $MinicondaDir "Scripts")
+        Add-ToPath (Join-Path $MinicondaDir "condabin")
+        Initialize-Conda
+        return
+    }
+
+    Install-Miniconda
+    Add-ToPath (Join-Path $MinicondaDir "Scripts")
+    Add-ToPath (Join-Path $MinicondaDir "condabin")
+    Initialize-Conda
+}
+
+function Get-FuseJupyterYml {
+    $juliaScript = @'
+try
+    using FUSE
+catch
+    using Pkg
+    Pkg.Registry.add(RegistrySpec(url="https://github.com/ProjectTorreyPines/FuseRegistry.jl.git"))
+    Pkg.Registry.add("General")
+    Pkg.add("FUSE")
+    using FUSE
+end
+print(pkgdir(FUSE, "docs", "jupyter_environment.yml"))
+'@
+    return julia -e $juliaScript
+}
+
+function Ensure-FuseCondaEnv {
+    Ensure-Conda
+    Set-CondaChannels
+    $yml = Get-FuseJupyterYml
+    Write-InstallLog "Jupyter environment file: $yml"
+    $envNames = conda env list | ForEach-Object {
+        if ($_ -match '^\s*(\S+)') { $Matches[1] }
+    }
+    if ($envNames -contains $CondaEnvName) {
+        Write-InstallLog "Conda env '$CondaEnvName' exists — updating"
+        conda env update -n $CondaEnvName -f $yml --prune
+    }
+    else {
+        Write-InstallLog "Creating conda env '$CondaEnvName'"
+        conda env create -f $yml
+    }
+    conda activate $CondaEnvName
+    Write-InstallLog "Active Python: $(python -c 'import sys; print(sys.executable)')"
+}
+
+function Get-FusePkgDir {
+    return julia -e 'using FUSE; print(pkgdir(FUSE))'
+}
+
+function Get-FusebotDir {
+    $candidates = @()
+
+    if (Test-Command juliaup) {
+        $candidates += Split-Path (Get-Command juliaup).Source -Parent
+    }
+    if (Test-Command julia) {
+        $juliaDir = Split-Path (Get-Command julia).Source -Parent
+        if ($juliaDir -match 'juliaup' -or (Test-Path $juliaDir)) {
+            $candidates += $juliaDir
+        }
+    }
+    $candidates += @(
+        (Join-Path $env:USERPROFILE ".local\bin"),
+        (Join-Path $env:LOCALAPPDATA "Programs\Julia\bin")
+    )
+
+    foreach ($dir in $candidates) {
+        if (-not $dir) { continue }
+        try {
+            New-Item -ItemType Directory -Force -Path $dir | Out-Null
+            $testFile = Join-Path $dir ".write_test"
+            New-Item -ItemType File -Force -Path $testFile | Out-Null
+            Remove-Item $testFile -Force
+            return $dir
+        }
+        catch {
+            continue
+        }
+    }
+    Write-InstallError "Could not find a writable directory for fusebot"
+}
+
+function Install-FusebotCli {
+    $fusebotDir = Get-FusebotDir
+    Write-InstallLog "fusebot install directory: $fusebotDir"
+    $env:FUSE_INSTALL_DIR = $fusebotDir
+    Add-ToPath $fusebotDir
+
+    $juliaScript = Join-Path $ScriptDir "install_fuse_julia.jl"
+    & julia $juliaScript fusebot
+    if ($LASTEXITCODE -ne 0) {
+        Write-InstallLog "fusebot install via Julia failed — copying fusebot manually"
+        $fuseDir = Get-FusePkgDir
+        Copy-Item (Join-Path $fuseDir "fusebot") (Join-Path $fusebotDir "fusebot") -Force
+        if ($env:FUSE_SETUP_SHELL -eq "true") {
+            julia -e "using FUSE; FUSE.setup_fusebot_shell!(\"$fusebotDir\")" 2>$null
+        }
+    }
+}
+
+function Invoke-FusebotOrMake {
+    param(
+        [Parameter(Mandatory = $true)][string]$Target,
+        [Parameter(ValueFromRemainingArguments = $true)][string[]]$ExtraArgs
+    )
+
+    if (Test-Command fusebot) {
+        Write-InstallLog "fusebot $Target $($ExtraArgs -join ' ')"
+        & fusebot $Target @ExtraArgs
+        return
+    }
+
+    $fuseDir = Get-FusePkgDir
+    Write-InstallLog "fusebot not on PATH — running make $Target in $fuseDir"
+    Push-Location $fuseDir
+    try {
+        $env:PTP_ORIGINAL_DIR = $InstallDir
+        & make $Target @ExtraArgs
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Install-IJuliaKernels {
+    Invoke-FusebotOrMake install_IJulia
+}
+
+function Clone-FuseExamples {
+    Set-Location $InstallDir
+    $examplesDir = Join-Path $InstallDir "FuseExamples"
+    if (Test-Path (Join-Path $examplesDir ".git")) {
+        Write-InstallLog "Updating FuseExamples"
+        git -C $examplesDir fetch origin
+        git -C $examplesDir reset --hard origin/master
+    }
+    else {
+        Write-InstallLog "Cloning FuseExamples into $InstallDir"
+        git clone https://github.com/ProjectTorreyPines/FuseExamples.git
+    }
+}
+
+function Invoke-JuliaInstall {
+    param([string]$Step = "all")
+    $juliaScript = Join-Path $ScriptDir "install_fuse_julia.jl"
+    & julia $juliaScript $Step
+    if ($LASTEXITCODE -ne 0) {
+        Write-InstallError "Julia install step '$Step' failed"
+    }
+}
+
+function Install-FuseStack {
+    if (-not (Test-Command git)) {
+        Write-InstallError "git is required but not found (install Git for Windows)"
+    }
+
+    Set-Location $InstallDir
+    Ensure-Julia
+    Write-InstallLog "Working directory: $InstallDir"
+
+    Invoke-JuliaInstall packages
+    Invoke-JuliaInstall revise
+    Install-FusebotCli
+
+    Ensure-FuseCondaEnv
+    Install-IJuliaKernels
+    Clone-FuseExamples
+
+    if ($env:FUSE_SKIP_SMOKE -ne "1") {
+        Invoke-JuliaInstall smoke
+    }
+    else {
+        Write-InstallLog "Skipping smoke test (FUSE_SKIP_SMOKE=1)"
+    }
+
+    Write-InstallLog "FUSE install complete."
+    Write-InstallLog "Step 2 — verify fluxmatcher.ipynb cells 0–1:"
+    Write-InstallLog "  .\scripts\verify_fluxmatcher_notebook.ps1"
+}
+
+$env:FUSE_SETUP_SHELL = if ($env:FUSE_SETUP_SHELL) { $env:FUSE_SETUP_SHELL } else { "false" }
+
+Ensure-Julia
+Ensure-Conda
+
+if ($BootstrapOnly) {
+    Write-InstallLog "Bootstrap complete (Julia + conda available)."
+    exit 0
+}
+
+Install-FuseStack

--- a/scripts/verify_fluxmatcher_notebook.jl
+++ b/scripts/verify_fluxmatcher_notebook.jl
@@ -1,0 +1,15 @@
+#!/usr/bin/env julia
+"""
+Step 2 after install: run fluxmatcher.ipynb cell 0 (code imports).
+
+Cell 1 is markdown and is checked by verify_fluxmatcher_notebook.sh with Python.
+"""
+
+println("[verify_fluxmatcher] Running cell 0: using Revise, Plots, FUSE")
+flush(stdout)
+
+@time using Revise
+@time using Plots
+@time using FUSE
+
+println("[verify_fluxmatcher] Cell 0 passed")

--- a/scripts/verify_fluxmatcher_notebook.ps1
+++ b/scripts/verify_fluxmatcher_notebook.ps1
@@ -1,0 +1,76 @@
+# Step 2 after install: verify fluxmatcher.ipynb cells 0–1 from PowerShell.
+#
+#   .\scripts\verify_fluxmatcher_notebook.ps1
+
+#Requires -Version 5.1
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ScriptBaseUrl = if ($env:FUSE_SCRIPT_BASE_URL) { $env:FUSE_SCRIPT_BASE_URL } else {
+    "https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts"
+}
+
+if (-not (Test-Path (Join-Path $ScriptDir "verify_fluxmatcher_notebook.jl"))) {
+    $bundleDir = Join-Path $env:TEMP "fuse-verify-$PID"
+    New-Item -ItemType Directory -Force -Path $bundleDir | Out-Null
+    Invoke-WebRequest -Uri "$ScriptBaseUrl/verify_fluxmatcher_notebook.jl" -OutFile (Join-Path $bundleDir "verify_fluxmatcher_notebook.jl")
+    $ScriptDir = $bundleDir
+}
+$WorkDir = if ($env:FUSE_WORK_DIR) { $env:FUSE_WORK_DIR } else { (Get-Location).Path }
+$Notebook = Join-Path $WorkDir "FuseExamples\fluxmatcher.ipynb"
+
+function Write-VerifyLog {
+    param([string]$Message)
+    Write-Host "[verify_fluxmatcher] $Message"
+}
+
+$juliaupBin = Join-Path $env:USERPROFILE ".juliaup\bin"
+if (Test-Path (Join-Path $juliaupBin "julia.exe")) {
+    $env:Path = "$juliaupBin;$env:Path"
+}
+
+if (-not (Get-Command julia -ErrorAction SilentlyContinue)) {
+    Write-Error "julia not on PATH"
+}
+
+if (-not (Test-Path $Notebook)) {
+    Write-Error "$Notebook not found. Run the install script first, or set FUSE_WORK_DIR."
+}
+
+Set-Location $WorkDir
+
+$pythonCandidates = @(
+    (Join-Path $env:USERPROFILE ".local\miniconda3\envs\fuse\python.exe"),
+    (Get-Command python -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source)
+)
+$Python = $pythonCandidates | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+if (-not $Python) {
+    Write-Error "python not on PATH (activate the fuse conda env first)"
+}
+
+& $Python - @"
+import json
+import sys
+from pathlib import Path
+
+path = Path(r"$Notebook")
+nb = json.loads(path.read_text(encoding="utf-8"))
+if len(nb["cells"]) < 2:
+    sys.exit("fluxmatcher.ipynb must have at least 2 cells")
+if nb["cells"][0]["cell_type"] != "code":
+    sys.exit("Cell 0 must be a code cell")
+if nb["cells"][1]["cell_type"] != "markdown":
+    sys.exit("Cell 1 must be a markdown cell")
+text = "".join(nb["cells"][1].get("source", [])).lower()
+if "flux-matcher" not in text and "flux matcher" not in text:
+    sys.exit("Cell 1 markdown does not mention flux-matcher")
+print("[verify_fluxmatcher] Cell 1 (markdown) present")
+"@
+
+$juliaVerify = Join-Path $ScriptDir "verify_fluxmatcher_notebook.jl"
+& julia $juliaVerify
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Julia verification failed"
+}
+
+Write-VerifyLog "fluxmatcher.ipynb cells 0–1 verification PASSED"

--- a/scripts/verify_fluxmatcher_notebook.sh
+++ b/scripts/verify_fluxmatcher_notebook.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Step 2 after install: verify fluxmatcher.ipynb cells 0–1 from the command line.
+#
+# Laptop:
+#   bash scripts/verify_fluxmatcher_notebook.sh
+#
+# NERSC:
+#   module load julia/1.11.7 && bash scripts/verify_fluxmatcher_notebook.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+log() { echo "[verify_fluxmatcher] $*"; }
+
+if command -v module >/dev/null 2>&1 && ! command -v julia >/dev/null 2>&1; then
+    module load "${FUSE_JULIA_MODULE:-julia/1.11.7}" 2>/dev/null || module load julia
+fi
+
+if [[ -f "${HOME}/.juliaup/bin/julia" ]]; then
+    export PATH="${HOME}/.juliaup/bin:${PATH}"
+fi
+
+command -v julia >/dev/null 2>&1 || { echo "ERROR: julia not on PATH" >&2; exit 1; }
+
+WORK_DIR="${FUSE_WORK_DIR:-${PWD}}"
+if [[ ! -f "${WORK_DIR}/FuseExamples/fluxmatcher.ipynb" ]]; then
+    echo "ERROR: ${WORK_DIR}/FuseExamples/fluxmatcher.ipynb not found." >&2
+    echo "Run the install script first, or set FUSE_WORK_DIR to your FuseExamples parent directory." >&2
+    exit 1
+fi
+
+cd "${WORK_DIR}"
+
+if [[ -x "${HOME}/.local/miniconda3/envs/fuse/bin/python" ]]; then
+    PYTHON="${HOME}/.local/miniconda3/envs/fuse/bin/python"
+elif command -v python >/dev/null 2>&1; then
+    PYTHON="$(command -v python)"
+else
+    echo "ERROR: python not on PATH (activate the fuse conda env first)" >&2
+    exit 1
+fi
+
+"${PYTHON}" - <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path("FuseExamples/fluxmatcher.ipynb")
+nb = json.loads(path.read_text())
+if len(nb["cells"]) < 2:
+    sys.exit("fluxmatcher.ipynb must have at least 2 cells")
+if nb["cells"][0]["cell_type"] != "code":
+    sys.exit("Cell 0 must be a code cell")
+if nb["cells"][1]["cell_type"] != "markdown":
+    sys.exit("Cell 1 must be a markdown cell")
+text = "".join(nb["cells"][1].get("source", [])).lower()
+if "flux-matcher" not in text and "flux matcher" not in text:
+    sys.exit("Cell 1 markdown does not mention flux-matcher")
+print("[verify_fluxmatcher] Cell 1 (markdown) present")
+PY
+
+julia "${SCRIPT_DIR}/verify_fluxmatcher_notebook.jl"
+log "fluxmatcher.ipynb cells 0–1 verification PASSED"


### PR DESCRIPTION
This pull request introduces a new, streamlined one-command installation system for FUSE, supporting both laptop (Linux/macOS) and NERSC environments. It adds robust, automated install scripts, verification tools, and documentation updates to make onboarding much easier for new users. The main changes are the addition of portable shell and Julia scripts to set up Julia, FUSE, conda, fusebot, JupyterLab, and example notebooks, along with clear documentation and verification steps.