### PR TITLE
Omega container: one-step Jupyter launch and clear home-quota error

### DIFF
--- a/deploy/omega-container/README.md
+++ b/deploy/omega-container/README.md
@@ -59,7 +59,14 @@ singularity and auto-selects the newest image):
 Pin a specific version by passing the `.sif` explicitly:
 `fuse-container /fusion/projects/dt/fuse_containers/fuse_v1.1.5.sif ...`.
 
-Install the Jupyter kernel for the published image:
+Start a Jupyter notebook on the container (worker nodes only; installs the
+kernelspec automatically, `THREADS=N` to change the kernel's thread count):
+
+```bash
+/fusion/projects/dt/fuse_containers/fuse-container notebook   # or: lab
+```
+
+Or install just the Jupyter kernel for the published image:
 
 ```bash
 SIF=/fusion/projects/dt/fuse_containers/fuse_<version>.sif \
@@ -149,6 +156,25 @@ handles the details:
   write logs/scratch to a depot. The in-image `fuse` entrypoint handles this:
   it prepends `$HOME/.julia_fuse_container` as a writable first depot.
 
+### Home directory over quota
+
+The per-user depot above needs only a few MB, but if `$HOME` is at its quota
+even the initial `mkdir` fails (`quota -s` to check). The launcher pre-creates
+the depot and reports this clearly; without that check Julia dies at package
+init with a cryptic `InitError(mkdir ... Unknown system error -122)` (EDQUOT).
+Either free up home space, or redirect the writable depot to node-local
+scratch (`SINGULARITYENV_` survives `--cleanenv`, plain env vars do not; the
+launcher auto-binds the redirected path into the container):
+
+```bash
+mkdir -p /local-scratch/$USER/.julia_fuse_container
+export SINGULARITYENV_JULIA_DEPOT_PATH="/local-scratch/$USER/.julia_fuse_container:/opt/fuse/.julia"
+fuse-container
+```
+
+Note `/local-scratch` is per-node: on another Slurm node the depot starts
+empty, which is fine — it only holds logs and scratch files.
+
 Quick smoke test (everything after the SIF is passed to Julia):
 
 ```bash
@@ -185,6 +211,15 @@ newer EPYC 7513 nodes also select the znver2 sysimage clone), and end with
 `SLURM SMOKE OK`.
 
 ## 4. Interactive use via Jupyter
+
+One-step, on a worker node (refuses to run on the login node; add
+`--no-browser` and an SSH tunnel for remote use):
+
+```bash
+fuse-container notebook        # or: lab; THREADS=8 fuse-container notebook
+```
+
+Or install just the kernelspec and use any Jupyter later:
 
 ```bash
 module load singularity/3.11.3

--- a/deploy/omega-container/README.md
+++ b/deploy/omega-container/README.md
@@ -149,6 +149,25 @@ handles the details:
   write logs/scratch to a depot. The in-image `fuse` entrypoint handles this:
   it prepends `$HOME/.julia_fuse_container` as a writable first depot.
 
+### Home directory over quota
+
+The per-user depot above needs only a few MB, but if `$HOME` is at its quota
+even the initial `mkdir` fails (`quota -s` to check). The launcher pre-creates
+the depot and reports this clearly; without that check Julia dies at package
+init with a cryptic `InitError(mkdir ... Unknown system error -122)` (EDQUOT).
+Either free up home space, or redirect the writable depot to node-local
+scratch (`SINGULARITYENV_` survives `--cleanenv`, plain env vars do not; the
+launcher auto-binds the redirected path into the container):
+
+```bash
+mkdir -p /local-scratch/$USER/.julia_fuse_container
+export SINGULARITYENV_JULIA_DEPOT_PATH="/local-scratch/$USER/.julia_fuse_container:/opt/fuse/.julia"
+fuse-container
+```
+
+Note `/local-scratch` is per-node: on another Slurm node the depot starts
+empty, which is fine — it only holds logs and scratch files.
+
 Quick smoke test (everything after the SIF is passed to Julia):
 
 ```bash

--- a/deploy/omega-container/fuse-container
+++ b/deploy/omega-container/fuse-container
@@ -5,6 +5,8 @@
 #   fuse-container [args...]         # args passed to the in-container `fuse`
 #                                    # (e.g. -e '...script...', --threads=N)
 #   fuse-container <sif> [args...]   # pin a specific image (explicit .sif path)
