### PR TITLE
Fix laptop install aborting with "PS1: unbound variable" at conda activate

### DIFF
--- a/scripts/install_fuse_common.sh
+++ b/scripts/install_fuse_common.sh
@@ -92,15 +92,28 @@ EOF
     [[ -x "${MINICONDA_DIR}/bin/conda" ]] || die "Miniconda install failed (conda not found at ${MINICONDA_DIR}/bin/conda)"
 }
 
+# conda's shell functions (activation, `shell.bash hook`, sourced conda.sh)
+# reference $PS1, which is unbound under `set -u` in a non-interactive shell.
+# Run them with nounset temporarily disabled so the install does not abort with
+# "PS1: unbound variable" (see conda/conda#3200).
+conda_activate() {
+    set +u
+    conda activate "$@"
+    set -u
+}
+
 activate_conda() {
   # shellcheck disable=SC1091
+    set +u
     if [[ -f "${MINICONDA_DIR}/etc/profile.d/conda.sh" ]]; then
         source "${MINICONDA_DIR}/etc/profile.d/conda.sh"
     elif command -v conda >/dev/null 2>&1; then
         eval "$("$(command -v conda)" shell.bash hook 2>/dev/null)" || true
     else
+        set -u
         die "conda is not available (install Miniconda or module load conda)"
     fi
+    set -u
 }
 
 bootstrap_conda_channels() {
@@ -166,7 +179,7 @@ ensure_fuse_conda_env() {
         log "Creating conda env '${CONDA_ENV_NAME}'"
         conda env create -f "${yml}"
     fi
-    conda activate "${CONDA_ENV_NAME}"
+    conda_activate "${CONDA_ENV_NAME}"
     log "Active Python: $(python -c 'import sys; print(sys.executable)')"
 }
 


### PR DESCRIPTION
## Problem

For older versions of conda, re-running the one-line laptop install script fails at the very end, right after the conda `fuse` env is created/updated:

```
/var/folders/.../fuse-install-27318/install_fuse_common.sh: line 154: PS1: unbound variable
```

## Root cause

`scripts/install_fuse_common.sh` runs under `set -euo pipefail` (i.e. `set -u` / `nounset`). conda's activation shell functions reference `$PS1`. In a non-interactive shell, `PS1` is unset, so `conda activate fuse` (and the sourced `conda.sh` / `shell.bash hook`) abort with `PS1: unbound variable`. This is a long-standing conda + `nounset` incompatibility (conda/conda#3200), which is fixed with modern versions of conda.

Reproduced exactly:

```
$ bash -c 'set -u; echo "${PS1}"'
bash: PS1: unbound variable
```

## Fix

Wrap conda's shell-function invocations with `nounset` temporarily disabled:

- Added a `conda_activate` helper that runs `conda activate` with `set +u` and restores `set -u` afterward.
- Guarded `activate_conda` (which sources `conda.sh` / evals `shell.bash hook`) the same way.
- Switched `ensure_fuse_conda_env` to call `conda_activate`.

`set -u` is restored immediately after each conda call, so the rest of the script keeps its strict unbound-variable checking.

## Testing

- `bash -n scripts/install_fuse_common.sh` passes.
- Simulated the failure with a mock `conda` whose activation function sets `PS1="(env) $PS1"` (same as real conda). Under `set -u`, calling `conda activate fuse` directly reproduces `PS1: unbound variable`; calling it through the new `conda_activate` wrapper succeeds, and `set -u` is confirmed still active afterward.
