### PR TITLE
Add FUSE container for omega, fix IJulia kernel launch

### DIFF
--- a/deploy/omega-container/README.md
+++ b/deploy/omega-container/README.md
@@ -1,0 +1,193 @@
+# FUSE in a Singularity container on GA's omega cluster
+
+This directory builds the same self-contained FUSE image as
+[`../perlmutter-container`](../perlmutter-container) (FUSE.jl, all
+ProjectTorreyPines packages, and a precompiled `sys_fuse.so` sysimage for
+fast startup) and ships it as a **Singularity SIF** — a single read-only file
+on `/fusion` that any omega node can run. The pipeline is:
+
+1. rootless `podman build` on a worker node (storage on node-local
+   `/local-scratch`, since NFS `$HOME` is slow and quota-bound for images),
+2. `podman save` → `singularity build` to a SIF,
+3. run everywhere with `singularity exec/run` (module `singularity/3.11.3`).
+
+The image is built from the shared
+[`Containerfile`](../perlmutter-container/Containerfile) with
+`--build-arg JULIA_CPU_TARGET="generic;cascadelake,...;znver2,..."` (same
+targets as the omega module deploy). The compute fleet is all AMD — EPYC 7502
+(znver2, unflagged nodes) and EPYC 7513 (znver3, feature flag `amd`), both of
+which run the znver2 clone — while the cascadelake target covers Intel
+login/head nodes and `generic` catches anything else.
+
+## Contents
+
+| File | Purpose |
+|------|---------|
+| `build.sh` | podman build → SIF export (uses `../perlmutter-container/Containerfile`). |
+| `install_kernel.sh` | Installs a Jupyter kernelspec wrapping `singularity exec`. |
+| `kernel.json.template` | Template for the kernelspec. |
+| `test_slurm.sbatch` | Smoke test as a Slurm job (submit per architecture). |
+| `test_kernel_headless.py` | Headless Jupyter-kernel smoke test via `jupyter_client`. |
+
+## Prerequisite: squashfuse (fast SIF startup)
+
+Omega's singularity install is unprivileged (no setuid starter) and the nodes
+have no `squashfuse`, so by default singularity **extracts** the SIF to a
+temporary sandbox on every run — minutes of overhead for an image this size.
+With `squashfuse` on `PATH` and the `--sif-fuse` flag, the SIF is FUSE-mounted
+directly and startup takes seconds.
+
+A shared build lives next to the published SIFs (`<sif-dir>/bin/squashfuse`);
+all scripts in this directory pick it up automatically. To (re)build it:
+
+```bash
+git clone https://github.com/vasi/squashfuse.git && cd squashfuse
+./autogen.sh && ./configure --prefix=<sif-dir> && make && make install
+```
+
+## 1. Build the image
+
+The build runs the FUSE test suite + tutorial as the sysimage precompile
+workload, so it is heavy (hours). Run it from an interactive allocation
+(`short` is capped at 30 min — use `medium`), or directly on an idle worker
+node. **podman storage is node-local**: run every step on the same node.
+
+```bash
+salloc -p medium -t 8:00:00 -c 16
+module load singularity/3.11.3
+
+cd <FUSE repo root>
+SIF_DIR=/fusion/ga/projects/ird/ptp/$USER/fuse_containers ./deploy/omega-container/build.sh
+```
+
+`build.sh` will:
+
+1. Resolve the image tag (`fuse:<version>`) from the latest FUSE.jl release
+   (override with `FUSE_ENVIRONMENT=v2.6.0`).
+2. `podman build` with omega's dual CPU target, storing images on
+   `/local-scratch/$USER` (no NFS, no persistent config).
+3. `podman save` → `singularity build` → `SIF_DIR/fuse_<version>.sif`
+   (default `SIF_DIR` is node-local `/local-scratch/$USER`; point it at a
+   `/fusion` path to make the SIF visible cluster-wide).
+
+## 2. Run the FUSE REPL
+
+```bash
+module load singularity/3.11.3
+export PATH=<sif-dir>/bin:$PATH   # squashfuse, see above
+
+singularity run --cleanenv --sif-fuse --bind /fusion <sif-dir>/fuse_<version>.sif
+```
+
+This launches a Julia REPL with the FUSE sysimage preloaded (via the
+in-image `fuse` wrapper — the container's entrypoint). Notes on flags:
+
+- `--cleanenv` keeps host Julia variables (`JULIA_PROJECT`,
+  `JULIA_DEPOT_PATH`, ... from the module-based workflow) out of the
+  container. Pass runtime knobs explicitly, e.g.
+  `--env JULIA_NUM_THREADS=8`.
+- `--bind /fusion` exposes the shared filesystems (`$HOME`, `/tmp`, and the
+  current directory are bound by default).
+- The SIF is fully read-only, and Julia package init **crashes** if it cannot
+  write logs/scratch to a depot. The `fuse` wrapper handles this: when the
+  baked depot is not writable it prepends `$HOME/.julia_fuse_container` as a
+  writable first depot. Always run through `fuse` (not bare `julia`), or set
+  `--env JULIA_DEPOT_PATH=$HOME/.julia_fuse_container:/opt/fuse/.julia`
+  yourself.
+
+> Use `singularity run` only for the bare interactive REPL. For one-liners and
+> scripts use `singularity exec ... <sif> fuse ...`: singularity `run`
+> re-word-splits its arguments (docker-CMD emulation `eval`s them), which
+> mangles quoted `-e '...'` code.
+
+Quick smoke test:
+
+```bash
+singularity exec --cleanenv --sif-fuse --bind /fusion <sif> \
+  fuse -e 'using FUSE; ini,act=FUSE.case_parameters(:D3D,:L_mode); println("FUSE OK: ", pkgversion(FUSE))'
+```
+
+Offline/self-contained test (unprivileged singularity cannot drop the network
+like podman's `--network none`; `JULIA_PKG_OFFLINE` plus watching for
+`Downloading` lines is the omega equivalent):
+
+```bash
+singularity exec --cleanenv --sif-fuse --bind /fusion \
+  --env JULIA_PKG_OFFLINE=true <sif> \
+  fuse -e 'using FUSE; ini,act=FUSE.case_parameters(:D3D,:L_mode); dd=FUSE.init(ini,act); println("OFFLINE OK")'
+```
+
+## 3. Slurm jobs
+
+Use the same `singularity exec` line inside `sbatch`/`srun`. The provided
+test job validates the image on both compute-node generations:
+
+```bash
+SIF=<sif-dir>/fuse_<version>.sif
+sbatch --export=ALL,SIF=$SIF -C amd deploy/omega-container/test_slurm.sbatch
+sbatch --export=ALL,SIF=$SIF \
+       --exclude="$(sinfo -h -N -p short -o '%N %f' | awk '$2=="amd"{print $1}' | paste -sd,)" \
+       deploy/omega-container/test_slurm.sbatch
+```
+
+Each job should print the in-container sysimage path, a `using FUSE` time of
+seconds (not minutes), the node's `Sys.CPU_NAME` (`znver2` on both — the
+newer EPYC 7513 nodes also select the znver2 sysimage clone), and end with
+`SLURM SMOKE OK`.
+
+## 4. Interactive use via Jupyter
+
+```bash
+module load singularity/3.11.3
+SIF=<sif-dir>/fuse_<version>.sif ./deploy/omega-container/install_kernel.sh
+# optionally: THREADS=8 SIF=... ./install_kernel.sh
+```
+
+This writes `$HOME/.local/share/jupyter/kernels/fuse-<version>/kernel.json`,
+whose argv runs the in-container Julia via `singularity exec` (with the
+absolute singularity path baked in, since Jupyter cannot `module load`).
+Singularity's default `$HOME` bind makes the Jupyter connection file visible
+inside the container.
+
+Test it headless (uses `jupyter_client`, available in the omega FUSE conda
+environment — see [`docs/src/install_omega.md`](../../docs/src/install_omega.md)):
+
+```bash
+python3 deploy/omega-container/test_kernel_headless.py fuse-<version>
+```
+
+Expected: `KERNEL OK <version>` and `HEADLESS KERNEL TEST PASSED`. In a real
+Jupyter session (SSH-tunnel workflow from `install_omega.md`), select the
+**Julia FUSE-<version> container** kernel.
+
+> If your Jupyter writes connection files under `$XDG_RUNTIME_DIR` instead of
+> `$HOME/.local/share/jupyter/runtime`, set
+> `JUPYTER_RUNTIME_DIR=$HOME/.local/share/jupyter/runtime` before starting
+> Jupyter so the container can see them.
+
+## 5. Mounting data
+
+Singularity binds `$HOME`, `/tmp`, and the current directory by default; add
+`--bind /fusion` for the shared project areas. Bind anything else the same
+way:
+
+```bash
+singularity exec --cleanenv --sif-fuse --bind /fusion,/local-scratch <sif> ...
+```
+
+## 6. Publishing a shared image
+
+To make an image available to all FUSE users, copy the SIF (and the
+`bin/squashfuse` helper) into the group-owned containers area:
+
+```bash
+# requires membership in the 'julia' group
+mkdir -p /fusion/projects/codes/julia/fuse/containers/bin
+cp <sif-dir>/fuse_<version>.sif /fusion/projects/codes/julia/fuse/containers/
+cp <sif-dir>/bin/squashfuse     /fusion/projects/codes/julia/fuse/containers/bin/
+chmod a+rX -R /fusion/projects/codes/julia/fuse/containers
+```
+
+Users then run with
+`<containers>/fuse_<version>.sif` and get `squashfuse` from
+`<containers>/bin` automatically (all scripts here look next to the SIF).

