### PR TITLE
Extend laptop install past conda env

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,3 @@
+{
+  "install": "export PATH=\"$HOME/.juliaup/bin:$PATH\"\njuliaup update 2>/dev/null || true\njulia --project=@. -e 'using Pkg; Pkg.Registry.update(); Pkg.resolve(); Pkg.instantiate(); Pkg.precompile()' 2>&1"
+}

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -4,7 +4,7 @@ This guide walks you through setting up everything you need to run FUSE: the **J
 
 ## One-command install
 
-These scripts install FUSE, Revise, fusebot, the Jupyter stack (`fuse` conda env), IJulia kernels, and clone [`FuseExamples`](https://github.com/ProjectTorreyPines/FuseExamples). Everything runs from the shell — no Julia REPL.
+These scripts install FUSE, Revise, fusebot, the Jupyter stack (`fuse` conda env), IJulia kernels, and clone [`FuseExamples`](https://github.com/ProjectTorreyPines/FuseExamples).
 
 They then activate the `fuse` env, run `fusebot install_IJulia` (or `make install_IJulia` / `scripts/install_ijulia.sh` if fusebot fails), and finish by executing the **first three cells** of `FuseExamples/fluxmatcher.ipynb`. A fresh install typically takes **20–40 minutes** (Julia packages + conda + IJulia + the first flux-matcher solve; the notebook cells are often ~6 minutes on one thread).
 
@@ -23,7 +23,7 @@ Skip the notebook solve with `FUSE_SKIP_VERIFY=1 bash scripts/install_fuse_lapto
 
 ### NERSC (Perlmutter)
 
-From a login node (run the depot symlink under [Home quota / memory pressure](@ref nersc-home-quota) first if `$HOME` is tight). Loads `julia/1.11.7` and `conda` by default, then continues through IJulia, `FuseExamples`, and the fluxmatcher cells (fine on a login node — typically ~6 minutes on one thread for the notebook solve).
+From a login node (run the depot symlink under [Home quota / memory pressure](@ref nersc-home-quota) first if `$HOME` is under memory pressure). Loads `julia/1.11.7` and `conda` by default, then continues through IJulia, `FuseExamples`, and the fluxmatcher cells (fine on a login node — typically ~6 minutes on one thread for the notebook solve).
 
 ```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/install_fuse_nersc.sh)

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -6,7 +6,7 @@ This guide walks you through setting up everything you need to run FUSE: the **J
 
 These scripts install FUSE, Revise, fusebot, the Jupyter stack (`fuse` conda env), IJulia kernels, and clone [`FuseExamples`](https://github.com/ProjectTorreyPines/FuseExamples). Everything runs from the shell — no Julia REPL.
 
-On a **laptop**, the script then activates the `fuse` env, runs `fusebot install_IJulia` (or `make install_IJulia` / `scripts/install_ijulia.sh` if fusebot fails), and finishes by executing the **first three cells** of `FuseExamples/fluxmatcher.ipynb`. A fresh laptop install typically takes **35–60+ minutes** (Julia packages + conda + IJulia + the first flux-matcher solve).
+On a **laptop**, the script then activates the `fuse` env, runs `fusebot install_IJulia` (or `make install_IJulia` / `scripts/install_ijulia.sh` if fusebot fails), and finishes by executing the **first three cells** of `FuseExamples/fluxmatcher.ipynb`. A fresh laptop install typically takes **20–40 minutes** (Julia packages + conda + IJulia + the first flux-matcher solve).
 
 ### Laptop (Linux or macOS)
 

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -4,7 +4,9 @@ This guide walks you through setting up everything you need to run FUSE: the **J
 
 ## One-command install
 
-These scripts install FUSE, Revise, fusebot, the Jupyter stack, IJulia kernels, and clone [`FuseExamples`](https://github.com/ProjectTorreyPines/FuseExamples). Everything runs from the shell — no Julia REPL. A fresh install typically takes **20–45 minutes** (Julia packages + conda environment + IJulia kernels).
+These scripts install FUSE, Revise, fusebot, the Jupyter stack (`fuse` conda env), IJulia kernels, and clone [`FuseExamples`](https://github.com/ProjectTorreyPines/FuseExamples). Everything runs from the shell — no Julia REPL.
+
+On a **laptop**, the script then activates the `fuse` env, runs `fusebot install_IJulia` (or `make install_IJulia` / `scripts/install_ijulia.sh` if fusebot fails), and finishes by executing the **first three cells** of `FuseExamples/fluxmatcher.ipynb`. A fresh laptop install typically takes **35–60+ minutes** (Julia packages + conda + IJulia + the first flux-matcher solve).
 
 ### Laptop (Linux or macOS)
 
@@ -17,9 +19,11 @@ bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/m
 
 From a local `FUSE.jl` clone: `bash scripts/install_fuse_laptop.sh`
 
+Skip the notebook solve with `FUSE_SKIP_VERIFY=1 bash scripts/install_fuse_laptop.sh` if you only want packages + kernels.
+
 ### NERSC (Perlmutter)
 
-From a login node (run the depot symlink under [Home quota / memory pressure](@ref nersc-home-quota) first if `$HOME` is tight). Loads `julia/1.11.7` and `conda` by default.
+From a login node (run the depot symlink under [Home quota / memory pressure](@ref nersc-home-quota) first if `$HOME` is tight). Loads `julia/1.11.7` and `conda` by default. NERSC stops after the smoke test; run the fluxmatcher verify command below as Step 2 (avoids a long solve on a login node).
 
 ```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/install_fuse_nersc.sh)
@@ -31,7 +35,7 @@ Override the Julia module with `FUSE_JULIA_MODULE=julia/1.12.0 bash scripts/inst
 
 ### Windows
 
-From any directory in **PowerShell**. Installs Julia via [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/) (Microsoft Store) or the Julia App Installer when `julia` is missing, and Miniconda when `conda` is missing.
+From any directory in **PowerShell**. Installs Julia via [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/) (Microsoft Store) or the Julia App Installer when `julia` is missing, and Miniconda when `conda` is missing. Like the laptop script, it finishes by running the first three `fluxmatcher.ipynb` cells unless you set `FUSE_SKIP_VERIFY=1`.
 
 ```powershell
 winget install julia -s msstore --accept-source-agreements --accept-package-agreements --disable-interactivity; `
@@ -42,13 +46,13 @@ From a local `FUSE.jl` clone: `.\scripts\install_fuse_windows.ps1`
 
 If `winget` is unavailable, install Julia with `Add-AppxPackage -AppInstallerFile https://install.julialang.org/Julia.appinstaller`, open a new terminal, then run the install script.
 
-### Step 2: verify `fluxmatcher.ipynb`
+### Verify `fluxmatcher.ipynb` (NERSC Step 2 / re-run)
 
-After the install finishes, confirm you can run the **first three cells** of [`FuseExamples/fluxmatcher.ipynb`](https://github.com/ProjectTorreyPines/FuseExamples/blob/master/fluxmatcher.ipynb):
+The laptop and Windows one-command installs already run the **first three cells** of [`FuseExamples/fluxmatcher.ipynb`](https://github.com/ProjectTorreyPines/FuseExamples/blob/master/fluxmatcher.ipynb). On NERSC — or to re-run after install — use:
 
 * **Cell 0** (code): `using Revise`, `using Plots`, `using FUSE`
 * **Cell 1** (markdown): flux-matcher introduction (checked for presence, not executed)
-* **Cell 2** (code): flux-matches the DIII-D L-mode case — this actually runs the flux-matcher, so allow **15+ minutes** on the first run (compilation plus the solve)
+* **Cell 2** (code): flux-matches the DIII-D L-mode case — allow **15+ minutes** on the first run (compilation plus the solve)
 
 **Linux, macOS, and NERSC:**
 

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -6,7 +6,7 @@ This guide walks you through setting up everything you need to run FUSE: the **J
 
 These scripts install FUSE, Revise, fusebot, the Jupyter stack (`fuse` conda env), IJulia kernels, and clone [`FuseExamples`](https://github.com/ProjectTorreyPines/FuseExamples). Everything runs from the shell — no Julia REPL.
 
-On a **laptop**, the script then activates the `fuse` env, runs `fusebot install_IJulia` (or `make install_IJulia` / `scripts/install_ijulia.sh` if fusebot fails), and finishes by executing the **first three cells** of `FuseExamples/fluxmatcher.ipynb`. A fresh laptop install typically takes **20–40 minutes** (Julia packages + conda + IJulia + the first flux-matcher solve).
+They then activate the `fuse` env, run `fusebot install_IJulia` (or `make install_IJulia` / `scripts/install_ijulia.sh` if fusebot fails), and finish by executing the **first three cells** of `FuseExamples/fluxmatcher.ipynb`. A fresh install typically takes **20–40 minutes** (Julia packages + conda + IJulia + the first flux-matcher solve; the notebook cells are often ~6 minutes on one thread).
 
 ### Laptop (Linux or macOS)
 
@@ -23,7 +23,7 @@ Skip the notebook solve with `FUSE_SKIP_VERIFY=1 bash scripts/install_fuse_lapto
 
 ### NERSC (Perlmutter)
 
-From a login node (run the depot symlink under [Home quota / memory pressure](@ref nersc-home-quota) first if `$HOME` is tight). Loads `julia/1.11.7` and `conda` by default. NERSC stops after the smoke test; run the fluxmatcher verify command below as Step 2 (avoids a long solve on a login node).
+From a login node (run the depot symlink under [Home quota / memory pressure](@ref nersc-home-quota) first if `$HOME` is tight). Loads `julia/1.11.7` and `conda` by default, then continues through IJulia, `FuseExamples`, and the fluxmatcher cells (fine on a login node — typically ~6 minutes on one thread for the notebook solve).
 
 ```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/install_fuse_nersc.sh)
@@ -31,11 +31,11 @@ bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/m
 
 From a local `FUSE.jl` clone: `bash scripts/install_fuse_nersc.sh`
 
-Override the Julia module with `FUSE_JULIA_MODULE=julia/1.12.0 bash scripts/install_fuse_nersc.sh` when needed. See [On NERSC (Perlmutter)](@ref nersc-install) for depot layout, `fusebot`, and Jupyter notes.
+Override the Julia module with `FUSE_JULIA_MODULE=julia/1.12.0 bash scripts/install_fuse_nersc.sh` when needed. Skip the notebook solve with `FUSE_SKIP_VERIFY=1` if desired. See [On NERSC (Perlmutter)](@ref nersc-install) for depot layout, `fusebot`, and Jupyter notes.
 
 ### Windows
 
-From any directory in **PowerShell**. Installs Julia via [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/) (Microsoft Store) or the Julia App Installer when `julia` is missing, and Miniconda when `conda` is missing. Like the laptop script, it finishes by running the first three `fluxmatcher.ipynb` cells unless you set `FUSE_SKIP_VERIFY=1`.
+From any directory in **PowerShell**. Installs Julia via [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/) (Microsoft Store) or the Julia App Installer when `julia` is missing, and Miniconda when `conda` is missing. Like the laptop and NERSC scripts, it finishes by running the first three `fluxmatcher.ipynb` cells unless you set `FUSE_SKIP_VERIFY=1`.
 
 ```powershell
 winget install julia -s msstore --accept-source-agreements --accept-package-agreements --disable-interactivity; `
@@ -46,13 +46,13 @@ From a local `FUSE.jl` clone: `.\scripts\install_fuse_windows.ps1`
 
 If `winget` is unavailable, install Julia with `Add-AppxPackage -AppInstallerFile https://install.julialang.org/Julia.appinstaller`, open a new terminal, then run the install script.
 
-### Verify `fluxmatcher.ipynb` (NERSC Step 2 / re-run)
+### Re-verify `fluxmatcher.ipynb`
 
-The laptop and Windows one-command installs already run the **first three cells** of [`FuseExamples/fluxmatcher.ipynb`](https://github.com/ProjectTorreyPines/FuseExamples/blob/master/fluxmatcher.ipynb). On NERSC — or to re-run after install — use:
+The one-command installs already run the **first three cells** of [`FuseExamples/fluxmatcher.ipynb`](https://github.com/ProjectTorreyPines/FuseExamples/blob/master/fluxmatcher.ipynb). To re-run them later:
 
 * **Cell 0** (code): `using Revise`, `using Plots`, `using FUSE`
 * **Cell 1** (markdown): flux-matcher introduction (checked for presence, not executed)
-* **Cell 2** (code): flux-matches the DIII-D L-mode case — allow **15+ minutes** on the first run (compilation plus the solve)
+* **Cell 2** (code): flux-matches the DIII-D L-mode case — often ~6 minutes on one thread the first time (compilation plus the solve)
 
 **Linux, macOS, and NERSC:**
 

--- a/docs/src/install_nersc.md
+++ b/docs/src/install_nersc.md
@@ -6,7 +6,7 @@ For the pre-built `module load fuse` environment maintained by the FUSE team, se
 
 ## NERSC one-command install
 
-From a login node (run the depot symlink under [Home quota / memory pressure](@ref nersc-home-quota) first if `$HOME` is tight). Loads `julia/1.11.7` and `conda`, installs FUSE, Revise, fusebot (under `~/.local/bin` or `~/.local/shared/bin` if `bin` is not writable), the Jupyter conda environment, IJulia kernels, clones [`FuseExamples`](https://github.com/ProjectTorreyPines/FuseExamples), and finishes by running the **first three cells** of `fluxmatcher.ipynb` (typically ~6 minutes on one thread — fine on a login node). All steps run from the shell — no Julia REPL.
+From a login node (run the depot symlink under [Home quota / memory pressure](@ref nersc-home-quota) first if `$HOME` is under memory pressure). Loads `julia/1.11.7` and `conda`, installs FUSE, Revise, fusebot (under `~/.local/bin` or `~/.local/shared/bin` if `bin` is not writable), the Jupyter conda environment, IJulia kernels, clones [`FuseExamples`](https://github.com/ProjectTorreyPines/FuseExamples), and finishes by running the **first three cells** of `fluxmatcher.ipynb`.
 
 ```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/install_fuse_nersc.sh)
@@ -127,7 +127,7 @@ That environment includes sysimage-accelerated `fuse` and `julia` wrappers and p
 
 ### [Home quota / memory pressure](@id nersc-home-quota)
 
-If your home directory is tight on space or inode quota, keep the full Julia depot off `$HOME` by
+If your home directory is under memory or inode pressure, keep the full Julia depot off `$HOME` by
 symlinking `~/.julia` to `$PSCRATCH`:
 
 ```bash

--- a/docs/src/install_nersc.md
+++ b/docs/src/install_nersc.md
@@ -6,7 +6,7 @@ For the pre-built `module load fuse` environment maintained by the FUSE team, se
 
 ## NERSC one-command install
 
-From a login node (run the depot symlink under [Home quota / memory pressure](@ref nersc-home-quota) first if `$HOME` is tight). Loads `julia/1.11.7` and `conda`, installs FUSE, Revise, fusebot (under `~/.local/bin` or `~/.local/shared/bin` if `bin` is not writable), the Jupyter conda environment, IJulia kernels, and clones [`FuseExamples`](https://github.com/ProjectTorreyPines/FuseExamples). All steps run from the shell — no Julia REPL.
+From a login node (run the depot symlink under [Home quota / memory pressure](@ref nersc-home-quota) first if `$HOME` is tight). Loads `julia/1.11.7` and `conda`, installs FUSE, Revise, fusebot (under `~/.local/bin` or `~/.local/shared/bin` if `bin` is not writable), the Jupyter conda environment, IJulia kernels, clones [`FuseExamples`](https://github.com/ProjectTorreyPines/FuseExamples), and finishes by running the **first three cells** of `fluxmatcher.ipynb` (typically ~6 minutes on one thread — fine on a login node). All steps run from the shell — no Julia REPL.
 
 ```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/install_fuse_nersc.sh)
@@ -14,22 +14,11 @@ bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/m
 
 From a local `FUSE.jl` clone: `bash scripts/install_fuse_nersc.sh`
 
-Override the Julia module with `FUSE_JULIA_MODULE=julia/1.12.0 bash scripts/install_fuse_nersc.sh` when needed.
+Override the Julia module with `FUSE_JULIA_MODULE=julia/1.12.0 bash scripts/install_fuse_nersc.sh` when needed. Skip the notebook solve with `FUSE_SKIP_VERIFY=1` if you only want packages + kernels.
 
 If `fusebot` cannot be installed or `fusebot install_IJulia` fails (for example when `make` is missing), the script falls back to `make install_IJulia` and then to `scripts/install_ijulia.sh` from the FUSE package directory.
 
-### Step 2: verify `fluxmatcher.ipynb`
-
-Runs the **first three cells** of `FuseExamples/fluxmatcher.ipynb` — **cell 0** (`using Revise`, `using Plots`, `using FUSE`), **cell 1** (markdown, checked for presence), and **cell 2**, which flux-matches the DIII-D L-mode case (allow **15+ minutes** on the first run):
-
-```bash
-module load julia/1.11.7
-bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/verify_fluxmatcher_notebook.sh)
-```
-
-Or from a `FUSE.jl` clone: `bash scripts/verify_fluxmatcher_notebook.sh`
-
-Then start JupyterLab (with `module load conda` and `conda activate fuse`) and open `FuseExamples/fluxmatcher.ipynb`.
+Then start JupyterLab (with `module load conda` and `conda activate fuse`) and open `FuseExamples/fluxmatcher.ipynb`. To re-run the notebook cells from the shell later: `bash scripts/verify_fluxmatcher_notebook.sh`.
 
 ## Julia
 

--- a/docs/src/install_nersc.md
+++ b/docs/src/install_nersc.md
@@ -16,7 +16,7 @@ From a local `FUSE.jl` clone: `bash scripts/install_fuse_nersc.sh`
 
 Override the Julia module with `FUSE_JULIA_MODULE=julia/1.12.0 bash scripts/install_fuse_nersc.sh` when needed.
 
-If `fusebot` cannot be installed (for example when `~/.local/bin` does not exist), the script runs the same underlying `make` targets (`install_IJulia`, `install_examples`, …) directly from the FUSE package directory.
+If `fusebot` cannot be installed or `fusebot install_IJulia` fails (for example when `make` is missing), the script falls back to `make install_IJulia` and then to `scripts/install_ijulia.sh` from the FUSE package directory.
 
 ### Step 2: verify `fluxmatcher.ipynb`
 

--- a/scripts/install_fuse_common.sh
+++ b/scripts/install_fuse_common.sh
@@ -215,18 +215,47 @@ install_fusebot_cli() {
     fi
 }
 
+resolve_fuse_script() {
+    local name="$1"
+    if [[ -f "${SCRIPT_DIR}/${name}" ]]; then
+        echo "${SCRIPT_DIR}/${name}"
+        return 0
+    fi
+    local from_pkg=""
+    if from_pkg="$(julia -e "using FUSE; print(joinpath(pkgdir(FUSE), \"scripts\", \"${name}\"))" 2>/dev/null)" \
+        && [[ -n "${from_pkg}" && -f "${from_pkg}" ]]; then
+        echo "${from_pkg}"
+        return 0
+    fi
+    # Last resort for curl-bootstrap / older registry packages.
+    local base_url="${FUSE_SCRIPT_BASE_URL:-https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts}"
+    local bundle_dir="${TMPDIR:-/tmp}/fuse-install-scripts-$$"
+    mkdir -p "${bundle_dir}"
+    curl -fsSL "${base_url}/${name}" -o "${bundle_dir}/${name}"
+    if [[ "${name}" == *.sh ]]; then
+        local companion="${name%.sh}.jl"
+        curl -fsSL "${base_url}/${companion}" -o "${bundle_dir}/${companion}" 2>/dev/null || true
+    fi
+    [[ -f "${bundle_dir}/${name}" ]] || die "Could not locate scripts/${name}"
+    echo "${bundle_dir}/${name}"
+}
+
 run_fusebot_or_make() {
     local target="$1"
     shift || true
     if command -v fusebot >/dev/null 2>&1; then
         log "fusebot ${target} $*"
-        fusebot "${target}" "$@"
-        return 0
+        if fusebot "${target}" "$@"; then
+            return 0
+        fi
+        log "fusebot ${target} failed — falling back to make"
+    else
+        log "fusebot not on PATH — falling back to make"
     fi
 
     local fuse_dir
     fuse_dir="$(fuse_pkg_dir)"
-    log "fusebot not on PATH — running make ${target} in ${fuse_dir}"
+    log "Running make ${target} in ${fuse_dir}"
     (
         cd "${fuse_dir}"
         export PTP_ORIGINAL_DIR="${INSTALL_DIR}"
@@ -235,7 +264,36 @@ run_fusebot_or_make() {
 }
 
 install_ijulia_kernels() {
-    run_fusebot_or_make install_IJulia
+    # fusebot → make → direct install_ijulia.sh (no make required).
+    # Keeps going when fusebot is missing/broken or make is not installed.
+    if command -v fusebot >/dev/null 2>&1; then
+        log "fusebot install_IJulia"
+        if fusebot install_IJulia; then
+            return 0
+        fi
+        log "fusebot install_IJulia failed — trying make / direct install"
+    else
+        log "fusebot not on PATH — trying make / direct install"
+    fi
+
+    local fuse_dir
+    fuse_dir="$(fuse_pkg_dir)"
+
+    if command -v make >/dev/null 2>&1; then
+        log "make install_IJulia in ${fuse_dir}"
+        if (
+            cd "${fuse_dir}"
+            export PTP_ORIGINAL_DIR="${INSTALL_DIR}"
+            make install_IJulia
+        ); then
+            return 0
+        fi
+        log "make install_IJulia failed — running scripts/install_ijulia.sh directly"
+    else
+        log "make not found — running scripts/install_ijulia.sh directly"
+    fi
+
+    bash "${fuse_dir}/scripts/install_ijulia.sh"
 }
 
 clone_fuse_examples() {
@@ -248,6 +306,17 @@ clone_fuse_examples() {
         log "Cloning FuseExamples into ${INSTALL_DIR}"
         git clone https://github.com/ProjectTorreyPines/FuseExamples.git
     fi
+}
+
+verify_fluxmatcher_notebook() {
+    local verify_sh
+    verify_sh="$(resolve_fuse_script verify_fluxmatcher_notebook.sh)"
+    log "Verifying fluxmatcher.ipynb cells 0–2 (cell 2 can take 15+ minutes on first run)"
+    # Cell extraction needs Python from the fuse env.
+    if ! command -v python >/dev/null 2>&1; then
+        ensure_fuse_conda_env
+    fi
+    FUSE_WORK_DIR="${INSTALL_DIR}" bash "${verify_sh}"
 }
 
 run_julia_install() {
@@ -271,20 +340,33 @@ install_fuse_stack() {
     clone_fuse_examples
     run_julia_install smoke
 
-    log "FUSE install complete."
-    log "Step 2 — verify fluxmatcher.ipynb cells 0–2:"
-    log "  bash ${SCRIPT_DIR}/verify_fluxmatcher_notebook.sh"
+    if [[ "${FUSE_SKIP_VERIFY:-0}" == "1" ]]; then
+        export FUSE_VERIFY_FLUXMATCHER=false
+    fi
+
+    if [[ "${FUSE_VERIFY_FLUXMATCHER:-false}" == "true" ]]; then
+        verify_fluxmatcher_notebook
+        log "FUSE install complete (including fluxmatcher.ipynb cells 0–2)."
+    else
+        log "FUSE install complete."
+        log "Step 2 — verify fluxmatcher.ipynb cells 0–2:"
+        log "  bash $(resolve_fuse_script verify_fluxmatcher_notebook.sh)"
+    fi
 }
 
 platform="${1:-}"
 case "${platform}" in
     laptop)
         export FUSE_SETUP_SHELL="${FUSE_SETUP_SHELL:-false}"
+        # Laptop one-command install finishes by running fluxmatcher cells 0–2.
+        export FUSE_VERIFY_FLUXMATCHER="${FUSE_VERIFY_FLUXMATCHER:-true}"
         ensure_juliaup
         install_fuse_stack
         ;;
     nersc)
         export FUSE_SETUP_SHELL="${FUSE_SETUP_SHELL:-true}"
+        # Keep the long flux-matcher solve as an explicit Step 2 on login nodes.
+        export FUSE_VERIFY_FLUXMATCHER="${FUSE_VERIFY_FLUXMATCHER:-false}"
         load_nersc_modules
         install_fuse_stack
         ;;

--- a/scripts/install_fuse_common.sh
+++ b/scripts/install_fuse_common.sh
@@ -312,7 +312,7 @@ clone_fuse_examples() {
 verify_fluxmatcher_notebook() {
     local verify_sh
     verify_sh="$(resolve_fuse_script verify_fluxmatcher_notebook.sh)"
-    log "Verifying fluxmatcher.ipynb cells 0–2 (cell 2 can take 15+ minutes on first run)"
+    log "Verifying fluxmatcher.ipynb cells 0–2 (often ~6 minutes on one thread the first time)"
     # Cell extraction needs Python from the fuse env.
     if ! command -v python >/dev/null 2>&1; then
         ensure_fuse_conda_env
@@ -366,8 +366,8 @@ case "${platform}" in
         ;;
     nersc)
         export FUSE_SETUP_SHELL="${FUSE_SETUP_SHELL:-true}"
-        # Keep the long flux-matcher solve as an explicit Step 2 on login nodes.
-        export FUSE_VERIFY_FLUXMATCHER="${FUSE_VERIFY_FLUXMATCHER:-false}"
+        # Same finish as laptop: fluxmatcher cells 0–2 (~6 minutes on 1 thread is fine on a login node).
+        export FUSE_VERIFY_FLUXMATCHER="${FUSE_VERIFY_FLUXMATCHER:-true}"
         load_nersc_modules
         install_fuse_stack
         ;;

--- a/scripts/install_fuse_common.sh
+++ b/scripts/install_fuse_common.sh
@@ -80,7 +80,8 @@ install_miniconda() {
     cat > "${helper}" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
-tmp="\$(mktemp)"
+# Constructor installers require the filename to end in ".sh" (they check \$0).
+tmp="\$(mktemp "\${TMPDIR:-/tmp}/miniconda-installer-XXXXXX.sh")"
 curl -fsSL "${installer}" -o "\${tmp}"
 bash "\${tmp}" -b -p "${MINICONDA_DIR}"
 rm -f "\${tmp}"

--- a/scripts/install_fuse_laptop.sh
+++ b/scripts/install_fuse_laptop.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # One-shot FUSE install for laptops (juliaup + Miniconda if needed).
 #
+# After creating the fuse conda env this activates it, runs
+# fusebot install_IJulia (with make / install_ijulia.sh fallbacks), clones
+# FuseExamples, and runs the first three cells of fluxmatcher.ipynb.
+# Set FUSE_SKIP_VERIFY=1 to skip the notebook solve.
+#
 # Copy-paste (from any working directory):
 #   curl -fsSL https://install.julialang.org | sh -s -- -y && \
 #   bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/install_fuse_laptop.sh)
@@ -22,7 +27,10 @@ resolve_script_dir() {
 
     local bundle_dir="${TMPDIR:-/tmp}/fuse-install-$$"
     mkdir -p "${bundle_dir}"
-    for file in install_fuse_common.sh install_fuse_julia.jl; do
+    # Include fluxmatcher verify scripts so the laptop install can finish by
+    # running cells 0–2 even when the registry FUSE package is older.
+    for file in install_fuse_common.sh install_fuse_julia.jl \
+                verify_fluxmatcher_notebook.sh verify_fluxmatcher_notebook.jl; do
         curl -fsSL "${SCRIPT_BASE_URL}/${file}" -o "${bundle_dir}/${file}"
     done
     echo "${bundle_dir}"

--- a/scripts/install_fuse_laptop.sh
+++ b/scripts/install_fuse_laptop.sh
@@ -15,7 +15,19 @@
 
 set -euo pipefail
 
+# Companions are fetched from the same scripts/ directory as this file's
+# published URL. Override with FUSE_SCRIPT_BASE_URL. Default matches the
+# documented one-command install (ProjectTorreyPines/master).
 SCRIPT_BASE_URL="${FUSE_SCRIPT_BASE_URL:-https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts}"
+
+# If the caller passed this script's own raw URL as $1 (optional), derive the
+# companion base from it so a single curl to any fork/branch stays self-contained:
+#   u=https://raw.githubusercontent.com/ORG/FUSE.jl/REF/scripts/install_fuse_laptop.sh
+#   bash <(curl -fsSL "$u") "$u"
+if [[ "${1:-}" == http://* || "${1:-}" == https://* ]]; then
+    SCRIPT_BASE_URL="${FUSE_SCRIPT_BASE_URL:-${1%/*}}"
+    shift
+fi
 
 resolve_script_dir() {
     local self_dir
@@ -37,4 +49,4 @@ resolve_script_dir() {
 }
 
 SCRIPT_DIR="$(resolve_script_dir)"
-exec bash "${SCRIPT_DIR}/install_fuse_common.sh" laptop
+exec bash "${SCRIPT_DIR}/install_fuse_common.sh" laptop "$@"

--- a/scripts/install_fuse_nersc.sh
+++ b/scripts/install_fuse_nersc.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # One-shot FUSE install for NERSC Perlmutter login nodes.
 #
+# After creating the fuse conda env this activates it, runs
+# fusebot install_IJulia (with make / install_ijulia.sh fallbacks), clones
+# FuseExamples, and runs the first three cells of fluxmatcher.ipynb
+# (~6 minutes on 1 thread — fine on a login node).
+# Set FUSE_SKIP_VERIFY=1 to skip the notebook solve.
+#
 # Copy-paste (from any working directory, e.g. $HOME or $PSCRATCH):
 #   bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/install_fuse_nersc.sh)
 #
@@ -15,6 +21,15 @@ set -euo pipefail
 
 SCRIPT_BASE_URL="${FUSE_SCRIPT_BASE_URL:-https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts}"
 
+# If the caller passed this script's own raw URL as $1 (optional), derive the
+# companion base from it so a single curl to any fork/branch stays self-contained:
+#   u=https://raw.githubusercontent.com/ORG/FUSE.jl/REF/scripts/install_fuse_nersc.sh
+#   bash <(curl -fsSL "$u") "$u"
+if [[ "${1:-}" == http://* || "${1:-}" == https://* ]]; then
+    SCRIPT_BASE_URL="${FUSE_SCRIPT_BASE_URL:-${1%/*}}"
+    shift
+fi
+
 resolve_script_dir() {
     local self_dir
     self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -25,11 +40,12 @@ resolve_script_dir() {
 
     local bundle_dir="${TMPDIR:-/tmp}/fuse-install-$$"
     mkdir -p "${bundle_dir}"
-    for file in install_fuse_common.sh install_fuse_julia.jl; do
+    for file in install_fuse_common.sh install_fuse_julia.jl \
+                verify_fluxmatcher_notebook.sh verify_fluxmatcher_notebook.jl; do
         curl -fsSL "${SCRIPT_BASE_URL}/${file}" -o "${bundle_dir}/${file}"
     done
     echo "${bundle_dir}"
 }
 
 SCRIPT_DIR="$(resolve_script_dir)"
-exec bash "${SCRIPT_DIR}/install_fuse_common.sh" nersc
+exec bash "${SCRIPT_DIR}/install_fuse_common.sh" nersc "$@"

--- a/scripts/install_fuse_windows.ps1
+++ b/scripts/install_fuse_windows.ps1
@@ -366,7 +366,7 @@ function Resolve-FuseScript {
 
 function Verify-FluxmatcherNotebook {
     $verifyPs1 = Resolve-FuseScript "verify_fluxmatcher_notebook.ps1"
-    Write-InstallLog "Verifying fluxmatcher.ipynb cells 0–2 (cell 2 can take 15+ minutes on first run)"
+    Write-InstallLog "Verifying fluxmatcher.ipynb cells 0–2 (often ~6 minutes on one thread the first time)"
     if (-not (Test-Command python)) {
         Ensure-FuseCondaEnv
     }

--- a/scripts/install_fuse_windows.ps1
+++ b/scripts/install_fuse_windows.ps1
@@ -1,5 +1,10 @@
 # One-shot FUSE install for Windows laptops (juliaup + Miniconda if needed).
 #
+# After creating the fuse conda env this activates it, runs
+# fusebot install_IJulia (with make / install_ijulia_kernels.jl fallbacks),
+# clones FuseExamples, and runs the first three cells of fluxmatcher.ipynb.
+# Set FUSE_SKIP_VERIFY=1 to skip the notebook solve.
+#
 # Copy-paste (PowerShell, from any working directory):
 #   winget install julia -s msstore --accept-source-agreements --accept-package-agreements --disable-interactivity; `
 #   irm https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts/install_fuse_windows.ps1 | iex
@@ -270,15 +275,22 @@ function Invoke-FusebotOrMake {
     if (Test-Command fusebot) {
         Write-InstallLog "fusebot $Target $($ExtraArgs -join ' ')"
         & fusebot $Target @ExtraArgs
-        return
+        if ($LASTEXITCODE -eq 0) { return }
+        Write-InstallLog "fusebot $Target failed — falling back to make"
+    }
+    else {
+        Write-InstallLog "fusebot not on PATH — falling back to make"
     }
 
     $fuseDir = Get-FusePkgDir
-    Write-InstallLog "fusebot not on PATH — running make $Target in $fuseDir"
+    Write-InstallLog "Running make $Target in $fuseDir"
     Push-Location $fuseDir
     try {
         $env:PTP_ORIGINAL_DIR = $InstallDir
         & make $Target @ExtraArgs
+        if ($LASTEXITCODE -ne 0) {
+            Write-InstallError "make $Target failed"
+        }
     }
     finally {
         Pop-Location
@@ -286,7 +298,46 @@ function Invoke-FusebotOrMake {
 }
 
 function Install-IJuliaKernels {
-    Invoke-FusebotOrMake install_IJulia
+    # fusebot → make → direct install_ijulia_kernels.jl (no make required).
+    if (Test-Command fusebot) {
+        Write-InstallLog "fusebot install_IJulia"
+        & fusebot install_IJulia
+        if ($LASTEXITCODE -eq 0) { return }
+        Write-InstallLog "fusebot install_IJulia failed — trying make / direct install"
+    }
+    else {
+        Write-InstallLog "fusebot not on PATH — trying make / direct install"
+    }
+
+    $fuseDir = Get-FusePkgDir
+    if (Test-Command make) {
+        Write-InstallLog "make install_IJulia in $fuseDir"
+        Push-Location $fuseDir
+        try {
+            $env:PTP_ORIGINAL_DIR = $InstallDir
+            & make install_IJulia
+            if ($LASTEXITCODE -eq 0) { return }
+        }
+        finally {
+            Pop-Location
+        }
+        Write-InstallLog "make install_IJulia failed — running install_ijulia_kernels.jl directly"
+    }
+    else {
+        Write-InstallLog "make not found — running install_ijulia_kernels.jl directly"
+    }
+
+    $kernelScript = Join-Path $fuseDir "scripts\install_ijulia_kernels.jl"
+    & julia $kernelScript
+    if ($LASTEXITCODE -ne 0) {
+        Write-InstallError "Direct IJulia kernel install failed"
+    }
+    try {
+        python -m pip install --upgrade webio_jupyter_extension
+    }
+    catch {
+        Write-InstallLog "WARNING: could not install webio_jupyter_extension"
+    }
 }
 
 function Clone-FuseExamples {
@@ -300,6 +351,29 @@ function Clone-FuseExamples {
     else {
         Write-InstallLog "Cloning FuseExamples into $InstallDir"
         git clone https://github.com/ProjectTorreyPines/FuseExamples.git
+    }
+}
+
+function Resolve-FuseScript {
+    param([Parameter(Mandatory = $true)][string]$Name)
+    $local = Join-Path $ScriptDir $Name
+    if (Test-Path $local) { return $local }
+    $fuseDir = Get-FusePkgDir
+    $fromPkg = Join-Path $fuseDir "scripts\$Name"
+    if (Test-Path $fromPkg) { return $fromPkg }
+    Write-InstallError "Could not locate scripts/$Name"
+}
+
+function Verify-FluxmatcherNotebook {
+    $verifyPs1 = Resolve-FuseScript "verify_fluxmatcher_notebook.ps1"
+    Write-InstallLog "Verifying fluxmatcher.ipynb cells 0–2 (cell 2 can take 15+ minutes on first run)"
+    if (-not (Test-Command python)) {
+        Ensure-FuseCondaEnv
+    }
+    $env:FUSE_WORK_DIR = $InstallDir
+    & $verifyPs1
+    if ($LASTEXITCODE -ne 0) {
+        Write-InstallError "fluxmatcher.ipynb verification failed"
     }
 }
 
@@ -336,9 +410,25 @@ function Install-FuseStack {
         Write-InstallLog "Skipping smoke test (FUSE_SKIP_SMOKE=1)"
     }
 
-    Write-InstallLog "FUSE install complete."
-    Write-InstallLog "Step 2 — verify fluxmatcher.ipynb cells 0–2:"
-    Write-InstallLog "  .\scripts\verify_fluxmatcher_notebook.ps1"
+    $verify = if ($env:FUSE_SKIP_VERIFY -eq "1") {
+        "false"
+    }
+    elseif ($env:FUSE_VERIFY_FLUXMATCHER) {
+        $env:FUSE_VERIFY_FLUXMATCHER
+    }
+    else {
+        "true"
+    }
+
+    if ($verify -eq "true") {
+        Verify-FluxmatcherNotebook
+        Write-InstallLog "FUSE install complete (including fluxmatcher.ipynb cells 0–2)."
+    }
+    else {
+        Write-InstallLog "FUSE install complete."
+        Write-InstallLog "Step 2 — verify fluxmatcher.ipynb cells 0–2:"
+        Write-InstallLog "  $(Resolve-FuseScript 'verify_fluxmatcher_notebook.ps1')"
+    }
 }
 
 $env:FUSE_SETUP_SHELL = if ($env:FUSE_SETUP_SHELL) { $env:FUSE_SETUP_SHELL } else { "false" }

--- a/scripts/verify_fluxmatcher_notebook.jl
+++ b/scripts/verify_fluxmatcher_notebook.jl
@@ -19,7 +19,7 @@ cells_file = get(ENV, "FUSE_VERIFY_CELLS", "")
 
 if !isempty(cells_file) && isfile(cells_file)
     println("[verify_fluxmatcher] Running the first three cells (code cells 0 and 2; cell 1 is markdown)")
-    println("[verify_fluxmatcher] NOTE: cell 2 flux-matches a DIII-D L-mode case and can take 15+ minutes on first run")
+    println("[verify_fluxmatcher] NOTE: cell 2 flux-matches a DIII-D L-mode case (often ~6 minutes on one thread the first time)")
     flush(stdout)
     @time include(cells_file)
     println("[verify_fluxmatcher] First three cells passed")

--- a/scripts/verify_fluxmatcher_notebook.sh
+++ b/scripts/verify_fluxmatcher_notebook.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # Verify fluxmatcher.ipynb cells 0–2 from the command line.
-# On laptops this is the final step of the one-command install; on NERSC it is
-# still an explicit Step 2 after install_fuse_nersc.sh.
+# Also the final step of the laptop and NERSC one-command installs.
 #
 # Laptop:
 #   bash scripts/verify_fluxmatcher_notebook.sh

--- a/scripts/verify_fluxmatcher_notebook.sh
+++ b/scripts/verify_fluxmatcher_notebook.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Step 2 after install: verify fluxmatcher.ipynb cells 0–2 from the command line.
+# Verify fluxmatcher.ipynb cells 0–2 from the command line.
+# On laptops this is the final step of the one-command install; on NERSC it is
+# still an explicit Step 2 after install_fuse_nersc.sh.
 #
 # Laptop:
 #   bash scripts/verify_fluxmatcher_notebook.sh
@@ -9,7 +11,25 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_BASE_URL="${FUSE_SCRIPT_BASE_URL:-https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/scripts}"
+
+resolve_script_dir() {
+    local self_dir
+    self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [[ -f "${self_dir}/verify_fluxmatcher_notebook.jl" ]]; then
+        echo "${self_dir}"
+        return 0
+    fi
+
+    # curl | bash / process-substitution: download the Julia runner next to us.
+    local bundle_dir="${TMPDIR:-/tmp}/fuse-verify-$$"
+    mkdir -p "${bundle_dir}"
+    curl -fsSL "${SCRIPT_BASE_URL}/verify_fluxmatcher_notebook.jl" \
+        -o "${bundle_dir}/verify_fluxmatcher_notebook.jl"
+    echo "${bundle_dir}"
+}
+
+SCRIPT_DIR="$(resolve_script_dir)"
 
 log() { echo "[verify_fluxmatcher] $*"; }
 


### PR DESCRIPTION
The laptop one-command install was stopping (or failing) right after creating the `fuse` conda env. This change makes the post-conda path robust and completes the install end-to-end on **laptop, Windows, and NERSC**.

### One-command flow (after conda env create)

1. Activate the `fuse` env
2. Run `fusebot install_IJulia`, falling back to `make install_IJulia`, then to `scripts/install_ijulia.sh` / `install_ijulia_kernels.jl` if fusebot or make fails
3. Clone / update `FuseExamples`
4. Smoke test
5. Run the first three cells of `fluxmatcher.ipynb` (cells 0 & 2 code; cell 1 markdown checked) — typically ~6 minutes on one thread (fine on a NERSC login node)

### Fixes found during curl e2e

- **Miniconda bootstrap:** constructor installers require the downloaded filename to end in `.sh`
- **Curl branch bootstrap:** `bash <(curl -fsSL "$u") "$u"` derives companion script URLs from the same raw `scripts/` directory