### PR TITLE
Fix study CI: make ActorSOLPSNN.Psol a no-default Entry instead of NaN sentinel

### DIFF
--- a/src/actors/sol/solps_nn_actor.jl
+++ b/src/actors/sol/solps_nn_actor.jl
@@ -52,7 +52,7 @@ const _SOLPSNN_BOUNDS = (
     quantities::Entry{Vector{Symbol}} =
         Entry{Vector{Symbol}}("-", "SOLPS-NN quantities to evaluate (subset of $(sort(collect(keys(_SOLPSNN_QMAP)))))";
             default=[:te, :ti, :ne, :pwmxap, :psol])
-    Psol::Entry{T} = Entry{T}("W", "Power across the separatrix (defaults to IMAS.power_sol when NaN)"; default=T(NaN))
+    Psol::Entry{T} = Entry{T}("W", "Power across the separatrix (defaults to IMAS.power_sol when not set)")
     D_puff::Entry{T} = Entry{T}("particles/s", "Main-ion (D) gas puff rate"; default=1.0e22)
     N_puff::Entry{T} = Entry{T}("particles/s", "Impurity (N) seeding rate (must be > 0; model uses log10)"; default=1.0e20)
     D_core::Entry{T} = Entry{T}("particles/s", "Main-ion core fuelling rate"; default=1.0e22)
@@ -92,7 +92,7 @@ onto either scalar boundary quantities (peak outer-target heat flux `pwmxap`,
 integrated ion flux `fnixap`, power across the separatrix `psol`) or full 2D
 fields on the fixed SOLPS-ITER B2 grid (`te`, `ti`, `ne`), rescaled to the
 machine major radius. `R` and `B` are taken from `dd.equilibrium`; `Psol` defaults to `IMAS.power_sol`
-(override via the `Psol` parameter); the gas-puff/transport inputs are actor parameters.
+when the `Psol` parameter is not set; the gas-puff/transport inputs are actor parameters.
 
 2D fields are written to `dd.edge_profiles` as a General Grid Description (GGD)
 slice; the peak heat flux is written to the outer divertor target when target
@@ -153,7 +153,8 @@ function _step(actor::ActorSOLPSNN)
 
     R = eqt.boundary.geometric_axis.r
     B = abs(eqt.global_quantities.vacuum_toroidal_field.b0)
-    Psol = isnan(par.Psol) ? IMAS.power_sol(dd.core_sources, dd.core_profiles.profiles_1d[]) : Float64(par.Psol)
+    Psol_par = getproperty(par, :Psol, missing)
+    Psol = ismissing(Psol_par) ? IMAS.power_sol(dd.core_sources, dd.core_profiles.profiles_1d[]) : Float64(Psol_par)
 
     X = Float64[R, B, Psol, par.D_puff, par.N_puff, par.D_core, par.D_perp, par.chi_perp]
     actor.inputs = X

--- a/test/runtests_study.jl
+++ b/test/runtests_study.jl
@@ -102,6 +102,19 @@ using FUSE.SimulationParameters.Distributions
         acts2 = [ i.act for i in db.items ];
         df2 = db.df
 
+        # ActorSOLPSNN.Psol defaults to NaN (sentinel for "use IMAS.power_sol"), but
+        # SimulationParameters.diff errors on NaN==NaN (fixed in SimulationParameters > 2.1.3,
+        # after which this resolution step can be removed). Resolve the sentinel to its
+        # runtime default before comparing; only when both sides are NaN, so a genuine
+        # difference would still be caught.
+        for (act1, act2, dd) in zip(acts1, acts2, dds1)
+            if isnan(act1.ActorSOLPSNN.Psol) && isnan(act2.ActorSOLPSNN.Psol)
+                Psol = dd === nothing ? 0.0 : IMAS.power_sol(dd.core_sources, dd.core_profiles.profiles_1d[])
+                act1.ActorSOLPSNN.Psol = Psol
+                act2.ActorSOLPSNN.Psol = Psol
+            end
+        end
+
         # Comparison
         @test dds1 == dds2
         @test all(.!diff.(inis1, inis2))

--- a/test/runtests_study.jl
+++ b/test/runtests_study.jl
@@ -102,19 +102,6 @@ using FUSE.SimulationParameters.Distributions
         acts2 = [ i.act for i in db.items ];
         df2 = db.df
 
-        # ActorSOLPSNN.Psol defaults to NaN (sentinel for "use IMAS.power_sol"), but
-        # SimulationParameters.diff errors on NaN==NaN (fixed in SimulationParameters > 2.1.3,
-        # after which this resolution step can be removed). Resolve the sentinel to its
-        # runtime default before comparing; only when both sides are NaN, so a genuine
-        # difference would still be caught.
-        for (act1, act2, dd) in zip(acts1, acts2, dds1)
-            if isnan(act1.ActorSOLPSNN.Psol) && isnan(act2.ActorSOLPSNN.Psol)
-                Psol = dd === nothing ? 0.0 : IMAS.power_sol(dd.core_sources, dd.core_profiles.profiles_1d[])
-                act1.ActorSOLPSNN.Psol = Psol
-                act2.ActorSOLPSNN.Psol = Psol
-            end
-        end
-
         # Comparison
         @test dds1 == dds2
         @test all(.!diff.(inis1, inis2))


### PR DESCRIPTION
## Problem

`runtests_study.jl` has been red since #1124: `ActorSOLPSNN.Psol` defaulted to `NaN` as a sentinel for "use `IMAS.power_sol`", and `SimulationParameters.diff` errors on it because `NaN == NaN` is `false` — even though both sides are identical.

## Fix

Make `Psol` a no-default `Entry` (value `missing` until set), which is what SimulationParameters natively understands as "unset" — `diff`, save/load, and display all handle it correctly in every registered version, same as the ~27 existing no-default actor entries. The actor reads it with the three-arg `getproperty(par, :Psol, missing)` accessor and falls back to `IMAS.power_sol`, preserving the documented behavior; explicit overrides work as before.

This fixes CI on its own, with no dependency on a SimulationParameters release. (An earlier commit on this branch worked around the issue in the test; that is reverted here.)

Related: ProjectTorreyPines/SimulationParameters.jl#21 independently makes `diff` NaN-safe via `isequal` and fixes a vector-diff typo — worth merging as a robustness fix, but CI is not blocked on it.

## Testing

- Unset `Psol` reads as `missing` via the three-arg accessor; plain read throws `NotsetParameterException` as for other required-style entries.
- `diff(FUSE.ParametersActors(), FUSE.ParametersActors())` passes (the CI comparison path).
- Explicit override (`act.ActorSOLPSNN.Psol = 1e7`) round-trips correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)