--- a/deploy/omega-container/build.sh
+++ b/deploy/omega-container/build.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Build the FUSE container for GA's omega cluster and export it as a
+# Singularity SIF that runs on any omega node.
+#
+# Pipeline: rootless podman build (node-local storage) -> podman save ->
+# singularity build. The SIF is omega's analog of Perlmutter's
+# `podman-hpc migrate`: a single read-only file that can live on /fusion
+# and be executed anywhere via `singularity run/exec`.
+#
+# The sysimage build is heavy (runs the FUSE test suite + tutorial, several
+# hours), so prefer an interactive allocation. NOTE: omega's `short` partition
+# is capped at 30 min — use medium/long:
+#
+#   salloc -p medium -t 8:00:00 -c 16
+#   module load singularity/3.11.3
+#   ./deploy/omega-container/build.sh
+#
+# Override the image tag (defaults to the latest FUSE.jl release):
+#   FUSE_ENVIRONMENT=v2.6.0 ./deploy/omega-container/build.sh
+#
+# Write the SIF to shared storage (instead of node-local /local-scratch),
+# so it is visible from every omega node:
+#   SIF_DIR=/fusion/ga/projects/ird/ptp/$USER/fuse_containers ./build.sh
+#
+# Optional:
+#   PODMAN_CLEANUP=1  wipe the node-local podman store afterwards (default:
+#                     keep it, so rebuilds reuse cached layers)
+
+set -euo pipefail
+
+scriptdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# FUSE repo root == build context (Containerfile copies the Makefile from here)
+repo_root="$(cd "$scriptdir/../.." && pwd)"
+
+# CPU targets baked into the sysimage: omega mixes Intel cascadelake and AMD
+# znver2 (EPYC 7502) nodes. Mirrors deploy/omega/deploy.sh.
+omega_cpu_target="generic;cascadelake,-xsaveopt,-rdrnd,clone_all;znver2,-xsaveopt,-rdrnd,clone_all"
+
+# Resolve the image tag: explicit override, else latest GitHub release name.
+if [[ -n "${FUSE_ENVIRONMENT:-}" ]]; then
+    version="$FUSE_ENVIRONMENT"
+else
+    version="$(curl -s https://api.github.com/repos/ProjectTorreyPines/FUSE.jl/releases/latest | jq -r .name)"
+fi
+if [[ -z "$version" || "$version" == "null" ]]; then
+    echo "ERROR: could not determine FUSE version (set FUSE_ENVIRONMENT)." >&2
+    exit 1
+fi
+
+image="fuse:$version"
+
+if ! command -v podman >/dev/null 2>&1; then
+    echo "ERROR: podman not found. Run this on an omega worker node." >&2
+    exit 1
+fi
+if ! command -v singularity >/dev/null 2>&1; then
+    echo "ERROR: singularity not found. Run 'module load singularity/3.11.3' first." >&2
+    exit 1
+fi
+
+if [[ -z "${SLURM_JOB_ID:-}" ]]; then
+    echo "WARNING: not inside a Slurm allocation. The sysimage build is heavy;" >&2
+    echo "         prefer 'salloc -p medium -t 8:00:00 -c 16' first ('short' is" >&2
+    echo "         capped at 30 min). podman storage is node-local: run every" >&2
+    echo "         step of this script on the same node." >&2
+fi
+
+# All container storage goes to node-local /local-scratch: the default podman
+# graphRoot and singularity cache sit in NFS $HOME, which is slow for image
+# overlays and eats quota. Per-invocation flags — no persistent config files.
+scratch="/local-scratch/$USER"
+mkdir -p "$scratch/podman-storage" "$scratch/podman-run" \
+         "$scratch/singularity-tmp" "$scratch/singularity-cache"
+podman=(podman --root "$scratch/podman-storage" --runroot "$scratch/podman-run")
+export SINGULARITY_TMPDIR="$scratch/singularity-tmp"
+export SINGULARITY_CACHEDIR="$scratch/singularity-cache"
+
+sif_dir="${SIF_DIR:-$scratch}"
+mkdir -p "$sif_dir"
+sif="$sif_dir/fuse_${version}.sif"
+
+echo "### Building $image (context: $repo_root, CPU target: $omega_cpu_target)"
+"${podman[@]}" build -t "$image" \
+    --build-arg JULIA_CPU_TARGET="$omega_cpu_target" \
+    -f "$scriptdir/../perlmutter-container/Containerfile" "$repo_root"
+
+echo "### Exporting $image -> $sif"
+tar="$scratch/fuse_${version}.tar"
+"${podman[@]}" save --format docker-archive -o "$tar" "localhost/$image"
+singularity build --force "$sif" "docker-archive://$tar"
+rm -f "$tar"
+chmod a+r "$sif"
+
+if [[ "${PODMAN_CLEANUP:-0}" == "1" ]]; then
+    echo "### Cleaning node-local podman store"
+    "${podman[@]}" system reset --force
+fi
+
+echo
+echo "### Done: $sif"
+if [[ "$sif_dir" == "$scratch" ]]; then
+    echo "NOTE: the SIF is on node-local /local-scratch — copy it to /fusion (or"
+    echo "      rebuild with SIF_DIR=...) so other nodes can use it."
+fi
+echo "Run the FUSE REPL with (put squashfuse on PATH for fast SIF mounting,"
+echo "see README.md):"
+echo "    singularity run --cleanenv --sif-fuse --bind /fusion $sif"
+echo "Install the Jupyter kernel with:"
+echo "    SIF=$sif ./deploy/omega-container/install_kernel.sh"

