### PR TITLE
Container: harden build against REPL pty-precompile deadlock; bake procps/ssh/rsync

### DIFF
--- a/deploy/perlmutter-container/Containerfile
+++ b/deploy/perlmutter-container/Containerfile
@@ -61,6 +61,13 @@ WORKDIR /opt/build
 COPY deploy/perlmutter-container/install_fuse_container.jl /opt/build/install_fuse_container.jl
 COPY Makefile /opt/build/Makefile
 
+# Build the REPL stdlib cache up front, time-boxed and retried: with a custom
+# JULIA_CPU_TARGET the shipped cache is invalid, and REPL's precompile drives a
+# scripted pseudo-terminal session that can deadlock forever on a missed prompt
+# under podman's no-TTY environment (REPL/src/precompile.jl has no timeout).
+# A failed warm-up is harmless — the sysimage bakes REPL regardless.
+RUN timeout 600 julia -e 'import REPL' || timeout 600 julia -e 'import REPL' || true
+
 # Installs FUSE and all PTP packages into $FUSE_INSTALL_DIR, builds IJulia, and
 # compiles /opt/fuse/sys_fuse.so. This step is heavy (runs the FUSE test suite
 # and tutorial as precompile workload) and is best run inside a CPU allocation.
@@ -101,6 +108,12 @@ RUN fuse -e 'import IJulia, Plots, WebIO, Interact, EFIT, ArgParse'
 # Registries are cloned 0700; without world-read every in-container Pkg
 # operation fails for non-root users.
 RUN chmod -R a+rX /opt/fuse/.julia/registries
+
+# procps: FUSE's memory monitor shells out to `ps -o rss=` (utils_end.jl).
+# openssh-client + rsync: FUSE's remote D3D data fetching (src/cases/D3D.jl).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends procps openssh-client rsync \
+    && rm -rf /var/lib/apt/lists/*
 
 # Links the GHCR package to this repository (kept last: label-only changes
 # then rebuild from cache in seconds).


### PR DESCRIPTION
Two container improvements, found while building v1.1.6 and running postdictive studies in the image:

## Build hardening: REPL precompile deadlock

With a custom `JULIA_CPU_TARGET`, Julia's shipped REPL stdlib cache is invalid and gets rebuilt during the install. That rebuild (REPL/src/precompile.jl) drives a scripted pseudo-terminal session with **no timeout and no opt-out** — under podman's no-TTY build environment it can miss a prompt and hang the whole install silently, forever (observed: 3.5 h at zero CPU before manual intervention; the same step passed in the previous build, so it is a race).

Fix: warm the REPL cache in its own time-boxed, retried layer before the heavy install. Worst case is bounded (2 x 10 min) and a failed warm-up is harmless — the sysimage bakes REPL regardless (verified: the v1.1.6 build continued fine after the wedged rebuild was killed).

## Runtime tools: procps, openssh-client, rsync

- `ps`: FUSE's memory monitor (`utils_end.jl`) shells out to `ps -o rss=` — crashes studies in the image without it.
- `ssh`/`rsync`: FUSE's remote D3D data fetching (`src/cases/D3D.jl`) — with these baked (and `~/.ssh` bound from home), shot-data fetching works fully in-container.

Both verified against a full `StudyPostdictive` run of D3D shot 168830 in the container on omega (with host-side shims standing in for the missing binaries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)