### PR TITLE
Container: fix Jupyter kernel hang (--color=yes) and registry permissions

### DIFF
--- a/deploy/omega-container/kernel.json.template
+++ b/deploy/omega-container/kernel.json.template
@@ -2,7 +2,7 @@
   "argv": [
     "/bin/bash",
     "-c",
-    "export PATH=\"__SINGULARITY_DIR__:$PATH\"; exec \"__LAUNCHER__\" \"__SIF__\" --threads=__THREADS__ -e 'import IJulia; IJulia.run_kernel()' \"$1\"",
+    "export PATH=\"__SINGULARITY_DIR__:$PATH\"; exec \"__LAUNCHER__\" \"__SIF__\" --threads=__THREADS__ --color=yes -e 'import IJulia; IJulia.run_kernel()' \"$1\"",
     "fuse-kernel",
     "{connection_file}"
   ],

--- a/deploy/perlmutter-container/Containerfile
+++ b/deploy/perlmutter-container/Containerfile
@@ -98,6 +98,10 @@ RUN printf '%s\n' \
 # in a read-only image, into their own home depot.
 RUN fuse -e 'import IJulia, Plots, WebIO, Interact, EFIT, ArgParse'
 
+# Registries are cloned 0700; without world-read every in-container Pkg
+# operation fails for non-root users.
+RUN chmod -R a+rX /opt/fuse/.julia/registries
+
 # Links the GHCR package to this repository (kept last: label-only changes
 # then rebuild from cache in seconds).
 LABEL org.opencontainers.image.source="https://github.com/ProjectTorreyPines/FUSE.jl" \

--- a/deploy/perlmutter-container/kernel.json.template
+++ b/deploy/perlmutter-container/kernel.json.template
@@ -9,6 +9,7 @@ __SQUASH_ARGS__
     "julia",
     "--sysimage=/opt/fuse/sys_fuse.so",
     "--threads=__THREADS__",
+    "--color=yes",
     "-e",
     "import IJulia; IJulia.run_kernel()",
     "{connection_file}"


### PR DESCRIPTION
## Kernel hang fix

Container Jupyter kernels hung forever on the first \`FUSE.init\` cell (e.g. flux-matcher tutorial), with the frontend stuck busy and eventual "ZMQ closed stream" warnings.

Root cause: the kernelspec argv omitted \`--color=yes\` (standard IJulia kernelspecs include it). Without it \`Base.have_color === nothing\`; IJulia stores that in its stdio \`IOContext(:color => Base.have_color)\`, and the first \`printstyled\` — FUSE's actor logging during init — throws \`TypeError: non-boolean (Nothing) used in boolean context\`. IJulia's error-formatting path hits the same bug, so the failure is swallowed silently: no reply, no error, permanently dead shell channel.

Fix: add \`--color=yes\` to both kernel templates (omega + Perlmutter). Validated on omega with the v1.1.5 SIF: \`FUSE.init\` + \`plot(dd.equilibrium)\` + PNG render now pass on 1- and 8-thread kernels, with actor logs streaming.

Existing kernels can be fixed without reinstalling by adding \`--color=yes\` after \`--threads=N\` in \`~/.local/share/jupyter/kernels/fuse-*/kernel.json\`.

## Registry permissions fix

Registries are cloned \`0700\` inside the image, so every in-container \`Pkg\` operation fails with \`EACCES\` for non-root users. Added a late \`chmod -R a+rX\` layer. (If this lands together with the Revise layer from \`container-version-cachebust\`, keep the chmod after it — \`Pkg.add\` can re-tighten registry permissions.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)