+#   fuse-container notebook|lab      # install the Jupyter kernelspec and start
+#                                    # Jupyter (worker nodes only; THREADS=N)
 #
 # With no explicit SIF, the newest fuse_*.sif is used — from $FUSE_SIF_DIR if
 # set, else from the directory this launcher lives in (the published layout).
@@ -68,6 +70,67 @@ if ! command -v squashfuse >/dev/null 2>&1; then
     exit 127
 fi
 
+# `fuse-container [sif] notebook|lab [jupyter args...]`: install/refresh the
+# Jupyter kernelspec for this SIF, then start the host's Jupyter with it. The
+# kernelspec launches this script per kernel, so no mount is needed here.
+if [[ "${1:-}" == "notebook" || "${1:-}" == "lab" ]]; then
+    mode="$1"; shift
+    # Jupyter servers belong on worker nodes (omegaNN), not the login node.
+    node="$(hostname -s)"
+    if [[ ! "$node" =~ ^omega[0-9]+$ && -z "${FUSE_NOTEBOOK_ANYWHERE:-}" ]]; then
+        echo "fuse-container: refusing to start Jupyter on '$node' — use a worker node:" >&2
+        echo "    srun -p medium -t 8:00:00 -c 8 --pty bash" >&2
+        echo "  (FUSE_NOTEBOOK_ANYWHERE=1 overrides this check)" >&2
+        exit 1
+    fi
+    if ! command -v jupyter >/dev/null 2>&1; then
+        echo "fuse-container: 'jupyter' not found on PATH — activate your Python/conda env first." >&2
+        exit 127
+    fi
+    version="$(basename "$sif")"; version="${version#fuse_}"; version="${version%.sif}"
+    threads="${THREADS:-1}"
+    singularity_dir="$(dirname "$(command -v singularity)")"
+    launcher="$self_dir/$(basename "${BASH_SOURCE[0]:-$0}")"
+    kdir="$HOME/.local/share/jupyter/kernels/fuse-$version"
+    mkdir -p "$kdir"
+    cat > "$kdir/kernel.json" <<EOF
+{
+  "argv": [
+    "/bin/bash",
+    "-c",
+    "export PATH=\"$singularity_dir:\$PATH\"; exec \"$launcher\" \"$sif\" --threads=$threads --color=yes -e 'import IJulia; IJulia.run_kernel()' \"\$1\"",
+    "fuse-kernel",
+    "{connection_file}"
+  ],
+  "display_name": "Julia FUSE-$version container ($threads thread(s))",
+  "language": "julia",
+  "metadata": {
+    "debugger": true
+  }
+}
+EOF
+    echo "fuse-container: kernelspec 'fuse-$version' installed ($threads thread(s); set THREADS=N to change)"
+    exec jupyter "$mode" "$@"
+fi
+
+# Pre-flight: on the read-only SIF rootfs the in-image `fuse` entrypoint needs
+# a writable first depot — $HOME/.julia_fuse_container by default, overridable
+# with SINGULARITYENV_JULIA_DEPOT_PATH (plain env vars are stripped by
+# --cleanenv; the SINGULARITYENV_ prefix survives it). Create it here so a
+# full home quota fails with a clear message instead of Julia dying at package
+# init with InitError(mkdir ... error -122 EDQUOT).
+depot="${SINGULARITYENV_JULIA_DEPOT_PATH:-}"; depot="${depot%%:*}"
+[[ -z "$depot" ]] && depot="$HOME/.julia_fuse_container"
+if ! mkdir -p "$depot" 2>/dev/null || ! touch "$depot/.fuse_container_write_test" 2>/dev/null; then
+    echo "fuse-container: cannot write to $depot" >&2
+    echo "  Most likely your home directory is over quota ('quota -s' to check)." >&2
+    echo "  Free up space, or redirect the writable depot to node-local scratch:" >&2
+    echo "    mkdir -p /local-scratch/\$USER/.julia_fuse_container" >&2
+    echo "    export SINGULARITYENV_JULIA_DEPOT_PATH=\"/local-scratch/\$USER/.julia_fuse_container:/opt/fuse/.julia\"" >&2
+    exit 1
+fi
+rm -f "$depot/.fuse_container_write_test"
+
 # Byte offset of the squashfs partition inside the SIF (robust, not hardcoded).
 offset="$(singularity sif list "$sif" 2>/dev/null \
           | awk -F'|' '/Squashfs/ {split($4,a,"-"); gsub(/ /,"",a[1]); print a[1]; exit}')"
