### PR TITLE
Container: multi-arch publishing, automatic arm64 CI builds, and pre-publish acceptance checks

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -4,38 +4,64 @@ name: container
 # linux/amd64 and linux/arm64 (native Apple Silicon) built in parallel and
 # combined into one multi-arch tag.
 #
-# MANUAL DISPATCH ONLY, AND NOT CURRENTLY A WORKING RELEASE PATH. Release
-# images are built by hand — amd64 on omega, arm64 on an Apple Silicon laptop —
-# and combined into the multi-arch tag with:
+# WHICH LEG RUNS WHERE
+#
+#   arm64  — built automatically here on every published release.
+#   amd64  — built by hand on omega; CANNOT run on GitHub-hosted runners.
+#
+# The two legs differ because they hit two unrelated walls.
+#
+# amd64 is blocked by MEMORY: emitting the sysimage object peaks at ~98.5 GiB
+# RSS (measured on omega, 2026-07-26), far beyond the 16 GB of standard
+# GitHub-hosted runners. Swap and workload trimming both fail (runs
+# 30170851378, 30177176119, 30185669953); it would take the 32-core/128 GB
+# larger-runner class. So amd64 release images are built on omega with
+# deploy/omega-container/build.sh and pushed with publish_ghcr.sh.
+#
+# arm64 is blocked from having a sysimage AT ALL, by a LINKER limit rather than
+# a memory one. FUSE's sysimage embeds a ~3.2 GB blob of serialized program
+# state, and on aarch64 the linker must bridge that blob with 32-bit relative
+# references (R_AARCH64_PREL32) that max out at 2.147 GB. It is an
+# architecture-level object-file-format limit, not a resource shortage: the
+# build compiles for 5+ hours successfully and then fails in the final second at
+# the link step, identically for every variant tried (dual-target, single
+# target, light workload; verified on an M2 Max, 2026-08-04, FUSE v1.1.6 /
+# Julia 1.11.7). x86_64 escapes only because the medium code model gives it a
+# large-data section (.ldata) that moves the blob out of the critical span;
+# aarch64 has no equivalent.
+#
+# So the arm64 leg builds with FUSE_PRECOMPILE_WORKLOAD=none and ships per-
+# package pkgimages — many small libraries instead of one giant one — and the
+# in-image `fuse` launcher falls back to plain julia. Trade-off: `import FUSE`
+# takes ~30-60 s instead of ~5 s; compute speed after that is identical. Losing
+# the sysimage emission is also what drops the peak under 16 GB, which is why
+# this leg fits on ubuntu-24.04-arm at all.
+#
+# The multi-arch manifest (:<version> + :latest) can only be created once BOTH
+# per-arch tags exist. The manifest job below therefore skips itself when the
+# amd64 tag is missing — the usual case on a release run, since omega builds
+# later. Finish the release from omega with:
 #
 #     MANIFEST=1 FUSE_ENVIRONMENT=<version> deploy/omega-container/publish_ghcr.sh
 #
 # See deploy/omega-container/README.md, "Publishing to GHCR".
-#
-# The blocker is memory. The sysimage object emission peaks at ~98.5 GiB RSS
-# (measured on omega, 2026-07-26), far beyond the 16 GB of standard
-# GitHub-hosted runners; swap and workload trimming both fail (runs
-# 30170851378, 30177176119, 30185669953). It would take the 32-core/128 GB
-# larger-runner class to build in CI at all.
-#
-# The arm64 leg below builds WITHOUT a sysimage (FUSE_PRECOMPILE_WORKLOAD=none):
-# no aarch64 FUSE sysimage can link — the image data blob (~3.2 GB) overflows
-# the ±2 GiB R_AARCH64_PREL32 relocation span, for any CPU target and even the
-# light workload (verified on an M2 Max, 2026-08-04, FUSE v1.1.6 / Julia
-# 1.11.7; x86_64 escapes via the medium code model's .ldata section, which
-# aarch64 lacks). Skipping the sysimage should keep the arm64 peak under 16 GB,
-# but that path has never completed on ubuntu-24.04-arm — the three failed runs
-# above all predate it, so treat this leg as untested rather than proven.
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       fuse_version:
         description: "FUSE release to build (e.g. v1.2.0); empty = latest release"
         required: false
         default: ""
+      arch:
+        description: "Which leg(s) to build (amd64 needs a >=128 GB runner)"
+        type: choice
+        options: [arm64, amd64, both]
+        default: arm64
       workload:
-        description: "Sysimage trace workload"
+        description: "Sysimage trace workload (amd64 only; arm64 is always none)"
         type: choice
         options: [full, light]
         default: full
@@ -52,34 +78,45 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.v.outputs.version }}
+      matrix: ${{ steps.m.outputs.matrix }}
     steps:
       - id: v
         run: |
-          v="${{ inputs.fuse_version }}"
+          v="${{ github.event.release.tag_name }}"
+          [ -z "$v" ] && v="${{ inputs.fuse_version }}"
           [ -z "$v" ] && v="$(curl -s https://api.github.com/repos/ProjectTorreyPines/FUSE.jl/releases/latest | jq -r .tag_name)"
           echo "version=$v" >> "$GITHUB_OUTPUT"
           echo "building FUSE $v"