--- a/deploy/omega-container/install_kernel.sh
+++ b/deploy/omega-container/install_kernel.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Install a host-side Jupyter kernelspec that runs FUSE inside the Singularity
+# container on omega. Jupyter discovers kernels under
+# $HOME/.local/share/jupyter/kernels/. The kernel's argv wraps the in-container
+# Julia (with the FUSE sysimage) in `singularity exec`; singularity's default
+# binds ($HOME, /tmp) let the kernel reach the connection file, and
+# `--bind /fusion` exposes the shared filesystems.
+#
+# Run this AFTER ./build.sh has produced the SIF. Usage:
+#   module load singularity/3.11.3
+#   SIF=/fusion/.../fuse_v2.6.0.sif ./deploy/omega-container/install_kernel.sh
+#
+# Optional:
+#   THREADS=8  number of Julia threads the kernel starts with (default 1)
+#
+# Fast startup needs squashfuse on PATH so singularity can FUSE-mount the SIF
+# instead of extracting it (omega's singularity has no setuid starter). The
+# kernel looks for it in <dir-of-SIF>/bin first (the shared containers layout),
+# then falls back to whatever is on PATH at install time.
+
+set -euo pipefail
+
+scriptdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+: "${SIF:?set SIF=/path/to/fuse_<version>.sif}"
+if [[ ! -r "$SIF" ]]; then
+    echo "ERROR: SIF not found/readable: $SIF" >&2
+    exit 1
+fi
+threads="${THREADS:-1}"
+
+# Version for the kernel name: parse from the SIF filename (fuse_<version>.sif).
+version="$(basename "$SIF" .sif)"
+version="${version#fuse_}"
+
+if ! command -v singularity >/dev/null 2>&1; then
+    echo "ERROR: singularity not found. Run 'module load singularity/3.11.3' first." >&2
+    exit 1
+fi
+# Kernel argv cannot 'module load', so bake the absolute singularity path.
+singularity_bin="$(command -v singularity)"
+
+# Locate squashfuse for fast SIF mounting: next to the SIF, or on PATH.
+sif_fuse_flag="--sif-fuse"
+if [[ -x "$(dirname "$SIF")/bin/squashfuse" ]]; then
+    squashfuse_dir="$(dirname "$SIF")/bin"
+elif command -v squashfuse >/dev/null 2>&1; then
+    squashfuse_dir="$(dirname "$(command -v squashfuse)")"
+else
+    echo "WARNING: squashfuse not found — the kernel will extract the SIF on" >&2
+    echo "         every start (slow). Install squashfuse next to the SIF" >&2
+    echo "         (<dir-of-SIF>/bin/squashfuse) and re-run for fast startup." >&2
+    squashfuse_dir="/usr/bin"
+    sif_fuse_flag=""
+fi
+
+kernel_dir="$HOME/.local/share/jupyter/kernels/fuse-$version"
+mkdir -p "$kernel_dir"
+
+display="Julia FUSE-$version container ($threads thread(s))"
+
+sed -e "s|__SINGULARITY__|$singularity_bin|g" \
+    -e "s|__SQUASHFUSE_DIR__|$squashfuse_dir|g" \
+    -e "s|__SIF_FUSE__|$sif_fuse_flag|g" \
+    -e "s|__SIF__|$SIF|g" \
+    -e "s|__THREADS__|$threads|g" \
+    -e "s|__DISPLAY__|$display|g" \
+    "$scriptdir/kernel.json.template" > "$kernel_dir/kernel.json"
+
+echo
+echo "### Installed kernelspec at $kernel_dir/kernel.json"
+echo "Select the '$display' kernel in Jupyter (see docs/src/install_omega.md"
+echo "for the SSH-tunnel workflow), or test it headless with:"
+echo "    python3 $scriptdir/test_kernel_headless.py fuse-$version"