@@ -112,6 +175,12 @@ for var_dir in "FUSE_PEDESTAL_NN_DIR:pedestal_nn" "FUSE_SOLPS_NN_DIR:solps_nn_on
     fi
 done
 
+# A redirected depot (e.g. /local-scratch) is outside the default binds —
+# bind it explicitly so it exists inside the container. Nested/duplicate
+# binds (depot under /fusion or $HOME) are harmless.
+binds="${FUSE_BIND:-/fusion}"
+[[ -n "${SINGULARITYENV_JULIA_DEPOT_PATH:-}" ]] && binds="$binds,$depot"
+
 # The in-image `fuse` entrypoint loads the sysimage and, on this read-only
 # rootfs, prepends a writable $HOME depot. No args -> interactive REPL.
-singularity exec --cleanenv "${extra_env[@]}" --bind "${FUSE_BIND:-/fusion}" "$mnt" fuse "$@"
+singularity exec --cleanenv "${extra_env[@]}" --bind "$binds" "$mnt" fuse "$@"

--- a/deploy/omega-container/fuse-container
+++ b/deploy/omega-container/fuse-container
@@ -68,6 +68,24 @@ if ! command -v squashfuse >/dev/null 2>&1; then
     exit 127
 fi
 
+# Pre-flight: on the read-only SIF rootfs the in-image `fuse` entrypoint needs
+# a writable first depot — $HOME/.julia_fuse_container by default, overridable
+# with SINGULARITYENV_JULIA_DEPOT_PATH (plain env vars are stripped by
+# --cleanenv; the SINGULARITYENV_ prefix survives it). Create it here so a
+# full home quota fails with a clear message instead of Julia dying at package
+# init with InitError(mkdir ... error -122 EDQUOT).
+depot="${SINGULARITYENV_JULIA_DEPOT_PATH:-}"; depot="${depot%%:*}"
+[[ -z "$depot" ]] && depot="$HOME/.julia_fuse_container"
+if ! mkdir -p "$depot" 2>/dev/null || ! touch "$depot/.fuse_container_write_test" 2>/dev/null; then
+    echo "fuse-container: cannot write to $depot" >&2
+    echo "  Most likely your home directory is over quota ('quota -s' to check)." >&2
+    echo "  Free up space, or redirect the writable depot to node-local scratch:" >&2
+    echo "    mkdir -p /local-scratch/\$USER/.julia_fuse_container" >&2
+    echo "    export SINGULARITYENV_JULIA_DEPOT_PATH=\"/local-scratch/\$USER/.julia_fuse_container:/opt/fuse/.julia\"" >&2
+    exit 1
+fi
+rm -f "$depot/.fuse_container_write_test"
+
 # Byte offset of the squashfs partition inside the SIF (robust, not hardcoded).
 offset="$(singularity sif list "$sif" 2>/dev/null \
           | awk -F'|' '/Squashfs/ {split($4,a,"-"); gsub(/ /,"",a[1]); print a[1]; exit}')"
@@ -112,6 +130,12 @@ for var_dir in "FUSE_PEDESTAL_NN_DIR:pedestal_nn" "FUSE_SOLPS_NN_DIR:solps_nn_on
     fi
 done
 
+# A redirected depot (e.g. /local-scratch) is outside the default binds —
+# bind it explicitly so it exists inside the container. Nested/duplicate
+# binds (depot under /fusion or $HOME) are harmless.
+binds="${FUSE_BIND:-/fusion}"
+[[ -n "${SINGULARITYENV_JULIA_DEPOT_PATH:-}" ]] && binds="$binds,$depot"
+
 # The in-image `fuse` entrypoint loads the sysimage and, on this read-only
 # rootfs, prepends a writable $HOME depot. No args -> interactive REPL.
-singularity exec --cleanenv "${extra_env[@]}" --bind "${FUSE_BIND:-/fusion}" "$mnt" fuse "$@"
+singularity exec --cleanenv "${extra_env[@]}" --bind "$binds" "$mnt" fuse "$@"

