### PR TITLE
omega container: THREADS=8 in lab one-liner; clarify host jupyter requirement

### DIFF
--- a/deploy/omega-container/fuse-container
+++ b/deploy/omega-container/fuse-container
@@ -84,7 +84,7 @@ if [[ "${1:-}" == "notebook" || "${1:-}" == "lab" ]]; then
         exit 1
     fi
     if ! command -v jupyter >/dev/null 2>&1; then
-        echo "fuse-container: 'jupyter' not found on PATH — activate your Python/conda env first." >&2
+        echo "fuse-container: 'jupyter' not found on PATH — activate a Python/conda env that has it (on omega: 'module load fuse')." >&2
         exit 127
     fi
     version="$(basename "$sif")"; version="${version#fuse_}"; version="${version%.sif}"

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -32,9 +32,9 @@ These scripts install FUSE, Revise, fusebot, the Jupyter stack (`fuse` conda env
 
 They then activate the `fuse` env, run `fusebot install_IJulia` (or `make install_IJulia` / `scripts/install_ijulia.sh` if fusebot fails), and finish by executing the **first three cells** of `FuseExamples/fluxmatcher.ipynb`. A fresh install typically takes **20–40 minutes** (Julia packages + conda + IJulia + the first flux-matcher solve; the notebook cells are often ~6 minutes on one thread).
 
-### Laptop (Linux or macOS)
+### Laptop (Linux or macOS), omega, and other non-NERSC HPC
 
-From any directory on a personal machine. Installs [juliaup](https://github.com/JuliaLang/juliaup) when `julia` is missing and [Miniconda](https://docs.anaconda.com/miniconda/) when `conda` is missing.
+From any directory on a personal machine, omega, or another non-NERSC HPC system. Installs [juliaup](https://github.com/JuliaLang/juliaup) when `julia` is missing and [Miniconda](https://docs.anaconda.com/miniconda/) when `conda` is missing.
 
 ```bash
 curl -fsSL https://install.julialang.org | sh -s -- -y && \

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -14,9 +14,11 @@ This guide walks you through setting up everything you need to run FUSE: the **J
     ```bash
     docker run -it ghcr.io/projecttorreypines/fuse:latest
     ```
-    omega (JupyterLab, worker nodes; use plain `fuse-container` for a REPL):
+    omega (JupyterLab, worker nodes; use plain `fuse-container` for a REPL).
+    JupyterLab itself runs on the host, so `jupyter` must be on `PATH`
+    (e.g. via `module load fuse`):
     ```bash
-    module use /fusion/projects/dt/fuse_containers/modules && module load fuse-container && fuse-container lab
+    module use /fusion/projects/dt/fuse_containers/modules && module load fuse-container && THREADS=8 fuse-container lab
     ```
     NERSC (Perlmutter):
     ```bash


### PR DESCRIPTION
Two small usability fixes for the omega container Jupyter flow:

- The `install.md` omega one-liner now sets `THREADS=8` so the containerized kernel gets a useful thread count by default, and notes that JupyterLab itself runs on the host so `jupyter` must be on `PATH` (e.g. via `module load fuse`).
- The `fuse-container` launcher's "'jupyter' not found" error now tells omega users the concrete fix (`module load fuse`) instead of a generic "activate your env" hint. A new user hit exactly this and needed help to get past it.

The updated launcher has already been re-published to `/fusion/projects/dt/fuse_containers/fuse-container`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)