--- a/deploy/omega-container/kernel.json.template
+++ b/deploy/omega-container/kernel.json.template
@@ -1,0 +1,14 @@
+{
+  "argv": [
+    "/bin/bash",
+    "-c",
+    "export PATH=\"__SQUASHFUSE_DIR__:$PATH\"; exec \"__SINGULARITY__\" exec --cleanenv __SIF_FUSE__ --bind /fusion \"__SIF__\" fuse --threads=__THREADS__ -e 'import IJulia; IJulia.run_kernel()' \"$1\"",
+    "fuse-kernel",
+    "{connection_file}"
+  ],
+  "display_name": "__DISPLAY__",
+  "language": "julia",
+  "metadata": {
+    "debugger": true
+  }
+}

--- a/deploy/omega-container/test_kernel_headless.py
+++ b/deploy/omega-container/test_kernel_headless.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Headless test of the FUSE container Jupyter kernel (no browser/tunnel).
+
+Starts the kernelspec installed by install_kernel.sh through jupyter_client,
+runs a FUSE smoke cell, and checks the output. Usage:
+
+    python3 test_kernel_headless.py fuse-<version>
+
+Requires jupyter_client (available in the omega FUSE conda environment).
+"""
+
+import sys
+
+from jupyter_client.manager import KernelManager
+
+CODE = (
+    'using FUSE; '
+    'ini, act = FUSE.case_parameters(:D3D, :L_mode); '
+    'println("KERNEL OK ", pkgversion(FUSE))'
+)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__)
+        return 2
+    kernel_name = sys.argv[1]
+
+    km = KernelManager(kernel_name=kernel_name)
+    km.start_kernel()
+    kc = km.client()
+    kc.start_channels()
+    try:
+        print(f"waiting for kernel '{kernel_name}' to become ready ...")
+        kc.wait_for_ready(timeout=300)
+        print("kernel ready, executing smoke cell ...")
+        msg_id = kc.execute(CODE)
+        output = []
+        while True:
+            msg = kc.get_iopub_msg(timeout=600)
+            if msg["parent_header"].get("msg_id") != msg_id:
+                continue
+            msg_type = msg["msg_type"]
+            if msg_type == "stream":
+                output.append(msg["content"]["text"])
+            elif msg_type == "error":
+                print("\n".join(msg["content"]["traceback"]))
+                return 1
+            elif msg_type == "status" and msg["content"]["execution_state"] == "idle":
+                break
+        text = "".join(output)
+        print(text, end="")
+        if "KERNEL OK" not in text:
+            print("FAIL: expected 'KERNEL OK' in kernel output")
+            return 1
+        print("HEADLESS KERNEL TEST PASSED")
+        return 0
+    finally:
+        kc.stop_channels()
+        km.shutdown_kernel(now=False)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/omega-container/test_slurm.sbatch
+++ b/deploy/omega-container/test_slurm.sbatch
@@ -1,0 +1,54 @@
+#!/bin/bash
+#SBATCH --job-name=fuse-container-test
+#SBATCH --partition=short
+#SBATCH --time=0:25:00
+#SBATCH --nodes=1
+#SBATCH --cpus-per-task=8
+#SBATCH --output=fuse_container_test_%j.out
+#
+# Smoke-test the FUSE SIF inside a Slurm job. Submit once per node generation
+# to cover both CPU types in the omega compute fleet — all AMD: the 'amd'
+# feature flag marks the newer EPYC 7513 (znver3) nodes, the unflagged ones
+# are EPYC 7502 (znver2). (The sysimage's cascadelake target is kept for
+# Intel login/head nodes.)
+#
+#   sbatch --export=ALL,SIF=/fusion/.../fuse_v2.6.0.sif -C amd deploy/omega-container/test_slurm.sbatch
+#   sbatch --export=ALL,SIF=/fusion/.../fuse_v2.6.0.sif \
+#          --exclude="$(sinfo -h -N -p short -o '%N %f' | awk '$2=="amd"{print $1}' | paste -sd,)" \
+#          deploy/omega-container/test_slurm.sbatch
+#
+# Pass: prints the in-container sysimage path, `using FUSE` loads in seconds,
+# Sys.CPU_NAME reports znver2 (or znver3 nodes report znver2 — the closest
+# sysimage clone), ends with SLURM SMOKE OK.
+
+set -euo pipefail
+
+: "${SIF:?set SIF=/path/to/fuse_<version>.sif (sbatch --export=ALL,SIF=...)}"
+
+module load singularity/3.11.3
+
+# squashfuse (for fast SIF FUSE-mounting) lives next to the SIF in the shared
+# containers layout; fall back to extraction if absent.
+sif_fuse_flag="--sif-fuse"
+if [[ -x "$(dirname "$SIF")/bin/squashfuse" ]]; then
+    export PATH="$(dirname "$SIF")/bin:$PATH"
+elif ! command -v squashfuse >/dev/null 2>&1; then
+    echo "WARNING: squashfuse not found — falling back to SIF extraction (slow)"
+    sif_fuse_flag=""
+fi
+
+echo "node: $(hostname)"
+lscpu | grep 'Model name'
+
+# The in-image `fuse` wrapper runs julia with the sysimage and, on read-only
+# images like a SIF, prepends a writable $HOME depot (required — package init
+# crashes otherwise).
+singularity exec --cleanenv $sif_fuse_flag --bind /fusion \
+    "$SIF" \
+    fuse --threads="$SLURM_CPUS_PER_TASK" -e '
+        println("sysimage: ", unsafe_string(Base.JLOptions().image_file))
+        println("cpu: ", Sys.CPU_NAME, "  threads: ", Threads.nthreads())
+        @time using FUSE
+        ini, act = FUSE.case_parameters(:D3D, :L_mode)
+        dd = FUSE.init(ini, act)
+        println("SLURM SMOKE OK  FUSE ", pkgversion(FUSE))'

--- a/deploy/perlmutter-container/Containerfile
+++ b/deploy/perlmutter-container/Containerfile
@@ -11,6 +11,12 @@
 # bare names against registry.suse.com, so we pin Docker Hub explicitly.
 FROM docker.io/library/julia:1.11.7
 
+# CPU target(s) baked into the sysimage. The default matches Perlmutter's AMD
+# Milan nodes; other sites override at build time, e.g. omega (Intel
+# cascadelake + AMD znver2 nodes, see deploy/omega-container/build.sh):
+#   --build-arg JULIA_CPU_TARGET="generic;cascadelake,...;znver2,..."
+ARG JULIA_CPU_TARGET="generic;znver3,-xsaveopt,-rdrnd,clone_all"
+
 # --- system dependencies -----------------------------------------------------
 # git + CLI git is used by Pkg to clone the FuseRegistry packages; gcc is the
 # C compiler PackageCompiler invokes when building the system image.
@@ -35,14 +41,13 @@ RUN git config --system url."https://github.com/".insteadOf "git@github.com:" \
 # --- build-time Julia configuration ------------------------------------------
 # These mirror deploy/perlmutter/deploy.sh. JULIA_NUM_THREADS=1 is REQUIRED by
 # install_fuse_container.jl (PackageCompiler sysimage build asserts 1 thread).
-# The znver3 CPU target matches Perlmutter's AMD Milan login/compute/GPU nodes;
-# building the image on a Perlmutter node keeps the arch consistent.
+# JULIA_CPU_TARGET comes from the build ARG above (default: Perlmutter).
 ENV FUSE_INSTALL_DIR=/opt/fuse \
     JULIA_DEPOT_PATH=/opt/fuse/.julia \
     JULIA_PKG_USE_CLI_GIT=1 \
     JULIA_CC="gcc -O3" \
     JULIA_NUM_THREADS=1 \
-    JULIA_CPU_TARGET="generic;znver3,-xsaveopt,-rdrnd,clone_all"
+    JULIA_CPU_TARGET="${JULIA_CPU_TARGET}"
 
 # --- install FUSE + build the sysimage ---------------------------------------
 WORKDIR /opt/build
@@ -59,14 +64,27 @@ RUN julia /opt/build/install_fuse_container.jl
 # unset so users can choose (e.g. JULIA_NUM_THREADS=8) when they run the image.
 ENV JULIA_PROJECT=/opt/fuse \
     JULIA_DEPOT_PATH=/opt/fuse/.julia \
-    JULIA_CPU_TARGET="generic;znver3,-xsaveopt,-rdrnd,clone_all"
+    JULIA_CPU_TARGET="${JULIA_CPU_TARGET}"
 
-# `fuse` launches a Julia REPL preloaded with the FUSE sysimage.
+# `fuse` launches a Julia REPL preloaded with the FUSE sysimage. When the
+# image runs fully read-only (e.g. a Singularity SIF — unlike podman-hpc there
+# is no writable overlay), Julia must get a writable first depot or package
+# init crashes writing logs/scratch (Scratch.jl via GPUCompiler). Prepend one
+# only when the current first depot is not writable.
 RUN printf '%s\n' \
     '#!/bin/bash' \
+    'if [ ! -w "${JULIA_DEPOT_PATH%%:*}" ]; then' \
+    '    export JULIA_DEPOT_PATH="$HOME/.julia_fuse_container:$JULIA_DEPOT_PATH"' \
+    'fi' \
     'exec julia --sysimage=/opt/fuse/sys_fuse.so "$@"' \
     > /usr/local/bin/fuse \
     && chmod 0555 /usr/local/bin/fuse
+
+# Precompile the interactive stack UNDER the sysimage: package caches produced
+# by the install (plain julia) are invalid once sys_fuse.so is loaded, so
+# without this every user would re-precompile IJulia/Plots/... on first use —
+# in a read-only image, into their own home depot.
+RUN fuse -e 'import IJulia, Plots, WebIO, Interact, EFIT, ArgParse'
 
 WORKDIR /root
 CMD ["fuse"]

--- a/deploy/perlmutter-container/install_kernel.sh
+++ b/deploy/perlmutter-container/install_kernel.sh
@@ -47,16 +47,15 @@ if ! command -v podman-hpc >/dev/null 2>&1; then
     exit 1
 fi
 
-# Pull the IJulia kernel.jl path that install_fuse_container.jl recorded in the
-# image, so the kernelspec points at the right file inside the container.
-echo "### Resolving IJulia kernel path from $image${squash_dir:+ (squash-dir: $squash_dir)}"
-kernel_jl="$(podman-hpc "${podman_global[@]}" run --rm "$image" cat /opt/fuse/ijulia_kernel_path.txt | tr -d '\r\n')"
-if [[ -z "$kernel_jl" ]]; then
-    echo "ERROR: could not read /opt/fuse/ijulia_kernel_path.txt from $image." >&2
+# Confirm the image is usable before installing the kernelspec. The kernel
+# launches IJulia with `-e "import IJulia; IJulia.run_kernel()"` (the modern
+# IJulia entrypoint — running src/kernel.jl as a script no longer works).
+echo "### Checking $image${squash_dir:+ (squash-dir: $squash_dir)}"
+if ! podman-hpc "${podman_global[@]}" run --rm "$image" julia -e 'import IJulia' >/dev/null; then
+    echo "ERROR: could not import IJulia from $image." >&2
     echo "       Did you run build.sh (build + migrate) first?" >&2
     exit 1
 fi
-echo "    $kernel_jl"
 
 kernel_dir="$HOME/.local/share/jupyter/kernels/fuse-$version"
 mkdir -p "$kernel_dir"
@@ -72,7 +71,6 @@ else
 fi
 
 sed -e "s|__IMAGE__|$image|g" \
-    -e "s|__KERNEL_JL__|$kernel_jl|g" \
     -e "s|__THREADS__|$threads|g" \
     -e "s|__DISPLAY__|$display|g" \
     -e "s|^__SQUASH_ARGS__\$|$squash_repl|" \

--- a/deploy/perlmutter-container/kernel.json.template
+++ b/deploy/perlmutter-container/kernel.json.template
@@ -9,7 +9,8 @@ __SQUASH_ARGS__
     "julia",
     "--sysimage=/opt/fuse/sys_fuse.so",
     "--threads=__THREADS__",
-    "__KERNEL_JL__",
+    "-e",
+    "import IJulia; IJulia.run_kernel()",
     "{connection_file}"
   ],
   "display_name": "__DISPLAY__",

--- a/docs/src/install_omega.md
+++ b/docs/src/install_omega.md
@@ -46,6 +46,16 @@ The FUSE module does several things:
        restart too quickly and the precompilation was not finished. In any case, if the problem
        does not resolve after restarting the kernel twice, reach out to the FUSE developers.
 
+## FUSE container (Singularity)
+
+As an alternative to the `fuse` module, FUSE also ships as a self-contained
+Singularity image: a single `.sif` file with FUSE, all ProjectTorreyPines
+packages, and a precompiled sysimage baked in — no modules, no private depot,
+startup in seconds, runnable on any omega node (REPL, Slurm jobs, or as a
+Jupyter kernel). See
+[`deploy/omega-container/README.md`](https://github.com/ProjectTorreyPines/FUSE.jl/blob/master/deploy/omega-container/README.md)
+for how to build, run, and install the Jupyter kernel.
+
 ## Connecting to a Jupyter-lab server running on OMEGA from your laptop
 
 1. Connect to `omega` and launch `screen`


### PR DESCRIPTION
Builds and tests a FUSE image for GA's omega cluster: rootless podman build (node-local storage) -> podman save -> singularity build, producing a SIF that runs on any omega node via singularity exec/run. The perlmutter Containerfile now takes a JULIA_CPU_TARGET build ARG so both sites share one source of truth (omega uses cascadelake+znver2, matching deploy/omega).

Testing on omega14 surfaced and fixed real bugs, applied to both container variants:
- A fully read-only image (SIF, unlike podman-hpc's writable overlay) crashes Julia package init trying to write scratch/log files; the `fuse` entrypoint now auto-prepends a writable depot when the baked one isn't writable.
- IJulia kernels launched by running src/kernel.jl as a script silently no-op with current IJulia; both kernelspecs now use `-e 'import IJulia; IJulia.run_kernel()'`.
- Packages outside the sysimage re-precompile under it on first use; the image now bakes an under-sysimage precompile pass.

Verified: smoke/offline tests, Slurm jobs on both omega compute-node generations (znver2 and znver3), and a headless Jupyter-kernel run through the singularity wrapper.