--- a/deploy/omega-container/fuse-container.lua
+++ b/deploy/omega-container/fuse-container.lua
@@ -31,12 +31,6 @@ your home directory is over quota, redirect it to node-local scratch:
   mkdir -p /local-scratch/$USER/.julia_fuse_container
   export SINGULARITYENV_JULIA_DEPOT_PATH="/local-scratch/$USER/.julia_fuse_container:/opt/fuse/.julia"
 
-The container writes a small per-user depot to ~/.julia_fuse_container. If
-your home directory is over quota, redirect it to node-local scratch:
-
-  mkdir -p /local-scratch/$USER/.julia_fuse_container
-  export SINGULARITYENV_JULIA_DEPOT_PATH="/local-scratch/$USER/.julia_fuse_container:/opt/fuse/.julia"
-
 See deploy/omega-container/README.md in the FUSE.jl repo.
 ]])
 

--- a/deploy/omega-container/fuse-container.lua
+++ b/deploy/omega-container/fuse-container.lua
@@ -23,6 +23,13 @@ all ProjectTorreyPines packages, and a precompiled sysimage. No private depot.
   fuse-container                       interactive FUSE REPL (newest image)
   fuse-container -e 'using FUSE; ...'  run a script / one-liner
   fuse-container <path.sif> ...        pin a specific image version
+  fuse-container notebook|lab          Jupyter on the container (worker nodes)
+
+The container writes a small per-user depot to ~/.julia_fuse_container. If
+your home directory is over quota, redirect it to node-local scratch:
+
+  mkdir -p /local-scratch/$USER/.julia_fuse_container
+  export SINGULARITYENV_JULIA_DEPOT_PATH="/local-scratch/$USER/.julia_fuse_container:/opt/fuse/.julia"
 
 See deploy/omega-container/README.md in the FUSE.jl repo.
 ]])

--- a/deploy/omega-container/fuse-container.lua
+++ b/deploy/omega-container/fuse-container.lua
@@ -24,6 +24,12 @@ all ProjectTorreyPines packages, and a precompiled sysimage. No private depot.
   fuse-container -e 'using FUSE; ...'  run a script / one-liner
   fuse-container <path.sif> ...        pin a specific image version
 
+The container writes a small per-user depot to ~/.julia_fuse_container. If
+your home directory is over quota, redirect it to node-local scratch:
+
+  mkdir -p /local-scratch/$USER/.julia_fuse_container
+  export SINGULARITYENV_JULIA_DEPOT_PATH="/local-scratch/$USER/.julia_fuse_container:/opt/fuse/.julia"
+
 See deploy/omega-container/README.md in the FUSE.jl repo.
 ]])
 

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -14,9 +14,9 @@ This guide walks you through setting up everything you need to run FUSE: the **J
     ```bash
     docker run -it ghcr.io/projecttorreypines/fuse:latest
     ```
-    omega:
+    omega (JupyterLab, worker nodes; use plain `fuse-container` for a REPL):
     ```bash
-    module use /fusion/projects/dt/fuse_containers/modules && module load fuse-container && fuse-container
+    module use /fusion/projects/dt/fuse_containers/modules && module load fuse-container && fuse-container lab
     ```
     NERSC (Perlmutter):
     ```bash


### PR DESCRIPTION
Two omega-container launcher improvements:

## One-step Jupyter: `fuse-container notebook|lab`

```bash
fuse-container notebook      # or: lab; THREADS=8 fuse-container notebook
```

- Installs/refreshes the Jupyter kernelspec for the selected SIF (including the `--color=yes` fix from #1143), honoring `THREADS=N`, then execs the host's `jupyter` with any extra args passed through.
- Refuses to start on the login node (hostname not `omegaNN`), pointing at `srun -p medium ... --pty bash`; `FUSE_NOTEBOOK_ANYWHERE=1` overrides.
- Validated headlessly on omega14 (kernelspec via API, cell execution, login-node refusal via hostname shim).

## Clear error when home quota blocks the writable depot

The launcher pre-creates the per-user depot and, when $HOME is over quota, fails with a clear message and the `SINGULARITYENV_JULIA_DEPOT_PATH` scratch-redirect recipe instead of Julia dying at package init with `InitError(mkdir ... error -122)` (EDQUOT). A redirected depot is auto-bound into the container. README + modulefile document the redirect.

Launcher and modulefile are already published to `/fusion/projects/dt/fuse_containers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