+
+      # A release build is arm64-only: amd64 needs ~98.5 GiB to emit the
+      # sysimage and is built on omega (see header). Manual dispatch can still
+      # ask for amd64, e.g. to retry it on a larger-runner class.
+      - id: m
+        run: |
+          arch="${{ inputs.arch }}"
+          [ -z "$arch" ] && arch="arm64"
+
+          # universal x86_64 set: NERSC Perlmutter (znver3), GA omega
+          # (cascadelake/znver2/znver3), generic fallback for laptops
+          amd64='{"arch":"amd64","runner":"ubuntu-24.04","cpu_target":"generic;cascadelake,-xsaveopt,-rdrnd,clone_all;znver2,-xsaveopt,-rdrnd,clone_all;znver3,-xsaveopt,-rdrnd,clone_all","workload":"${{ inputs.workload || 'full' }}"}'
+          # generic aarch64 (Apple Silicon Docker/podman VMs, Graviton, …).
+          # cpu_target only shapes the pkgimages here — there is no sysimage,
+          # and the fuse launcher unsets it at runtime so the JIT goes native.
+          arm64='{"arch":"arm64","runner":"ubuntu-24.04-arm","cpu_target":"generic","workload":"none"}'
+
+          case "$arch" in
+            amd64) include="[$amd64]" ;;
+            both)  include="[$amd64,$arm64]" ;;
+            *)     include="[$arm64]" ;;
+          esac
+          echo "matrix={\"include\":$include}" >> "$GITHUB_OUTPUT"
+          echo "building leg(s): $arch"
 
   build:
     needs: version
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - arch: amd64
-            runner: ubuntu-24.04
-            # universal x86_64 set: NERSC Perlmutter (znver3), GA omega
-            # (cascadelake/znver2/znver3), generic fallback for laptops
-            cpu_target: "generic;cascadelake,-xsaveopt,-rdrnd,clone_all;znver2,-xsaveopt,-rdrnd,clone_all;znver3,-xsaveopt,-rdrnd,clone_all"
-            workload: ${{ inputs.workload || 'full' }}
-          - arch: arm64
-            runner: ubuntu-24.04-arm
-            # generic aarch64 (Apple Silicon Docker/podman VMs, Graviton, …).
-            # No sysimage on aarch64 (see header) — cpu_target only shapes the
-            # pkgimages, and the fuse launcher unsets it at runtime so the JIT
-            # goes native.
-            cpu_target: "generic"
-            workload: none
+      matrix: ${{ fromJson(needs.version.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 355
     steps:
@@ -91,10 +128,13 @@ jobs:
                       /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
           df -h /
 
-      # sysimage object emission peaks beyond the 16 GB runner RAM (the OOM
-      # starves the runner agent -> "runner lost communication"); swap lets
-      # the peak spill to disk at the cost of some speed
+      # Only the sysimage legs need this: object emission peaks beyond the
+      # 16 GB runner RAM (the OOM starves the runner agent -> "runner lost
+      # communication"), and swap lets the peak spill to disk at the cost of
+      # some speed. workload=none (arm64) never emits a sysimage, so it stays
+      # well under the limit and skips this.
       - name: Add swap
+        if: matrix.workload != 'none'
         run: |
           for loc in /mnt /; do
             avail=$(df -BG --output=avail "$loc" | tail -1 | tr -dc '0-9')
@@ -118,7 +158,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build image (heavy — compiles the FUSE sysimage)
+      # heavy: installs FUSE + every PTP package and precompiles them, plus the
+      # sysimage unless workload=none
+      - name: Build image
         run: |
           docker build \
             -f deploy/perlmutter-container/Containerfile \
@@ -148,9 +190,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # :<version> and :latest are manifest lists over BOTH per-arch tags, so
+      # they can only be published once both exist. On a release run only arm64
+      # was just built and amd64 arrives later from omega, so skip rather than
+      # publish a half manifest that would strand x86_64 users on :latest.
       - name: Publish multi-arch manifest (version + latest)
         run: |
           v="${{ needs.version.outputs.version }}"
+          missing=""
+          for arch in amd64 arm64; do
+            docker manifest inspect "$IMAGE:$v-$arch" >/dev/null 2>&1 || missing="$missing $arch"
+          done
+          if [ -n "$missing" ]; then
+            echo "::notice::Skipping manifest — missing per-arch tag(s):$missing."
+            echo "Publish it once the missing leg is pushed:"
+            echo "    MANIFEST=1 FUSE_ENVIRONMENT=$v deploy/omega-container/publish_ghcr.sh"
+            exit 0
+          fi
           docker buildx imagetools create \
             -t "$IMAGE:$v" -t "$IMAGE:latest" \
             "$IMAGE:$v-amd64" "$IMAGE:$v-arm64"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -166,6 +166,7 @@ jobs:
             -f deploy/perlmutter-container/Containerfile \
             --build-arg JULIA_CPU_TARGET="${{ matrix.cpu_target }}" \
             --build-arg FUSE_PRECOMPILE_WORKLOAD="${{ matrix.workload }}" \
+            --build-arg FUSE_VERSION="${{ needs.version.outputs.version }}" \
             -t "$IMAGE:${{ needs.version.outputs.version }}-${{ matrix.arch }}" \
             .
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -4,26 +4,34 @@ name: container
 # linux/amd64 and linux/arm64 (native Apple Silicon) built in parallel and
 # combined into one multi-arch tag.
 #
-# MANUAL DISPATCH ONLY — the amd64 leg is not viable on standard GitHub-hosted
-# runners: the sysimage object emission peaks at ~98.5 GiB RSS (measured on
-# omega, 2026-07-26), far beyond their 16 GB (swap and workload trimming both
-# fail; runs 30170851378, 30177176119, 30185669953). Requires 32-core/128 GB
-# larger runners to ever run in CI. Until then, amd64 release images are built
-# on omega and pushed with deploy/omega-container/publish_ghcr.sh.
+# MANUAL DISPATCH ONLY, AND NOT CURRENTLY A WORKING RELEASE PATH. Release
+# images are built by hand — amd64 on omega, arm64 on an Apple Silicon laptop —
+# and combined into the multi-arch tag with:
 #
-# The arm64 leg builds WITHOUT a sysimage (FUSE_PRECOMPILE_WORKLOAD=none):
+#     MANIFEST=1 FUSE_ENVIRONMENT=<version> deploy/omega-container/publish_ghcr.sh
+#
+# See deploy/omega-container/README.md, "Publishing to GHCR".
+#
+# The blocker is memory. The sysimage object emission peaks at ~98.5 GiB RSS
+# (measured on omega, 2026-07-26), far beyond the 16 GB of standard
+# GitHub-hosted runners; swap and workload trimming both fail (runs
+# 30170851378, 30177176119, 30185669953). It would take the 32-core/128 GB
+# larger-runner class to build in CI at all.
+#
+# The arm64 leg below builds WITHOUT a sysimage (FUSE_PRECOMPILE_WORKLOAD=none):
 # no aarch64 FUSE sysimage can link — the image data blob (~3.2 GB) overflows
 # the ±2 GiB R_AARCH64_PREL32 relocation span, for any CPU target and even the
 # light workload (verified on an M2 Max, 2026-08-04, FUSE v1.1.6 / Julia
 # 1.11.7; x86_64 escapes via the medium code model's .ldata section, which
-# aarch64 lacks). Skipping the sysimage keeps the arm64 peak well under 16 GB,
-# so this leg IS viable on ubuntu-24.04-arm.
+# aarch64 lacks). Skipping the sysimage should keep the arm64 peak under 16 GB,
+# but that path has never completed on ubuntu-24.04-arm — the three failed runs
+# above all predate it, so treat this leg as untested rather than proven.
 
 on:
   workflow_dispatch:
     inputs:
       fuse_version:
-        description: "FUSE release to build (e.g. v1.1.5); empty = latest release"
+        description: "FUSE release to build (e.g. v1.2.0); empty = latest release"
         required: false
         default: ""
       workload:
@@ -47,8 +55,7 @@ jobs:
     steps:
       - id: v
         run: |
-          v="${{ github.event.release.tag_name }}"
-          [ -z "$v" ] && v="${{ inputs.fuse_version }}"
+          v="${{ inputs.fuse_version }}"
           [ -z "$v" ] && v="$(curl -s https://api.github.com/repos/ProjectTorreyPines/FUSE.jl/releases/latest | jq -r .tag_name)"
           echo "version=$v" >> "$GITHUB_OUTPUT"
           echo "building FUSE $v"

--- a/deploy/omega-container/README.md
+++ b/deploy/omega-container/README.md
@@ -57,7 +57,7 @@ singularity and auto-selects the newest image):
 ```
 
 Pin a specific version by passing the `.sif` explicitly:
-`fuse-container /fusion/projects/dt/fuse_containers/fuse_v1.1.5.sif ...`.
+`fuse-container /fusion/projects/dt/fuse_containers/fuse_v1.2.0.sif ...`.
 
 Start a Jupyter notebook on the container (worker nodes only; installs the
 kernelspec automatically, `THREADS=N` to change the kernel's thread count):
@@ -130,7 +130,7 @@ SIF_DIR=/fusion/ga/projects/ird/ptp/$USER/fuse_containers ./deploy/omega-contain
 `build.sh` will:
 
 1. Resolve the image tag (`fuse:<version>`) from the latest FUSE.jl release
-   (override with `FUSE_ENVIRONMENT=v2.6.0`).
+   (override with `FUSE_ENVIRONMENT=v1.2.0`).
 2. `podman build` with omega's dual CPU target, storing images on
    `/local-scratch/$USER` (no NFS, no persistent config).
 3. `podman save` → `singularity build` → `SIF_DIR/fuse_<version>.sif`
@@ -286,26 +286,64 @@ access to the shared Lmod tree (e.g. `/fusion/usc/c8/modulefiles-git`) can drop
 
 ### Publishing to GHCR (all sites and laptops)
 
-Release images are built on omega and pushed to
-`ghcr.io/projecttorreypines/fuse:<version>` (+ `latest`) with the script
-below. (A [`container` workflow](../../.github/workflows/container.yml)
-exists for CI builds but is manual-dispatch-only and currently disabled: the
-sysimage emission peaks at ~98.5 GiB RSS, far beyond standard GitHub-hosted
-runners — it would need the 32-core/128 GB larger-runner class.)
+`ghcr.io/projecttorreypines/fuse:<version>` and `:latest` are **manifest
+lists**: one tag pointing at both per-architecture images, so users get the
+right one automatically from a single command.
 
-To publish after `build.sh` on the same omega node:
+```
+ghcr.io/projecttorreypines/fuse:<version>        manifest list
+    ├── ghcr.io/projecttorreypines/fuse:<version>-amd64    built on omega
+    └── ghcr.io/projecttorreypines/fuse:<version>-arm64    built on Apple Silicon
+```
+
+Neither leg is a working CI path — a [`container`
+workflow](../../.github/workflows/container.yml) exists but is
+manual-dispatch-only: the sysimage emission peaks at ~98.5 GiB RSS, far beyond
+standard GitHub-hosted runners (it would need the 32-core/128 GB larger-runner
+class). Release images are therefore built by hand, amd64 on omega and arm64 on
+an Apple Silicon laptop, then combined with `publish_ghcr.sh MANIFEST=1`.
+
+Publishing is three steps. All need `gh` authenticated with `write:packages`
+(`gh auth refresh --hostname github.com -s write:packages`).
+
+**1. amd64, after `build.sh` on the same omega node** (the podman store is
+node-local). This pushes only `:<version>-amd64` and does not move `latest`:
 
 ```bash
-# after build.sh, on the same node; needs gh auth with write:packages
 FUSE_ENVIRONMENT=<version> ./deploy/omega-container/publish_ghcr.sh
+```
+
+**2. arm64, on an Apple Silicon machine with Docker.** No aarch64 FUSE sysimage
+can link (the ~3.2 GB image data blob overflows the ±2 GiB `R_AARCH64_PREL32`
+relocation span), so this leg builds with `FUSE_PRECOMPILE_WORKLOAD=none` —
+package precompilation only, and the in-image `fuse` launcher falls back to
+plain `julia`:
+
+```bash
+docker build -f deploy/perlmutter-container/Containerfile \
+  --build-arg JULIA_CPU_TARGET="generic" \
+  --build-arg FUSE_PRECOMPILE_WORKLOAD="none" \
+  -t ghcr.io/projecttorreypines/fuse:<version>-arm64 .
+docker run --rm ghcr.io/projecttorreypines/fuse:<version>-arm64 \
+  fuse -e 'import FUSE; print(pkgversion(FUSE))'
+gh auth token | docker login ghcr.io -u "$(gh api /user --jq .login)" --password-stdin
+docker push ghcr.io/projecttorreypines/fuse:<version>-arm64
+```
+
+**3. The manifest, from either machine, once both arch tags exist and have
+passed their acceptance tests.** This is the step that moves `latest` for
+everyone:
+
+```bash
+MANIFEST=1 FUSE_ENVIRONMENT=<version> ./deploy/omega-container/publish_ghcr.sh
+docker manifest inspect ghcr.io/projecttorreypines/fuse:latest  # expect amd64 + arm64
 ```
 
 Consuming the published image:
 
 ```bash
-# Laptop / any machine with Docker or podman (x86_64)
+# Laptop / any machine with Docker or podman — architecture selected automatically
 docker run -it ghcr.io/projecttorreypines/fuse:<version>
-# Apple Silicon Macs: add --platform linux/amd64 (runs emulated — slow but works)
 
 # NERSC Perlmutter
 podman-hpc pull ghcr.io/projecttorreypines/fuse:<version>
@@ -316,5 +354,8 @@ podman-hpc run --rm -it ghcr.io/projecttorreypines/fuse:<version>
 singularity build fuse_<version>.sif docker://ghcr.io/projecttorreypines/fuse:<version>
 ```
 
-The image is x86_64-only (the sysimage is architecture-specific); on Apple
-Silicon it runs under emulation.
+The x86_64 image is built with the universal `JULIA_CPU_TARGET`
+(`generic;cascadelake;znver2;znver3`), so one image is optimal on omega and
+NERSC Perlmutter alike and falls back to `generic` on laptops. It carries the
+precompiled sysimage; the arm64 image does not, so its first-call latency is
+higher.

--- a/deploy/omega-container/README.md
+++ b/deploy/omega-container/README.md
@@ -292,18 +292,34 @@ right one automatically from a single command.
 
 ```
 ghcr.io/projecttorreypines/fuse:<version>        manifest list
-    ├── ghcr.io/projecttorreypines/fuse:<version>-amd64    built on omega
-    └── ghcr.io/projecttorreypines/fuse:<version>-arm64    built on Apple Silicon
+    ├── ghcr.io/projecttorreypines/fuse:<version>-amd64    built by hand on omega
+    └── ghcr.io/projecttorreypines/fuse:<version>-arm64    built in CI on release
 ```
 
-Neither leg is a working CI path — a [`container`
-workflow](../../.github/workflows/container.yml) exists but is
-manual-dispatch-only: the sysimage emission peaks at ~98.5 GiB RSS, far beyond
-standard GitHub-hosted runners (it would need the 32-core/128 GB larger-runner
-class). Release images are therefore built by hand, amd64 on omega and arm64 on
-an Apple Silicon laptop, then combined with `publish_ghcr.sh MANIFEST=1`.
+The two legs are built in different places, because they hit two unrelated
+walls.
 
-Publishing is three steps. All need `gh` authenticated with `write:packages`
+**amd64 is blocked by memory.** Emitting the sysimage object peaks at ~98.5 GiB
+RSS, far beyond the 16 GB of standard GitHub-hosted runners (it would need the
+32-core/128 GB larger-runner class), so amd64 is built by hand on omega.
+
+**arm64 cannot have a sysimage at all** — a linker limit, not a resource one.
+FUSE's sysimage embeds a ~3.2 GB blob of serialized program state, and on
+aarch64 the linker must bridge it with 32-bit relative references
+(`R_AARCH64_PREL32`) that max out at 2.147 GB. The build compiles for 5+ hours
+successfully and then fails in the final second at the link step, identically
+for every variant tried. x86_64 escapes only because the medium code model
+gives it a large-data section (`.ldata`) that moves the blob out of the
+critical span; aarch64 has no equivalent. The arm64 image therefore builds with
+`FUSE_PRECOMPILE_WORKLOAD=none` and ships per-package pkgimages — many small
+libraries instead of one giant one — so `import FUSE` takes ~30–60 s instead of
+~5 s, with identical compute speed after that. Skipping the sysimage emission
+is also what keeps the peak under 16 GB, so **arm64 builds automatically in CI
+on every published release** ([`container`
+workflow](../../.github/workflows/container.yml)).
+
+Publishing is therefore two manual steps (arm64 takes care of itself). Both
+need `gh` authenticated with `write:packages`
 (`gh auth refresh --hostname github.com -s write:packages`).
 
 **1. amd64, after `build.sh` on the same omega node** (the podman store is
@@ -313,26 +329,10 @@ node-local). This pushes only `:<version>-amd64` and does not move `latest`:
 FUSE_ENVIRONMENT=<version> ./deploy/omega-container/publish_ghcr.sh
 ```
 
-**2. arm64, on an Apple Silicon machine with Docker.** No aarch64 FUSE sysimage
-can link (the ~3.2 GB image data blob overflows the ±2 GiB `R_AARCH64_PREL32`
-relocation span), so this leg builds with `FUSE_PRECOMPILE_WORKLOAD=none` —
-package precompilation only, and the in-image `fuse` launcher falls back to
-plain `julia`:
-
-```bash
-docker build -f deploy/perlmutter-container/Containerfile \
-  --build-arg JULIA_CPU_TARGET="generic" \
-  --build-arg FUSE_PRECOMPILE_WORKLOAD="none" \
-  -t ghcr.io/projecttorreypines/fuse:<version>-arm64 .
-docker run --rm ghcr.io/projecttorreypines/fuse:<version>-arm64 \
-  fuse -e 'import FUSE; print(pkgversion(FUSE))'
-gh auth token | docker login ghcr.io -u "$(gh api /user --jq .login)" --password-stdin
-docker push ghcr.io/projecttorreypines/fuse:<version>-arm64
-```
-
-**3. The manifest, from either machine, once both arch tags exist and have
-passed their acceptance tests.** This is the step that moves `latest` for
-everyone:
+**2. The manifest, once both arch tags exist and have passed their acceptance
+tests.** This is the step that moves `latest` for everyone. The CI run that
+built arm64 skips the manifest when amd64 is not yet published, so this is
+normally run from omega right after step 1:
 
 ```bash
 MANIFEST=1 FUSE_ENVIRONMENT=<version> ./deploy/omega-container/publish_ghcr.sh

--- a/deploy/omega-container/README.md
+++ b/deploy/omega-container/README.md
@@ -84,6 +84,7 @@ The rest of this README covers building a new image and the full test flow.
 | `fuse-container.lua` | Lmod modulefile (`module load fuse-container`). |
 | `install_kernel.sh` | Installs a Jupyter kernelspec that runs via `fuse-container`. |
 | `kernel.json.template` | Template for the kernelspec. |
+| `acceptance.sh` | Pre-publish acceptance checks against a freshly built image + SIF. |
 | `test_slurm.sbatch` | Smoke test as a Slurm job (submit per architecture). |
 | `test_kernel_headless.py` | Headless Jupyter-kernel smoke test via `jupyter_client`. |
 
@@ -323,11 +324,16 @@ need `gh` authenticated with `write:packages`
 (`gh auth refresh --hostname github.com -s write:packages`).
 
 **1. amd64, after `build.sh` on the same omega node** (the podman store is
-node-local). This pushes only `:<version>-amd64` and does not move `latest`:
+node-local). Run the acceptance checks first — they are what catches a
+dependency that silently vanished between releases, and they exit nonzero if
+anything failed:
 
 ```bash
+FUSE_ENVIRONMENT=<version> ./deploy/omega-container/acceptance.sh
 FUSE_ENVIRONMENT=<version> ./deploy/omega-container/publish_ghcr.sh
 ```
+
+The push only creates `:<version>-amd64`; it does not move `latest`.
 
 **2. The manifest, once both arch tags exist and have passed their acceptance
 tests.** This is the step that moves `latest` for everyone. The CI run that

--- a/deploy/omega-container/acceptance.sh
+++ b/deploy/omega-container/acceptance.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# Acceptance checks for a freshly built FUSE container, run before publishing.
+#
+#   FUSE_ENVIRONMENT=v1.2.0 ./deploy/omega-container/acceptance.sh
+#
+# Runs on the omega node that built the image (the podman store is node-local).
+# Checks the podman image directly where possible, and the exported SIF through
+# the fuse-container launcher for the parts that only matter read-only.
+#
+# Optional:
+#   SIF=/path/to/fuse_<version>.sif   default: $SIF_DIR (or /local-scratch/$USER)
+#   SKIP_SLOW=1                       skip the flux-matcher solve
+#
+# Each check prints PASS/FAIL independently; the summary exits nonzero if any
+# failed. Checks assert the precondition they are actually testing, so a check
+# cannot pass while silently exercising nothing.
+
+set -uo pipefail
+
+# non-interactive ssh may not set USER, and the default paths below are per-user
+export USER="${USER:-$(id -un)}"
+
+if [[ -r /etc/profile.d/00-modulepath.sh ]]; then
+    source /etc/profile.d/00-modulepath.sh
+    source /etc/profile.d/modules.sh
+fi
+module load singularity/3.11.3 2>/dev/null || true
+
+if [[ -n "${FUSE_ENVIRONMENT:-}" ]]; then
+    version="$FUSE_ENVIRONMENT"
+else
+    version="$(curl -s https://api.github.com/repos/ProjectTorreyPines/FUSE.jl/releases/latest | jq -r .name)"
+fi
+[[ -n "$version" && "$version" != "null" ]] || { echo "ERROR: set FUSE_ENVIRONMENT" >&2; exit 1; }
+
+scriptdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+scratch="/local-scratch/$USER"
+shared="/fusion/projects/dt/fuse_containers"
+sif="${SIF:-${SIF_DIR:-$scratch}/fuse_${version}.sif}"
+image="localhost/fuse:$version"
+launcher="$scriptdir/fuse-container"
+out="$scratch/acceptance_${version}"
+mkdir -p "$out"
+
+podman=(podman)
+[[ -d "$scratch" ]] && podman=(podman --root "$scratch/podman-storage" --runroot "$scratch/podman-run")
+
+# The launcher needs squashfuse, which it looks for in bin/ next to the SIF. A
+# freshly built SIF in /local-scratch has no bin/, so fall back to the copy
+# published beside the shared images.
+[[ -x "$(dirname "$sif")/bin/squashfuse" ]] || export PATH="$shared/bin:$PATH"
+
+pass=0; fail=0; failed_names=()
+check() {
+    local name="$1"; shift
+    echo "----- $name"
+    if "$@"; then echo "PASS $name"; pass=$((pass+1))
+    else echo "FAIL $name"; fail=$((fail+1)); failed_names+=("$name"); fi
+}
+
+echo "=== FUSE $version container acceptance — $(date -Is) on $(hostname)"
+echo "=== image: $image"
+echo "=== sif:   $sif"
+echo
+
+# --- identity ---------------------------------------------------------------
+check "version-is-$version" bash -c "
+    got=\$(${podman[*]} run --rm $image fuse -e 'import FUSE; print(pkgversion(FUSE))')
+    echo \"  FUSE \$got\"; [ \"v\$got\" = \"$version\" ]"
+
+check "sysimage-loaded" bash -c "
+    p=\$(${podman[*]} run --rm $image fuse -e 'print(unsafe_string(Base.JLOptions().image_file))')
+    echo \"  sysimage: \$p\"; [ \"\$p\" = /opt/fuse/sys_fuse.so ]"
+
+check "core-package-versions" bash -c "
+    ${podman[*]} run --rm $image fuse -e '
+        import Pkg
+        found = Dict(d.name => d.version for d in values(Pkg.dependencies()))
+        for p in [\"FUSE\",\"IMAS\",\"IMASdd\",\"IMASggd\",\"TurbulentTransport\"]
+            println(\"  \", p, \" => \", get(found, p, \"NOT INSTALLED\"))
+        end'"
+
+# --- image hygiene ----------------------------------------------------------
+# Scan in Julia, not nested bash: through podman -> bash -c -> fuse -e the
+# quoting is three deep, and a quoting slip reads as "the image still has LFS
+# stubs". Collect into arrays -- `n += 1` in a top-level loop hits Julia soft
+# scope and throws UndefVarError instead of counting.
+check "no-LFS-pointer-stubs" bash -c "
+    ${podman[*]} run --rm $image fuse -e '
+        import TurbulentTransport
+        root = joinpath(pkgdir(TurbulentTransport), \"models\")
+        isdir(root) || (println(\"  no models dir at \", root); exit(1))
+        files = String[]; stubs = String[]
+        for (d, _, fs) in walkdir(root), f in fs
+            p = joinpath(d, f); push!(files, p)
+            startswith(String(open(io -> read(io, 40), p)), \"version https://git-lfs\") && push!(stubs, p)
+        end
+        isempty(files) && (println(\"  scanned nothing — models dir empty\"); exit(1))
+        println(\"  scanned \", length(files), \" model file(s); \", length(stubs), \" still LFS stubs\")
+        for s in first(stubs, 5); println(\"    STUB \", s); end
+        exit(isempty(stubs) ? 0 : 1)'"
+
+check "registries-world-readable" bash -c "
+    bad=\$(${podman[*]} run --rm $image bash -c 'find /opt/fuse/.julia/registries ! -perm -o+r | wc -l')
+    echo \"  non-world-readable entries: \$bad\"; [ \"\$bad\" = 0 ]"
+
+# Revise is not a FUSE dependency: it is installed explicitly because
+# FuseExamples notebooks open with `using Revise` and this image serves them
+# through its Jupyter kernel. v1.1.6 got it from a late Containerfile layer that
+# shipped in that image but never merged to master, so v1.2.0 lost it — exactly
+# the kind of released-vs-repo drift this script exists to catch.
+check "revise-loads" bash -c "
+    ${podman[*]} run --rm $image fuse -e 'using Revise; println(\"  Revise \", pkgversion(Revise))'"
+
+check "host-tools-present" bash -c "
+    ${podman[*]} run --rm $image bash -c 'for t in ps ssh rsync; do command -v \$t || { echo \"  missing \$t\"; exit 1; }; done'"
+
+# --- physics smoke ----------------------------------------------------------
+check "init-and-plot-png" bash -c "
+    ${podman[*]} run --rm -v $out:/out:Z $image fuse -e '
+        using FUSE, Plots
+        ini, act = FUSE.case_parameters(:D3D, :L_mode)
+        dd = FUSE.init(ini, act)
+        plot(dd.equilibrium)
+        savefig(\"/out/equilibrium.png\")' && ls -la $out/equilibrium.png"
+
+if [[ "${SKIP_SLOW:-0}" != "1" ]]; then
+    check "flux-matcher-offline" bash -c "
+        ${podman[*]} run --rm --network none $image fuse -e '
+            using FUSE
+            ini, act = FUSE.case_parameters(:D3D, :L_mode)
+            dd = FUSE.init(ini, act)
+            FUSE.ActorFluxMatcher(dd, act)
+            println(\"  ActorFluxMatcher completed with no network\")'"
+fi
+
+# --- SIF + shared NN weight dirs --------------------------------------------
+if [[ ! -f "$sif" ]]; then
+    echo "----- SIF checks"
+    echo "FAIL sif-exists ($sif not found)"; fail=$((fail+1)); failed_names+=("sif-exists")
+else
+    check "sif-smoke" bash -c "
+        $launcher $sif -e '
+            println(\"  sysimage: \", unsafe_string(Base.JLOptions().image_file))
+            println(\"  cpu: \", Sys.CPU_NAME)
+            using FUSE; println(\"  FUSE \", pkgversion(FUSE))'"
+
+    # The shared pedestal weights are read ONLY on the ne_from=:nn_predictor
+    # path. act.ActorPedestal.model=:EPED uses EPEDNN.jl's own baked weights and
+    # never touches this directory -- driving the actor would pass while testing
+    # nothing. Load the bundles directly, asserting the env var is honoured
+    # first, which is exactly what the launcher's injection must make work.
+    check "pedestal-nn-shared-dir" bash -c "
+        FUSE_PEDESTAL_NN_DIR=$shared/pedestal_nn $launcher $sif -e '
+            using FUSE
+            dir = FUSE.resolve_pedestal_nn_dir()
+            println(\"  resolved dir: \", dir)
+            @assert dir == ENV[\"FUSE_PEDESTAL_NN_DIR\"] \"env var not honoured\"
+            @assert FUSE.pedestal_nn_dir_complete(dir) \"shared pedestal-NN dir incomplete\"
+            FUSE.load_pedestal_nn()
+            println(\"  loaded PedestalNN bundles OK\")'"
+
+    # SOLPS-NN runs through ActorSOL's model switch, not by calling ActorSOLPSNN
+    # directly.
+    check "solps-nn-shared-dir" bash -c "
+        FUSE_SOLPS_NN_DIR=$shared/solps_nn_onnx $launcher $sif -e '
+            using FUSE
+            @assert ENV[\"FUSE_SOLPS_NN_DIR\"] == \"$shared/solps_nn_onnx\"
+            ini, act = FUSE.case_parameters(:D3D, :L_mode)
+            act.ActorSOL.model = :solps_nn
+            dd = FUSE.init(ini, act)
+            FUSE.ActorSOL(dd, act)
+            println(\"  ActorSOL(:solps_nn) OK\")'"
+fi
+
+echo
+echo "=== acceptance summary: $pass passed, $fail failed"
+if [[ "$fail" -gt 0 ]]; then
+    printf '    FAILED: %s\n' "${failed_names[@]}"
+    exit 1
+fi
+echo "=== ALL CHECKS PASSED — safe to publish $version"

--- a/deploy/omega-container/build.sh
+++ b/deploy/omega-container/build.sh
@@ -16,7 +16,7 @@
 #   ./deploy/omega-container/build.sh
 #
 # Override the image tag (defaults to the latest FUSE.jl release):
-#   FUSE_ENVIRONMENT=v2.6.0 ./deploy/omega-container/build.sh
+#   FUSE_ENVIRONMENT=v1.2.0 ./deploy/omega-container/build.sh
 #
 # Write the SIF to shared storage (instead of node-local /local-scratch),
 # so it is visible from every omega node:
@@ -85,6 +85,15 @@ echo "### Building $image (context: $repo_root, CPU target: $cpu_target)"
 "${podman[@]}" build -t "$image" \
     --build-arg JULIA_CPU_TARGET="$cpu_target" \
     -f "$scriptdir/../perlmutter-container/Containerfile" "$repo_root"
+
+echo "### Verifying the image contains FUSE $version"
+# Guards against a stale cached install layer shipping under the wrong tag.
+got="$("${podman[@]}" run --rm "localhost/$image" fuse -e 'import FUSE; print(pkgversion(FUSE))')"
+if [[ "v$got" != "$version" ]]; then
+    echo "ERROR: image has FUSE v$got, expected $version (stale podman cache?)." >&2
+    echo "       Wipe the store ('${podman[*]} system reset --force') and rebuild." >&2
+    exit 1
+fi
 
 echo "### Exporting $image -> $sif"
 tar="$scratch/fuse_${version}.tar"

--- a/deploy/omega-container/build.sh
+++ b/deploy/omega-container/build.sh
@@ -84,6 +84,7 @@ sif="$sif_dir/fuse_${version}.sif"
 echo "### Building $image (context: $repo_root, CPU target: $cpu_target)"
 "${podman[@]}" build -t "$image" \
     --build-arg JULIA_CPU_TARGET="$cpu_target" \
+    --build-arg FUSE_VERSION="$version" \
     -f "$scriptdir/../perlmutter-container/Containerfile" "$repo_root"
 
 echo "### Verifying the image contains FUSE $version"

--- a/deploy/omega-container/install_kernel.sh
+++ b/deploy/omega-container/install_kernel.sh
@@ -9,7 +9,7 @@
 #
 # Run this AFTER ./build.sh has produced the SIF. Usage:
 #   module load singularity/3.11.3
-#   SIF=/fusion/.../fuse_v2.6.0.sif ./deploy/omega-container/install_kernel.sh
+#   SIF=/fusion/.../fuse_v1.2.0.sif ./deploy/omega-container/install_kernel.sh
 #
 # Optional:
 #   THREADS=8  number of Julia threads the kernel starts with (default 1)

--- a/deploy/omega-container/publish_ghcr.sh
+++ b/deploy/omega-container/publish_ghcr.sh
@@ -1,24 +1,45 @@
 #!/bin/bash
-# Publish the built FUSE container image to the GitHub Container Registry:
+# Publish the FUSE container image to the GitHub Container Registry as a
+# multi-arch tag:
 #
-#     ghcr.io/projecttorreypines/fuse:<version>
+#     ghcr.io/projecttorreypines/fuse:<version>        (manifest list)
+#         ├── ghcr.io/projecttorreypines/fuse:<version>-amd64
+#         └── ghcr.io/projecttorreypines/fuse:<version>-arm64
 #
-# Run AFTER build.sh, on the same node (the image lives in the node-local
-# podman store). Requires the `gh` CLI authenticated with the write:packages
-# scope:
+# The version tag (and `latest`) is a manifest list: one tag that points at
+# both per-arch images, so `docker run ghcr.io/projecttorreypines/fuse:latest`
+# automatically pulls the image matching the client's architecture.
+#
+# Publishing is therefore two steps:
+#
+#   1. Per-arch push — run AFTER build.sh, on the same node (the image lives
+#      in the node-local podman store). Pushes to :<version>-<ARCH> and does
+#      NOT touch :<version> or :latest.
+#
+#          FUSE_ENVIRONMENT=v1.2.0 ./deploy/omega-container/publish_ghcr.sh
+#
+#      ARCH defaults to amd64 (the omega build). The arm64 image is built and
+#      pushed from an Apple Silicon machine with docker (see the README).
+#
+#   2. Manifest publish — run from ANY machine once BOTH per-arch tags exist.
+#      Combines them into :<version> and :latest. Only do this after both
+#      arch images passed their acceptance tests: this is the step that moves
+#      `latest` for all users.
+#
+#          MANIFEST=1 FUSE_ENVIRONMENT=v1.2.0 ./deploy/omega-container/publish_ghcr.sh
+#
+# NOTE: the version comes from the FUSE_ENVIRONMENT environment variable (or,
+# when unset, the latest GitHub release) — NOT from a positional argument.
+#
+# Requires the `gh` CLI authenticated with the write:packages scope:
 #
 #     gh auth refresh --hostname github.com -s write:packages
 #
-# Usage:
-#     FUSE_ENVIRONMENT=v1.1.5 ./deploy/omega-container/publish_ghcr.sh
-#
-# Optional:
-#     LATEST=1   also tag/push ghcr.io/projecttorreypines/fuse:latest
-#
 # Notes:
-# - The image built with the default (universal) JULIA_CPU_TARGET runs on
-#   NERSC Perlmutter (znver3), GA omega (cascadelake/znver2/znver3), and any
-#   x86_64 laptop (generic fallback), so one published tag serves all sites.
+# - The amd64 image built with the default (universal) JULIA_CPU_TARGET runs
+#   on NERSC Perlmutter (znver3), GA omega (cascadelake/znver2/znver3), and
+#   any x86_64 laptop (generic fallback). The arm64 image ships without a
+#   sysimage (no aarch64 FUSE sysimage can link) and serves Apple Silicon.
 # - The FIRST push creates the package with PRIVATE visibility. To let other
 #   sites pull without authentication, make it public once (org owners /
 #   package admins) at:
@@ -26,6 +47,12 @@
 #   -> Package settings -> Change visibility.
 
 set -euo pipefail
+
+if [[ $# -gt 0 ]]; then
+    echo "ERROR: this script takes no positional arguments. Set the version" >&2
+    echo "       via FUSE_ENVIRONMENT=$1 instead." >&2
+    exit 1
+fi
 
 if [[ -n "${FUSE_ENVIRONMENT:-}" ]]; then
     version="$FUSE_ENVIRONMENT"
@@ -37,39 +64,81 @@ if [[ -z "$version" || "$version" == "null" ]]; then
     exit 1
 fi
 
-scratch="/local-scratch/$USER"
-podman=(podman --root "$scratch/podman-storage" --runroot "$scratch/podman-run")
-image="localhost/fuse:$version"
 dest="ghcr.io/projecttorreypines/fuse"
+
+if ! command -v gh >/dev/null 2>&1 || ! gh auth status >/dev/null 2>&1; then
+    echo "ERROR: gh CLI not authenticated. Run 'gh auth login' and add the" >&2
+    echo "       write:packages scope (see header)." >&2
+    exit 1
+fi
+user="$(gh api /user --jq .login)"
+
+# Node-local podman storage (omega worker nodes): the default graphRoot is in
+# NFS $HOME, which is slow and eats quota. Fall back to podman defaults on
+# machines without /local-scratch (e.g. a laptop running the MANIFEST step).
+podman=(podman)
+scratch="/local-scratch/$USER"
+if [[ -d "$scratch" ]]; then
+    podman=(podman --root "$scratch/podman-storage" --runroot "$scratch/podman-run")
+fi
+
+if [[ "${MANIFEST:-0}" == "1" ]]; then
+    # --- step 2: combine the per-arch tags into :<version> and :latest ------
+    if command -v docker >/dev/null 2>&1 && docker buildx version >/dev/null 2>&1; then
+        # Registry-side manifest creation — copies no blobs.
+        echo "### Logging in to ghcr.io as $user (docker)"
+        gh auth token | docker login ghcr.io -u "$user" --password-stdin
+        trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
+        echo "### Creating manifest $dest:$version (+ latest) from -amd64 + -arm64"
+        docker buildx imagetools create \
+            -t "$dest:$version" -t "$dest:latest" \
+            "$dest:$version-amd64" "$dest:$version-arm64"
+        docker buildx imagetools inspect "$dest:$version"
+    else
+        echo "### Logging in to ghcr.io as $user (podman)"
+        gh auth token | "${podman[@]}" login ghcr.io -u "$user" --password-stdin
+        trap '"${podman[@]}" manifest rm "fuse-manifest-$version" >/dev/null 2>&1 || true
+              "${podman[@]}" logout ghcr.io >/dev/null 2>&1 || true' EXIT
+        echo "### Creating manifest $dest:$version (+ latest) from -amd64 + -arm64"
+        "${podman[@]}" manifest rm "fuse-manifest-$version" >/dev/null 2>&1 || true
+        "${podman[@]}" manifest create "fuse-manifest-$version"
+        # --all is REQUIRED: without it, `manifest add` tries to select the
+        # image matching the *host* architecture from the remote reference and
+        # fails on the foreign-arch tag ("no image found in image index for
+        # architecture amd64"). --all copies every entry, which also carries
+        # over the buildx attestation manifest. (verified on podman 4.9.4)
+        "${podman[@]}" manifest add --all "fuse-manifest-$version" "docker://$dest:$version-amd64"
+        "${podman[@]}" manifest add --all "fuse-manifest-$version" "docker://$dest:$version-arm64"
+        "${podman[@]}" manifest push --all "fuse-manifest-$version" "docker://$dest:$version"
+        "${podman[@]}" manifest push --all "fuse-manifest-$version" "docker://$dest:latest"
+        "${podman[@]}" manifest inspect "docker://$dest:$version"
+    fi
+    echo
+    echo "### Published $dest:$version and $dest:latest (multi-arch)"
+    exit 0
+fi
+
+# --- step 1: push the locally-built image to its per-arch tag ---------------
+arch="${ARCH:-amd64}"
+image="localhost/fuse:$version"
 
 if ! "${podman[@]}" image exists "$image"; then
     echo "ERROR: $image not found in the podman store on this node." >&2
     echo "       Run build.sh here first (the store is node-local)." >&2
     exit 1
 fi
-if ! command -v gh >/dev/null 2>&1 || ! gh auth status >/dev/null 2>&1; then
-    echo "ERROR: gh CLI not authenticated. Run 'gh auth login' and add the" >&2
-    echo "       write:packages scope (see header)." >&2
-    exit 1
-fi
 
-user="$(gh api /user --jq .login)"
 echo "### Logging in to ghcr.io as $user"
 gh auth token | "${podman[@]}" login ghcr.io -u "$user" --password-stdin
 
 # Always log out afterwards so no registry credential lingers on the node.
 trap '"${podman[@]}" logout ghcr.io >/dev/null 2>&1 || true' EXIT
 
-echo "### Pushing $image -> $dest:$version (several GB, takes a while)"
-"${podman[@]}" push "$image" "$dest:$version"
-
-if [[ "${LATEST:-0}" == "1" ]]; then
-    echo "### Pushing $dest:latest"
-    "${podman[@]}" push "$image" "$dest:latest"
-fi
+echo "### Pushing $image -> $dest:$version-$arch (several GB, takes a while)"
+"${podman[@]}" push "$image" "$dest:$version-$arch"
 
 echo
-echo "### Published $dest:$version"
-echo "If this was the first push, the package is PRIVATE — make it public in"
-echo "the package settings so all sites can pull it unauthenticated:"
-echo "    https://github.com/orgs/ProjectTorreyPines/packages/container/package/fuse"
+echo "### Published $dest:$version-$arch"
+echo "Users pull :$version / :latest, which are manifest lists — publish those"
+echo "with MANIFEST=1 once BOTH -amd64 and -arm64 tags exist:"
+echo "    MANIFEST=1 FUSE_ENVIRONMENT=$version $0"

--- a/deploy/omega-container/publish_ghcr.sh
+++ b/deploy/omega-container/publish_ghcr.sh
@@ -111,7 +111,10 @@ if [[ "${MANIFEST:-0}" == "1" ]]; then
         "${podman[@]}" manifest add --all "fuse-manifest-$version" "docker://$dest:$version-arm64"
         "${podman[@]}" manifest push --all "fuse-manifest-$version" "docker://$dest:$version"
         "${podman[@]}" manifest push --all "fuse-manifest-$version" "docker://$dest:latest"
-        "${podman[@]}" manifest inspect "docker://$dest:$version"
+        # No docker:// prefix here: `manifest add` accepts that transport but
+        # `manifest inspect` does not ("unsupported transport docker for looking
+        # up local images") — it takes a plain remote reference.
+        "${podman[@]}" manifest inspect "$dest:$version"
     fi
     echo
     echo "### Published $dest:$version and $dest:latest (multi-arch)"

--- a/deploy/omega-container/test_slurm.sbatch
+++ b/deploy/omega-container/test_slurm.sbatch
@@ -12,8 +12,8 @@
 # are EPYC 7502 (znver2). (The sysimage's cascadelake target is kept for
 # Intel login/head nodes.)
 #
-#   sbatch --export=ALL,SIF=/fusion/.../fuse_v2.6.0.sif -C amd deploy/omega-container/test_slurm.sbatch
-#   sbatch --export=ALL,SIF=/fusion/.../fuse_v2.6.0.sif \
+#   sbatch --export=ALL,SIF=/fusion/.../fuse_v1.2.0.sif -C amd deploy/omega-container/test_slurm.sbatch
+#   sbatch --export=ALL,SIF=/fusion/.../fuse_v1.2.0.sif \
 #          --exclude="$(sinfo -h -N -p short -o '%N %f' | awk '$2=="amd"{print $1}' | paste -sd,)" \
 #          deploy/omega-container/test_slurm.sbatch
 #

--- a/deploy/perlmutter-container/Containerfile
+++ b/deploy/perlmutter-container/Containerfile
@@ -68,6 +68,14 @@ COPY Makefile /opt/build/Makefile
 # A failed warm-up is harmless — the sysimage bakes REPL regardless.
 RUN timeout 600 julia -e 'import REPL' || timeout 600 julia -e 'import REPL' || true
 
+# Bust the install layer's cache per FUSE version: layer caching is
+# registry-blind, so without this a same-node rebuild for a NEW release would
+# cache-hit the old install and silently bake the previous FUSE version.
+# Same-version rebuilds still reuse the cache. Kept AFTER the REPL warm-up so a
+# version change does not needlessly invalidate that (version-independent) layer.
+ARG FUSE_VERSION=""
+ENV FUSE_BUILD_VERSION="${FUSE_VERSION}"
+
 # Installs FUSE and all PTP packages into $FUSE_INSTALL_DIR, builds IJulia, and
 # compiles /opt/fuse/sys_fuse.so. This step is heavy (runs the FUSE test suite
 # and tutorial as precompile workload) and is best run inside a CPU allocation.

--- a/deploy/perlmutter-container/Containerfile
+++ b/deploy/perlmutter-container/Containerfile
@@ -111,7 +111,7 @@ RUN printf '%s\n' \
 # by the install (plain julia) are invalid once sys_fuse.so is loaded, so
 # without this every user would re-precompile IJulia/Plots/... on first use —
 # in a read-only image, into their own home depot.
-RUN fuse -e 'import IJulia, Plots, WebIO, Interact, EFIT, ArgParse'
+RUN fuse -e 'import IJulia, Plots, WebIO, Interact, EFIT, ArgParse, Revise'
 
 # Registries are cloned 0700; without world-read every in-container Pkg
 # operation fails for non-root users.

--- a/deploy/perlmutter-container/README.md
+++ b/deploy/perlmutter-container/README.md
@@ -31,7 +31,7 @@ cd $PSCRATCH/.julia/dev/FUSE        # the FUSE repo root (build context)
 `build.sh` will:
 
 1. Resolve the image tag (`fuse:<version>`) from the latest FUSE.jl release
-   (override with `FUSE_ENVIRONMENT=v1.1.3`).
+   (override with `FUSE_ENVIRONMENT=v1.2.0`).
 2. `podman-hpc build -t fuse:<version> -f deploy/perlmutter-container/Containerfile .`
 3. `podman-hpc migrate fuse:<version>` — converts the image to a read-only
    squashfs under `$SCRATCH` so it can be used in jobs and on any login node.
@@ -70,20 +70,20 @@ alias fuse-podman='podman-hpc --squash-dir /global/cfs/cdirs/m3739/shared_images
 
 # 1) confirm the image is visible
 fuse-podman images | grep fuse
-# expect: localhost/fuse  v1.1.3  ...  R/O
+# expect: localhost/fuse  v1.2.0  ...  R/O
 
 # 2) fast smoke test (loads FUSE from the baked-in sysimage, starts in seconds)
-fuse-podman run --rm fuse:v1.1.3 \
+fuse-podman run --rm fuse:v1.2.0 \
   julia --sysimage=/opt/fuse/sys_fuse.so \
   -e 'using FUSE; ini,act=FUSE.case_parameters(:D3D,:L_mode); println("FUSE OK: ", pkgversion(FUSE))'
 
 # 3) offline test (proves it is fully self-contained: no "Downloading artifact" lines)
-fuse-podman run --rm --network none fuse:v1.1.3 \
+fuse-podman run --rm --network none fuse:v1.2.0 \
   julia --sysimage=/opt/fuse/sys_fuse.so \
   -e 'using FUSE; ini,act=FUSE.case_parameters(:D3D,:L_mode); dd=FUSE.init(ini,act); println("OFFLINE OK")'
 
 # 4) interactive REPL (optional)
-fuse-podman run --rm -it fuse:v1.1.3
+fuse-podman run --rm -it fuse:v1.2.0
 ```
 
 For the Jupyter equivalent, see [Interactive use via Jupyter](#3-interactive-use-via-jupyter)
@@ -135,7 +135,7 @@ FUSE_ENVIRONMENT=<version> ./deploy/perlmutter-container/install_kernel.sh
 1. Open [NERSC JupyterHub](https://jupyter.nersc.gov) and start a server on a
    Perlmutter login node.
 2. Create a new notebook and select the **Julia FUSE-<version>** kernel
-   (display name e.g. `Julia FUSE-v1.1.3 (1 thread(s))`).
+   (display name e.g. `Julia FUSE-v1.2.0 (1 thread(s))`).
 3. Run this test cell:
 
    ```julia

--- a/deploy/perlmutter-container/build.sh
+++ b/deploy/perlmutter-container/build.sh
@@ -8,7 +8,7 @@
 #   ./deploy/perlmutter-container/build.sh
 #
 # Override the image tag (defaults to the latest FUSE.jl release) with:
-#   FUSE_ENVIRONMENT=v1.1.3 ./deploy/perlmutter-container/build.sh
+#   FUSE_ENVIRONMENT=v1.2.0 ./deploy/perlmutter-container/build.sh
 #
 # Share the migrated image across the project (instead of personal SCRATCH):
 #   SQUASH_DIR=/global/cfs/cdirs/m3739/shared_images ./build.sh

--- a/deploy/perlmutter-container/build.sh
+++ b/deploy/perlmutter-container/build.sh
@@ -43,7 +43,7 @@ if [[ -z "${SLURM_JOB_ID:-}" ]]; then
 fi
 
 echo "### Building $image (context: $repo_root)"
-podman-hpc build -t "$image" -f "$scriptdir/Containerfile" "$repo_root"
+podman-hpc build -t "$image" --build-arg FUSE_VERSION="$version" -f "$scriptdir/Containerfile" "$repo_root"
 
 echo "### Migrating $image to a squashed read-only image"
 if [[ -n "${SQUASH_DIR:-}" ]]; then

--- a/deploy/perlmutter-container/install_fuse_container.jl
+++ b/deploy/perlmutter-container/install_fuse_container.jl
@@ -79,7 +79,12 @@ println("    ", packages)
 println()
 println("### Setup FUSE environment in ", install_dir)
 Pkg.activate(install_dir)
-Pkg.add([["FUSE", "Plots", "IJulia", "WebIO", "Interact", "EFIT", "ArgParse"]; packages])
+# Revise is listed explicitly: FuseExamples notebooks open with `using Revise`
+# (fluxmatcher.ipynb cell 0), and the container serves those through its Jupyter
+# kernel. It is NOT a FUSE dependency. The v1.1.6 image got it from a dedicated
+# late Containerfile layer that was built into that release but never merged to
+# master, so v1.2.0 — built from master — shipped without it.
+Pkg.add([["FUSE", "Plots", "IJulia", "WebIO", "Interact", "EFIT", "ArgParse", "Revise"]; packages])
 Pkg.build("IJulia")
 
 println()

--- a/deploy/perlmutter-container/install_kernel.sh
+++ b/deploy/perlmutter-container/install_kernel.sh
@@ -7,7 +7,7 @@
 # notebooks.
 #
 # Run this AFTER ./build.sh has built and migrated the image. Usage:
-#   FUSE_ENVIRONMENT=v1.1.3 ./deploy/perlmutter-container/install_kernel.sh
+#   FUSE_ENVIRONMENT=v1.2.0 ./deploy/perlmutter-container/install_kernel.sh
 #
 # Optional:
 #   THREADS=8      number of Julia threads the kernel starts with (default 1)
@@ -16,7 +16,7 @@
 #                  `podman-hpc --squash-dir <dir> run ...`. Example (project
 #                  image shared with all of m3739):
 #                    SQUASH_DIR=/global/cfs/cdirs/m3739/shared_images \
-#                    FUSE_ENVIRONMENT=v1.1.3 ./install_kernel.sh
+#                    FUSE_ENVIRONMENT=v1.2.0 ./install_kernel.sh
 
 set -euo pipefail
 

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -6,13 +6,16 @@ FUSE requires **Julia 1.11 or newer** (the regression suite runs on 1.11 and the
 
 !!! tip "No-install alternative: the FUSE container"
     If you just want to *run* released FUSE (not develop it), a self-contained
-    image with FUSE, all ProjectTorreyPines packages, and a precompiled
-    sysimage (startup in seconds) is published to
+    image with FUSE and all ProjectTorreyPines packages is published to
     [ghcr.io/projecttorreypines/fuse](https://github.com/orgs/ProjectTorreyPines/packages/container/package/fuse);
-    `latest` is the most recent FUSE release, and version tags (`v1.1.5`, ...)
-    are available for reproducibility.
+    `latest` is the most recent FUSE release, and version tags (`v1.2.0`, ...)
+    are available for reproducibility. The tags are multi-architecture, so the
+    same command pulls the right image on x86_64 and on Apple Silicon — no
+    `--platform` flag and no emulation. The x86_64 image carries a precompiled
+    sysimage (startup in seconds); the arm64 one ships package precompilation
+    only, so its first-call latency is higher.
 
-    Laptop (Docker; on Apple Silicon add `--platform linux/amd64`):
+    Laptop (Docker or podman):
     ```bash
     docker run -it ghcr.io/projecttorreypines/fuse:latest
     ```

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -12,8 +12,9 @@ FUSE requires **Julia 1.11 or newer** (the regression suite runs on 1.11 and the
     are available for reproducibility. The tags are multi-architecture, so the
     same command pulls the right image on x86_64 and on Apple Silicon — no
     `--platform` flag and no emulation. The x86_64 image carries a precompiled
-    sysimage (startup in seconds); the arm64 one ships package precompilation
-    only, so its first-call latency is higher.
+    sysimage, so `import FUSE` takes ~5 s; the arm64 image ships per-package
+    precompilation instead (no aarch64 sysimage can be linked), so `import FUSE`
+    takes ~30–60 s there. Compute speed after loading is the same.
 
     Laptop (Docker or podman):
     ```bash

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -10,11 +10,11 @@ FUSE requires **Julia 1.11 or newer** (the regression suite runs on 1.11 and the
     [ghcr.io/projecttorreypines/fuse](https://github.com/orgs/ProjectTorreyPines/packages/container/package/fuse);
     `latest` is the most recent FUSE release, and version tags (`v1.2.0`, ...)
     are available for reproducibility. The tags are multi-architecture, so the
-    same command pulls the right image on x86_64 and on Apple Silicon — no
-    `--platform` flag and no emulation. The x86_64 image carries a precompiled
-    sysimage, so `import FUSE` takes ~5 s; the arm64 image ships per-package
-    precompilation instead (no aarch64 sysimage can be linked), so `import FUSE`
-    takes ~30–60 s there. Compute speed after loading is the same.
+    same command pulls the right image on x86_64 and on Apple Silicon. The 
+    x86_64 image carries a precompiled sysimage, so `import FUSE` takes ~5 s; 
+    the arm64 image ships per-package precompilation instead (no aarch64 
+    sysimage can be linked), so `import FUSE` takes ~30–60 s there. Compute 
+    speed after loading is the same.
 
     Laptop (Docker or podman):
     ```bash


### PR DESCRIPTION
## Summary

Makes the FUSE container release reproducible from the repo, builds the arm64 leg automatically in CI, and fixes a dependency that silently disappeared in v1.2.0.

Five commits, each independently reviewable:

**`28ac82b7` Multi-arch GHCR publishing.** `:<version>` and `:latest` are manifest lists over per-arch images, so one command pulls the right image on x86_64 and Apple Silicon. v1.1.6 was published that way by hand, and `publish_ghcr.sh` would have overwritten the manifest with a single-arch image on the next release. The script now pushes to `:<version>-<arch>` (`ARCH`, default amd64) and gains a `MANIFEST=1` mode that combines the per-arch tags, preferring `docker buildx imagetools create` and falling back to podman. `build.sh` asserts `pkgversion(FUSE)` matches the tag after building, so a stale cached layer cannot ship under the wrong version.

**`6350f04b` Build arm64 automatically on release.** The two legs are blocked by unrelated walls, and the header/README now say so accurately. amd64 is blocked by *memory* — sysimage object emission peaks at ~98.5 GiB RSS, far beyond 16 GB runners — so it stays on omega. arm64 cannot have a sysimage *at all*, for a linker reason: the sysimage embeds a ~3.2 GB blob of serialized program state, and aarch64 must bridge it with 32-bit relative references (`R_AARCH64_PREL32`) capped at 2.147 GB. The build compiles for 5+ hours and then fails in the final second at the link step, identically for every variant tried. x86_64 escapes only via the medium code model's `.ldata` section, which aarch64 lacks. Shipping per-package pkgimages instead costs ~30–60 s for `import FUSE` versus ~5 s, with identical compute speed afterwards — and dropping the sysimage emission is what puts this leg back under 16 GB. Verified: a dispatched run built and pushed `v1.2.0-arm64` in **29.5 minutes**.

**`11ab9239` Install Revise explicitly.** The v1.2.0 container had no Revise, so `using Revise` failed. v1.1.6 had it from a dedicated late Containerfile layer (`601051953`, "container: bake Revise (late layer)") that was built into that release from the `v116-build` worktree but **never merged to master** — so v1.2.0, built from master, correctly reflected a master that had lost the fix. This breaks real usage: the container serves a Jupyter kernel via `fuse-container lab`, and `FuseExamples/fluxmatcher.ipynb` opens with `using Revise`, which the install docs point users at. Installing it alongside Plots/IJulia rather than in a late layer means it is resolved with everything else and cannot be dropped by a merge that misses one layer.

**`391f5607` Pre-publish acceptance checks.** The checks that found the Revise regression lived in a scratch file on node-local `/local-scratch`, which omega's cleanup wipes — the same cleanup that gutted the podman layer cache during this build. `deploy/omega-container/acceptance.sh` puts 12 checks in the repo and the README runs them before `publish_ghcr.sh`.

**`7fd53049` Bust the install layer cache per FUSE version** (cherry-picked from `e814f4476`). Auditing the Revise regression showed this was the *second* container fix built into the v1.1.6 image from the `v116-build` worktree and never merged to master. Layer caching is registry-blind, so rebuilding on a node whose podman store still holds a previous release's layers cache-hits the heavy install step and silently bakes the OLD FUSE version under the new tag — which, per its original commit message, "nearly happened building v1.1.6 over the v1.1.5 store". Threading the resolved version through a `FUSE_VERSION` build-arg into an `ENV` just before the install `RUN` busts the cache on a new version while same-version rebuilds still reuse it. This complements the `build.sh` assertion in `28ac82b7`: the assertion *detects* a wrong-version image, this *prevents* one.

## Notes for reviewers

- The `container` workflow was **disabled** in GitHub Actions (that is what the old README's "currently disabled" meant literally). Enabling it was required for the release trigger; it is now live for future releases.
- On a release run only arm64 builds, so the manifest job skips itself when the amd64 tag is missing rather than publishing an arm64-only `:latest` that would strand x86_64 users. Finish from omega with `MANIFEST=1 FUSE_ENVIRONMENT=<version> deploy/omega-container/publish_ghcr.sh`.
- **Is this drift systemic?** No. Swept every remote branch for container commits absent from master, content-checking `master`'s files rather than matching commit subjects (PR merges reword them). `container-ci-swap` looked like the largest risk at 7 unmerged commits but every change is present, landed via #1142/#1143 under squashed titles; same for `arm64-container-support` (#1148) and `omega-lab-oneliner` (#1146). `container-version-cachebust` was the only branch with genuinely stranded work — it is the one branch merged into the `v116-build` worktree for the release without ever getting its own PR. The cause is building a release off a worktree instead of off master, not a systemic merge failure.
- Every check in `acceptance.sh` asserts the precondition it is testing. This is not defensive padding: the pedestal check originally drove `ActorPedestal` with `model=:EPED`, which uses EPEDNN.jl's own baked weights and never reads `FUSE_PEDESTAL_NN_DIR` — it would have passed while testing nothing.

## Verification

- amd64 built on omega14 and verified in-image as FUSE 1.2.0, with `acceptance.sh` run before publishing.
- The Revise regression was confirmed against the published v1.1.6 SIF as a control rather than assumed from the failure alone.
- arm64 built, verified, and pushed by CI run 31784535705; re-dispatched as 31825772362 to pick up Revise.
- `podman manifest add` requires `--all` for foreign-arch remote refs (podman 4.9.4); validated against the live v1.1.6 tags, reproducing the published manifest structure exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
