### PR TITLE
container: bake TurbulentTransport LFS models; CI builds to manual-only (~100 GiB emission peak)

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -15,6 +15,11 @@ on:
         description: "FUSE release to build (e.g. v1.1.5); empty = latest release"
         required: false
         default: ""
+      workload:
+        description: "Sysimage trace workload"
+        type: choice
+        options: [full, light]
+        default: full
 
 permissions:
   contents: read
@@ -95,6 +100,7 @@ jobs:
           docker build \
             -f deploy/perlmutter-container/Containerfile \
             --build-arg JULIA_CPU_TARGET="${{ matrix.cpu_target }}" \
+            --build-arg FUSE_PRECOMPILE_WORKLOAD="${{ inputs.workload || 'full' }}" \
             -t "$IMAGE:${{ needs.version.outputs.version }}-${{ matrix.arch }}" \
             .
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,14 +1,17 @@
 name: container
 
-# Build and publish the FUSE container to ghcr.io/projecttorreypines/fuse on
-# every FUSE release: linux/amd64 and linux/arm64 (native Apple Silicon) are
-# built in parallel on GitHub-hosted runners and combined into one multi-arch
-# tag, so `docker pull ghcr.io/projecttorreypines/fuse:latest` gets the right
-# architecture everywhere.
+# Build and publish the FUSE container to ghcr.io/projecttorreypines/fuse:
+# linux/amd64 and linux/arm64 (native Apple Silicon) built in parallel and
+# combined into one multi-arch tag.
+#
+# MANUAL DISPATCH ONLY — not viable on standard GitHub-hosted runners: the
+# sysimage object emission peaks at ~98.5 GiB RSS (measured on omega,
+# 2026-07-26), far beyond their 16 GB (swap and workload trimming both fail;
+# runs 30170851378, 30177176119, 30185669953). Requires 32-core/128 GB larger
+# runners to ever run in CI. Until then, release images are built on omega
+# and pushed with deploy/omega-container/publish_ghcr.sh.
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       fuse_version:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -84,7 +84,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build image (heavy — compiles the FUSE sysimage)
         run: |
@@ -109,7 +113,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish multi-arch manifest (version + latest)
         run: |

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -63,6 +63,24 @@ jobs:
                       /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
           df -h /
 
+      # sysimage object emission peaks beyond the 16 GB runner RAM (the OOM
+      # starves the runner agent -> "runner lost communication"); swap lets
+      # the peak spill to disk at the cost of some speed
+      - name: Add swap
+        run: |
+          for loc in /mnt /; do
+            avail=$(df -BG --output=avail "$loc" | tail -1 | tr -dc '0-9')
+            if   [ "$avail" -ge 30 ]; then size=28G
+            elif [ "$avail" -ge 20 ]; then size=18G
+            else continue; fi
+            sudo fallocate -l "$size" "$loc/swapfile-ci" \
+              && sudo chmod 600 "$loc/swapfile-ci" \
+              && sudo mkswap "$loc/swapfile-ci" \
+              && sudo swapon "$loc/swapfile-ci" \
+              && break
+          done
+          free -h
+
       - uses: actions/checkout@v4
 
       - name: Log in to GHCR

--- a/deploy/omega-container/README.md
+++ b/deploy/omega-container/README.md
@@ -251,14 +251,14 @@ access to the shared Lmod tree (e.g. `/fusion/usc/c8/modulefiles-git`) can drop
 
 ### Publishing to GHCR (all sites and laptops)
 
-On every FUSE release, the [`container` workflow](../../.github/workflows/container.yml)
-builds the image for **linux/amd64** (universal x86_64 targets) and
-**linux/arm64** (native Apple Silicon) on GitHub-hosted runners and publishes
-them as one multi-arch tag: `ghcr.io/projecttorreypines/fuse:<version>` (+
-`latest`), so `docker pull` gets the right architecture everywhere. It can
-also be run manually (workflow dispatch).
+Release images are built on omega and pushed to
+`ghcr.io/projecttorreypines/fuse:<version>` (+ `latest`) with the script
+below. (A [`container` workflow](../../.github/workflows/container.yml)
+exists for CI builds but is manual-dispatch-only and currently disabled: the
+sysimage emission peaks at ~98.5 GiB RSS, far beyond standard GitHub-hosted
+runners — it would need the 32-core/128 GB larger-runner class.)
 
-To publish an x86_64 build by hand instead (e.g. from omega):
+To publish after `build.sh` on the same omega node:
 
 ```bash
 # after build.sh, on the same node; needs gh auth with write:packages

--- a/deploy/omega-container/fuse-container
+++ b/deploy/omega-container/fuse-container
@@ -95,15 +95,22 @@ if ! mountpoint -q "$mnt"; then
     exit 1
 fi
 
-# Shared pedestal-NN weights published next to the SIF (saves each user the
-# ~700 MB HuggingFace download); the in-image `fuse` entrypoint falls back to
-# a writable per-user cache when neither this nor the caller sets the var.
+# Shared NN weight dirs published next to the SIF (too large to bake into the
+# image: pedestal-NN ~0.7 GB from HuggingFace, SOLPS-NN ~4 GB converted ONNX
+# that additionally needs a conda pipeline to produce). Pass caller-set vars
+# through --cleanenv, else point at the shared copies when they exist; the
+# in-image `fuse` entrypoint falls back to a writable per-user cache for
+# pedestal-NN when neither is set.
 extra_env=()
-if [[ -n "${FUSE_PEDESTAL_NN_DIR:-}" ]]; then
-    extra_env+=(--env "FUSE_PEDESTAL_NN_DIR=$FUSE_PEDESTAL_NN_DIR")
-elif [[ -d "$(dirname "$sif")/pedestal_nn" ]]; then
-    extra_env+=(--env "FUSE_PEDESTAL_NN_DIR=$(dirname "$sif")/pedestal_nn")
-fi
+for var_dir in "FUSE_PEDESTAL_NN_DIR:pedestal_nn" "FUSE_SOLPS_NN_DIR:solps_nn_onnx"; do
+    var="${var_dir%%:*}"
+    shared="$(dirname "$sif")/${var_dir##*:}"
+    if [[ -n "${!var:-}" ]]; then
+        extra_env+=(--env "$var=${!var}")
+    elif [[ -d "$shared" ]]; then
+        extra_env+=(--env "$var=$shared")
+    fi
+done
 
 # The in-image `fuse` entrypoint loads the sysimage and, on this read-only
 # rootfs, prepends a writable $HOME depot. No args -> interactive REPL.

--- a/deploy/omega-container/fuse-container
+++ b/deploy/omega-container/fuse-container
@@ -95,6 +95,16 @@ if ! mountpoint -q "$mnt"; then
     exit 1
 fi
 
+# Shared pedestal-NN weights published next to the SIF (saves each user the
+# ~700 MB HuggingFace download); the in-image `fuse` entrypoint falls back to
+# a writable per-user cache when neither this nor the caller sets the var.
+extra_env=()
+if [[ -n "${FUSE_PEDESTAL_NN_DIR:-}" ]]; then
+    extra_env+=(--env "FUSE_PEDESTAL_NN_DIR=$FUSE_PEDESTAL_NN_DIR")
+elif [[ -d "$(dirname "$sif")/pedestal_nn" ]]; then
+    extra_env+=(--env "FUSE_PEDESTAL_NN_DIR=$(dirname "$sif")/pedestal_nn")
+fi
+
 # The in-image `fuse` entrypoint loads the sysimage and, on this read-only
 # rootfs, prepends a writable $HOME depot. No args -> interactive REPL.
-singularity exec --cleanenv --bind "${FUSE_BIND:-/fusion}" "$mnt" fuse "$@"
+singularity exec --cleanenv "${extra_env[@]}" --bind "${FUSE_BIND:-/fusion}" "$mnt" fuse "$@"

--- a/deploy/perlmutter-container/Containerfile
+++ b/deploy/perlmutter-container/Containerfile
@@ -83,6 +83,11 @@ RUN printf '%s\n' \
     'if [ ! -w "${JULIA_DEPOT_PATH%%:*}" ]; then' \
     '    export JULIA_DEPOT_PATH="$HOME/.julia_fuse_container:$JULIA_DEPOT_PATH"' \
     'fi' \
+    '# pedestal-NN weights auto-fetch (~700 MB, HuggingFace) defaults to a dir' \
+    '# inside the read-only package tree; give it a writable per-user cache.' \
+    'if [ -z "${FUSE_PEDESTAL_NN_DIR:-}" ]; then' \
+    '    export FUSE_PEDESTAL_NN_DIR="$HOME/.julia_fuse_container/pedestal_nn"' \
+    'fi' \
     'exec julia --sysimage=/opt/fuse/sys_fuse.so "$@"' \
     > /usr/local/bin/fuse \
     && chmod 0555 /usr/local/bin/fuse

--- a/deploy/perlmutter-container/Containerfile
+++ b/deploy/perlmutter-container/Containerfile
@@ -40,10 +40,15 @@ RUN git config --system url."https://github.com/".insteadOf "git@github.com:" \
     && git config --global url."https://github.com/".insteadOf "git@github.com:" \
     && git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
 
+# Sysimage trace workload: "full" (tutorial + test suite, the default) or
+# "light" (tutorial only — smaller emission for memory-constrained builders).
+ARG FUSE_PRECOMPILE_WORKLOAD="full"
+
 # --- build-time Julia configuration ------------------------------------------
 # These mirror deploy/perlmutter/deploy.sh. JULIA_NUM_THREADS=1 is REQUIRED by
 # install_fuse_container.jl (PackageCompiler sysimage build asserts 1 thread).
 # JULIA_CPU_TARGET comes from the build ARG above (default: Perlmutter).
+ENV FUSE_PRECOMPILE_WORKLOAD="${FUSE_PRECOMPILE_WORKLOAD}"
 ENV FUSE_INSTALL_DIR=/opt/fuse \
     JULIA_DEPOT_PATH=/opt/fuse/.julia \
     JULIA_PKG_USE_CLI_GIT=1 \

--- a/deploy/perlmutter-container/install_fuse_container.jl
+++ b/deploy/perlmutter-container/install_fuse_container.jl
@@ -119,6 +119,28 @@ end
 println("    installed/verified ", install_all_artifacts(first(DEPOT_PATH)), " downloadable artifact(s)")
 
 println()
+println("### Materialize TurbulentTransport Git LFS model files")
+# TurbulentTransport ships its NN weights via Git LFS; a Pkg install leaves
+# ~130-byte pointer stubs that the package downloads into its own package dir
+# on first use — impossible later in a read-only image (SIF). Materialize
+# every model now so the image is complete and works offline/read-only.
+import TurbulentTransport
+if isdefined(TurbulentTransport, :ensure_model_file!) && isdefined(TurbulentTransport, :is_lfs_pointer)
+    let root = joinpath(pkgdir(TurbulentTransport), "models"), n = 0
+        for (dir, _, files) in walkdir(root), f in files
+            path = joinpath(dir, f)
+            if TurbulentTransport.is_lfs_pointer(path)
+                TurbulentTransport.ensure_model_file!(path)
+                n += 1
+            end
+        end
+        println("    materialized $n model file(s)")
+    end
+else
+    @warn "TurbulentTransport LFS helpers not found — models may remain pointer stubs in the image"
+end
+
+println()
 println("### Create precompile script")
 # FUSE_PRECOMPILE_WORKLOAD=light traces only the tutorial (one full
 # ActorWholeFacility pipeline) instead of tutorial + test suite — a smaller

--- a/deploy/perlmutter-container/install_fuse_container.jl
+++ b/deploy/perlmutter-container/install_fuse_container.jl
@@ -120,12 +120,25 @@ println("    installed/verified ", install_all_artifacts(first(DEPOT_PATH)), " d
 
 println()
 println("### Create precompile script")
+# FUSE_PRECOMPILE_WORKLOAD=light traces only the tutorial (one full
+# ActorWholeFacility pipeline) instead of tutorial + test suite — a smaller
+# sysimage emission for memory-constrained builders (e.g. 16 GB CI runners),
+# at the cost of precompile coverage for the per-case/actor variants.
 precompile_execution_file = joinpath(install_dir, "precompile_script.jl")
-precompile_cmds = """
-using FUSE, EFIT, $pkgs_using
-include(joinpath(pkgdir(FUSE), "docs", "src", "tutorial.jl"))
-include(joinpath(pkgdir(FUSE), "test", "runtests.jl"))
-"""
+workload = get(ENV, "FUSE_PRECOMPILE_WORKLOAD", "full")
+println("    workload: $workload")
+precompile_cmds = if workload == "light"
+    """
+    using FUSE, EFIT, $pkgs_using
+    include(joinpath(pkgdir(FUSE), "docs", "src", "tutorial.jl"))
+    """
+else
+    """
+    using FUSE, EFIT, $pkgs_using
+    include(joinpath(pkgdir(FUSE), "docs", "src", "tutorial.jl"))
+    include(joinpath(pkgdir(FUSE), "test", "runtests.jl"))
+    """
+end
 write(precompile_execution_file, precompile_cmds)
 
 println()


### PR DESCRIPTION
Two outcomes from this week's container work: a correctness fix that's already shipped in the published images, and the empirical conclusion of the CI-build investigation.

## 1. Bake TurbulentTransport LFS models into the image
TurbulentTransport ships NN weights via Git LFS; `Pkg` installs leave ~130-byte pointer stubs that the package downloads *into its own package dir* on first use — impossible in a read-only image. In the published SIF only the 3 models exercised by the build trace were real; the other ~120 were stubs, so e.g. the flux-matcher tutorial (`ActorTGLF` → `sat3_em_d3d_azf-1_withnegD`) died with EROFS. `install_fuse_container.jl` now materializes **every** LFS model at build time, before the sysimage trace (123 files, ~+0.3 GB image).

Verified: rebuilt image runs `FUSE.init` → `ActorFluxMatcher` on D3D L-mode **offline**; republished to `/fusion/projects/dt/fuse_containers` and `ghcr.io/projecttorreypines/fuse` (`v1.1.5` + `latest`). Complemented upstream by TurbulentTransport v1.2.13 (merged/registered), which adds a Scratch.jl writable-cache fallback for any read-only install — including the omega module deploy.

## 2. Container CI: manual-dispatch-only
Standard GitHub-hosted runners (16 GB) cannot build this image: **sysimage object emission peaks at ~98.5 GiB RSS** (measured during the omega rebuild; ~590 packages × 4 CPU-target clones). Swap and trace-trimming don't change the outcome; only the 32-core/128 GB larger-runner class could host it — and those are billed per-minute even for public repos, unlike the standard runners.

The workflow therefore loses its `release:` trigger (it's also disabled in the repo's Actions settings) and keeps `workflow_dispatch`, preserving the multi-arch pipeline — plus the swap step, `docker/login-action`, and a `FUSE_PRECOMPILE_WORKLOAD=full|light` knob — should larger runners ever be provisioned. Release images are built on omega and pushed with `publish_ghcr.sh`; the README's publishing section now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)