### PR TITLE
Container: one-command JupyterLab on laptops (docker run ... lab)

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -177,6 +177,16 @@ jobs:
           echo "image has FUSE v$got, release is ${{ needs.version.outputs.version }}"
           [ "v$got" = "${{ needs.version.outputs.version }}" ]
 
+      # the laptop `docker run ... lab` flow needs the in-image Jupyter server,
+      # the lab launcher, and the baked FUSE kernelspec
+      - name: Verify the image is Jupyter-self-contained
+        run: |
+          docker run --rm "$IMAGE:${{ needs.version.outputs.version }}-${{ matrix.arch }}" bash -c '
+            jupyter lab --version || { echo "missing jupyter lab"; exit 1; }
+            [ -x /usr/local/bin/lab ] || { echo "missing lab launcher"; exit 1; }
+            jupyter kernelspec list | grep -q "^  fuse " || { echo "fuse kernelspec not found"; jupyter kernelspec list; exit 1; }
+            [ -f /opt/fuse/FuseExamples/fluxmatcher.ipynb ] || { echo "missing baked FuseExamples clone"; exit 1; }'
+
       - name: Push per-arch tag
         run: docker push "$IMAGE:${{ needs.version.outputs.version }}-${{ matrix.arch }}"
 

--- a/deploy/omega-container/README.md
+++ b/deploy/omega-container/README.md
@@ -351,6 +351,21 @@ Consuming the published image:
 # Laptop / any machine with Docker or podman — architecture selected automatically
 docker run -it ghcr.io/projecttorreypines/fuse:<version>
 
+# Laptop JupyterLab: the image ships a Jupyter server + FUSE kernelspec, so
+# one command serves JupyterLab on localhost:8888 (like `fuse-container lab`
+# on omega; THREADS=N sets the kernel's Julia threads). A fixed JUPYTER_TOKEN
+# gives a predictable URL — for the browser, or for VS Code's
+# "Select Kernel -> Existing Jupyter Server" (bind 127.0.0.1 so the known
+# token is not reachable from the LAN).
+docker run -it -p 127.0.0.1:8888:8888 -e JUPYTER_TOKEN=fuse -e THREADS=8 \
+    -v "$PWD":/work -w /work ghcr.io/projecttorreypines/fuse:<version> lab
+
+# NOTE: `docker run` re-uses a locally cached tag without consulting the
+# registry. If a machine pulled `latest` before the multi-arch manifest was
+# published it will keep running the wrong architecture (e.g. amd64 under
+# emulation on Apple Silicon, with HostCPUFeatures "CPU info is out-of-date"
+# warnings) until an explicit `docker pull ghcr.io/projecttorreypines/fuse:latest`.
+
 # NERSC Perlmutter
 podman-hpc pull ghcr.io/projecttorreypines/fuse:<version>
 podman-hpc migrate ghcr.io/projecttorreypines/fuse:<version>

--- a/deploy/omega-container/README.md
+++ b/deploy/omega-container/README.md
@@ -357,7 +357,7 @@ docker run -it ghcr.io/projecttorreypines/fuse:<version>
 # gives a predictable URL — for the browser, or for VS Code's
 # "Select Kernel -> Existing Jupyter Server" (bind 127.0.0.1 so the known
 # token is not reachable from the LAN).
-docker run -it -p 127.0.0.1:8888:8888 -e JUPYTER_TOKEN=fuse -e THREADS=8 \
+docker run -it --pull always -p 127.0.0.1:8888:8888 -e JUPYTER_TOKEN=fuse -e THREADS=8 \
     -v "$PWD":/work -w /work ghcr.io/projecttorreypines/fuse:<version> lab
 
 # NOTE: `docker run` re-uses a locally cached tag without consulting the

--- a/deploy/omega-container/acceptance.sh
+++ b/deploy/omega-container/acceptance.sh
@@ -115,6 +115,15 @@ check "revise-loads" bash -c "
 check "host-tools-present" bash -c "
     ${podman[*]} run --rm $image bash -c 'for t in ps ssh rsync; do command -v \$t || { echo \"  missing \$t\"; exit 1; }; done'"
 
+# The laptop one-command flow (`docker run ... lab`) serves JupyterLab from
+# inside the image, so the server, launcher, and baked kernelspec must ship.
+check "jupyterlab-self-contained" bash -c "
+    ${podman[*]} run --rm $image bash -c '
+        jupyter lab --version || { echo \"  missing jupyter lab\"; exit 1; }
+        [ -x /usr/local/bin/lab ] || { echo \"  missing lab launcher\"; exit 1; }
+        jupyter kernelspec list | grep -q \"^  fuse \" || { echo \"  fuse kernelspec not found\"; jupyter kernelspec list; exit 1; }
+        [ -f /opt/fuse/FuseExamples/fluxmatcher.ipynb ] || { echo \"  missing baked FuseExamples clone\"; exit 1; }'"
+
 # --- physics smoke ----------------------------------------------------------
 check "init-and-plot-png" bash -c "
     ${podman[*]} run --rm -v $out:/out:Z $image fuse -e '

--- a/deploy/omega-container/fuse-container
+++ b/deploy/omega-container/fuse-container
@@ -110,7 +110,49 @@ if [[ "${1:-}" == "notebook" || "${1:-}" == "lab" ]]; then
 }
 EOF
     echo "fuse-container: kernelspec 'fuse-$version' installed ($threads thread(s); set THREADS=N to change)"
-    exec jupyter "$mode" "$@"
+
+    # Give users a writable FuseExamples in the current directory, copied from
+    # the clone baked into the SIF at /opt/fuse/FuseExamples (older SIFs don't
+    # have it — then this is a no-op). An existing copy is left alone so user
+    # edits survive re-runs. Best effort: any failure just skips the copy.
+    # The SIF is mounted briefly with the same tracked-foreground-squashfuse
+    # approach as the main path below (see header for why not --sif-fuse),
+    # and unmounted before jupyter starts — the kernelspec mounts per kernel.
+    if [[ ! -e FuseExamples && -w . ]]; then
+        offset="$(singularity sif list "$sif" 2>/dev/null \
+                  | awk -F'|' '/Squashfs/ {split($4,a,"-"); gsub(/ /,"",a[1]); print a[1]; exit}')"
+        exmnt="$(mktemp -d "${TMPDIR:-/tmp}/fuse-mnt.XXXXXX")"
+        expid=""
+        if [[ -n "$offset" ]]; then
+            squashfuse -f -o ro,offset="$offset" "$sif" "$exmnt" &
+            expid=$!
+            for _ in $(seq 1 100); do mountpoint -q "$exmnt" && break; sleep 0.1; done
+        fi
+        if mountpoint -q "$exmnt"; then
+            if [[ -d "$exmnt/opt/fuse/FuseExamples" ]]; then
+                cp -a "$exmnt/opt/fuse/FuseExamples" . \
+                    && echo "fuse-container: copied FuseExamples notebooks into $PWD"
+            fi
+            fusermount -u "$exmnt" 2>/dev/null
+        fi
+        [[ -n "$expid" ]] && kill "$expid" 2>/dev/null
+        rmdir "$exmnt" 2>/dev/null
+    fi
+
+    # Open Jupyter's file browser at FuseExamples: default_url makes the
+    # banner token URL the user pastes land there directly. It must be set on
+    # the frontend app class (lab/notebook override ServerApp.default_url);
+    # an older host jupyter that doesn't know the class ignores it gracefully.
+    jupyter_args=()
+    if [[ -d FuseExamples ]]; then
+        if [[ "$mode" == "notebook" ]]; then
+            jupyter_args+=(--JupyterNotebookApp.default_url=/tree/FuseExamples)
+        else
+            jupyter_args+=(--LabApp.default_url=/lab/tree/FuseExamples)
+        fi
+        echo "fuse-container: Jupyter opens at FuseExamples/"
+    fi
+    exec jupyter "$mode" "${jupyter_args[@]}" "$@"
 fi
 
 # Pre-flight: on the read-only SIF rootfs the in-image `fuse` entrypoint needs

--- a/deploy/perlmutter-container/Containerfile
+++ b/deploy/perlmutter-container/Containerfile
@@ -68,6 +68,19 @@ COPY Makefile /opt/build/Makefile
 # A failed warm-up is harmless — the sysimage bakes REPL regardless.
 RUN timeout 600 julia -e 'import REPL' || timeout 600 julia -e 'import REPL' || true
 
+# JupyterLab server, so the image is Jupyter-self-contained on laptops:
+#   docker run -it -p 8888:8888 ghcr.io/projecttorreypines/fuse:latest lab
+# (On omega/NERSC the server runs on the host instead and only the kernel
+# lives in the container — this venv is unused there and costs ~300 MB.)
+# Kept BEFORE the FUSE_VERSION cache-bust: it is version-independent, so
+# same-node rebuilds for a new release reuse this layer.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3-venv \
+    && rm -rf /var/lib/apt/lists/* \
+    && python3 -m venv /opt/jupyter \
+    && /opt/jupyter/bin/pip install --no-cache-dir jupyterlab notebook \
+    && ln -s /opt/jupyter/bin/jupyter /usr/local/bin/jupyter
+
 # Bust the install layer's cache per FUSE version: layer caching is
 # registry-blind, so without this a same-node rebuild for a NEW release would
 # cache-hit the old install and silently bake the previous FUSE version.
@@ -115,6 +128,60 @@ RUN printf '%s\n' \
     > /usr/local/bin/fuse \
     && chmod 0555 /usr/local/bin/fuse
 
+# In-image Jupyter kernelspec for the baked FUSE install. /usr/local/share/
+# jupyter is on Jupyter's default kernel search path, so the /opt/jupyter
+# server finds it with no install step. Thread count is read at kernel launch
+# from JULIA_NUM_THREADS, which the `lab` launcher below derives from THREADS —
+# mirroring `THREADS=8 fuse-container lab` on omega.
+RUN kdir=/usr/local/share/jupyter/kernels/fuse \
+    && mkdir -p "$kdir" \
+    && v="${FUSE_BUILD_VERSION:+-$FUSE_BUILD_VERSION}" \
+    && printf '%s\n' \
+    '{' \
+    '  "argv": [' \
+    '    "/bin/bash",' \
+    '    "-c",' \
+    '    "exec fuse --color=yes -e '"'"'import IJulia; IJulia.run_kernel()'"'"' \"$1\"",' \
+    '    "fuse-kernel",' \
+    '    "{connection_file}"' \
+    '  ],' \
+    "  \"display_name\": \"Julia FUSE$v (container)\"," \
+    '  "language": "julia",' \
+    '  "metadata": { "debugger": true }' \
+    '}' \
+    > "$kdir/kernel.json"
+
+# `lab` / `notebook` start a JupyterLab (or classic notebook) server bound to
+# 0.0.0.0 so a published port reaches it:
+#   docker run -it -p 127.0.0.1:8888:8888 -e JUPYTER_TOKEN=fuse -e THREADS=8 \
+#       -v "$PWD":/work -w /work ghcr.io/projecttorreypines/fuse:latest lab
+# THREADS=N sets the FUSE kernel's Julia threads; a fixed JUPYTER_TOKEN gives
+# a predictable URL (browser, or VS Code "Existing Jupyter Server" attach).
+RUN printf '%s\n' \
+    '#!/bin/bash' \
+    'mode="$(basename "$0")"' \
+    'export JULIA_NUM_THREADS="${THREADS:-${JULIA_NUM_THREADS:-1}}"' \
+    'echo "FUSE kernel threads: $JULIA_NUM_THREADS (set THREADS=N to change)"' \
+    '# give users a writable FuseExamples in the (mounted) working directory;' \
+    '# an existing one is left alone so their edits survive re-runs' \
+    'if [ ! -e FuseExamples ] && [ -w . ] && [ -d /opt/fuse/FuseExamples ]; then' \
+    '    cp -a /opt/fuse/FuseExamples . && echo "copied FuseExamples notebooks into $PWD"' \
+    'fi' \
+    '# jupyter prints container-side URLs; with a fixed token we can print the' \
+    '# host-side link to click (assumes the documented -p HOSTPORT:8888 mapping),' \
+    '# opening the file browser at FuseExamples when it is there' \
+    'if [ -n "${JUPYTER_TOKEN:-}" ]; then' \
+    '    path=lab; [ "$mode" = notebook ] && path=tree' \
+    '    if [ -d FuseExamples ]; then' \
+    '        path="lab/tree/FuseExamples"; [ "$mode" = notebook ] && path="tree/FuseExamples"' \
+    '    fi' \
+    '    echo "open in your browser:  http://localhost:${PORT:-8888}/$path?token=$JUPYTER_TOKEN"' \
+    'fi' \
+    'exec jupyter "$mode" --ip=0.0.0.0 --port="${PORT:-8888}" --no-browser --allow-root "$@"' \
+    > /usr/local/bin/lab \
+    && chmod 0555 /usr/local/bin/lab \
+    && ln -s lab /usr/local/bin/notebook
+
 # Precompile the interactive stack UNDER the sysimage: package caches produced
 # by the install (plain julia) are invalid once sys_fuse.so is loaded, so
 # without this every user would re-precompile IJulia/Plots/... on first use —
@@ -124,6 +191,14 @@ RUN fuse -e 'import IJulia, Plots, WebIO, Interact, EFIT, ArgParse, Revise'
 # Registries are cloned 0700; without world-read every in-container Pkg
 # operation fails for non-root users.
 RUN chmod -R a+rX /opt/fuse/.julia/registries
+
+# FuseExamples notebooks, served by the `lab` launcher below: on startup it
+# copies this clone into the (mounted) working directory so users get a
+# writable copy whose edits persist on the host. A full clone (not shallow)
+# with the github origin, so that copy can simply `git pull` later. Placed
+# after the FUSE_VERSION cache-bust: each release build snapshots current
+# master.
+RUN git clone https://github.com/ProjectTorreyPines/FuseExamples /opt/fuse/FuseExamples
 
 # procps: FUSE's memory monitor shells out to `ps -o rss=` (utils_end.jl).
 # openssh-client + rsync: FUSE's remote D3D data fetching (src/cases/D3D.jl).

--- a/deploy/perlmutter-container/Containerfile
+++ b/deploy/perlmutter-container/Containerfile
@@ -157,7 +157,7 @@ RUN kdir=/usr/local/share/jupyter/kernels/fuse \
 
 # `lab` / `notebook` start a JupyterLab (or classic notebook) server bound to
 # 0.0.0.0 so a published port reaches it:
-#   docker run -it -p 127.0.0.1:8888:8888 -e JUPYTER_TOKEN=fuse -e THREADS=8 \
+#   docker run -it --pull always -p 127.0.0.1:8888:8888 -e JUPYTER_TOKEN=fuse -e THREADS=8 \
 #       -v "$PWD":/work -w /work ghcr.io/projecttorreypines/fuse:latest lab
 # THREADS=N sets the FUSE kernel's Julia threads; a fixed JUPYTER_TOKEN gives
 # a predictable URL (browser, or VS Code "Existing Jupyter Server" attach).

--- a/deploy/perlmutter-container/Containerfile
+++ b/deploy/perlmutter-container/Containerfile
@@ -149,7 +149,11 @@ RUN kdir=/usr/local/share/jupyter/kernels/fuse \
     '  "language": "julia",' \
     '  "metadata": { "debugger": true }' \
     '}' \
-    > "$kdir/kernel.json"
+    > "$kdir/kernel.json" \
+    # drop the kernelspec IJulia's Pkg.build installed into root's home: it
+    # shows up in the picker next to the FUSE kernel but launches plain julia,
+    # bypassing the `fuse` entrypoint (no writable-depot handling)
+    && rm -rf /root/.local/share/jupyter/kernels/julia-1.11
 
 # `lab` / `notebook` start a JupyterLab (or classic notebook) server bound to
 # 0.0.0.0 so a published port reaches it:

--- a/deploy/perlmutter-container/Containerfile
+++ b/deploy/perlmutter-container/Containerfile
@@ -177,7 +177,15 @@ RUN printf '%s\n' \
     '    fi' \
     '    echo "open in your browser:  http://localhost:${PORT:-8888}/$path?token=$JUPYTER_TOKEN"' \
     'fi' \
-    'exec jupyter "$mode" --ip=0.0.0.0 --port="${PORT:-8888}" --no-browser --allow-root "$@"' \
+    '# default_url makes any entry URL (including the banner ones jupyter' \
+    '# prints) land on the FuseExamples file browser. NOTE: must be set on the' \
+    '# frontend app class — lab/notebook override ServerApp.default_url.' \
+    'durl=""' \
+    'if [ -d FuseExamples ]; then' \
+    '    durl="--LabApp.default_url=/lab/tree/FuseExamples"' \
+    '    [ "$mode" = notebook ] && durl="--JupyterNotebookApp.default_url=/tree/FuseExamples"' \
+    'fi' \
+    'exec jupyter "$mode" --ip=0.0.0.0 --port="${PORT:-8888}" --no-browser --allow-root $durl "$@"' \
     > /usr/local/bin/lab \
     && chmod 0555 /usr/local/bin/lab \
     && ln -s lab /usr/local/bin/notebook

--- a/deploy/perlmutter-container/README.md
+++ b/deploy/perlmutter-container/README.md
@@ -26,7 +26,7 @@ and only the kernel lives in the container (see below).
 | `install_kernel.sh` | Generates and installs the FUSE Jupyter kernel for the current user. |
 | `acceptance.sh` | Acceptance suite for a pulled/built image (mirrors `../omega-container/acceptance.sh`). |
 | `test_slurm.sbatch` | Compute-node smoke test (D3D L-mode init + flux matcher in a debug-queue job). |
-| `install_fuse_container_nersc.sh` | One-command user setup: get the image (m3739 shared store, else registry pull) + install the Jupyter kernel. Curl-able, needs no checkout. |
+| `install_fuse_container_nersc.sh` | One-command user setup: get the image (m3739 shared store, else registry pull), install the Jupyter kernel, and copy the baked FuseExamples notebooks to `$HOME`. Curl-able, needs no checkout. |
 
 ## 1. Build the image
 

--- a/deploy/perlmutter-container/README.md
+++ b/deploy/perlmutter-container/README.md
@@ -6,6 +6,15 @@ PackageCompiler system image (`sys_fuse.so`) for fast startup. It mirrors the
 Lmod module deploy in [`../perlmutter`](../perlmutter) but ships everything in a
 single OCI image instead of an environment module.
 
+The image also carries a JupyterLab server (`/opt/jupyter` venv) and a baked
+`fuse` kernelspec, so on a laptop one command serves JupyterLab with the FUSE
+kernel: `docker run -it -p 127.0.0.1:8888:8888 -e JUPYTER_TOKEN=fuse -v
+"$PWD":/work -w /work ghcr.io/projecttorreypines/fuse:latest lab`
+(`-e THREADS=8` sets kernel threads; the fixed token also lets VS Code attach
+via "Select Kernel → Existing Jupyter Server").
+On Perlmutter and omega the Jupyter server runs on the host instead
+and only the kernel lives in the container (see below).
+
 ## Contents
 
 | File | Purpose |

--- a/deploy/perlmutter-container/README.md
+++ b/deploy/perlmutter-container/README.md
@@ -8,7 +8,7 @@ single OCI image instead of an environment module.
 
 The image also carries a JupyterLab server (`/opt/jupyter` venv) and a baked
 `fuse` kernelspec, so on a laptop one command serves JupyterLab with the FUSE
-kernel: `docker run -it -p 127.0.0.1:8888:8888 -e JUPYTER_TOKEN=fuse -v
+kernel: `docker run -it --pull always -p 127.0.0.1:8888:8888 -e JUPYTER_TOKEN=fuse -v
 "$PWD":/work -w /work ghcr.io/projecttorreypines/fuse:latest lab`
 (`-e THREADS=8` sets kernel threads; the fixed token also lets VS Code attach
 via "Select Kernel → Existing Jupyter Server").

--- a/deploy/perlmutter-container/install_fuse_container_nersc.sh
+++ b/deploy/perlmutter-container/install_fuse_container_nersc.sh
@@ -85,8 +85,22 @@ fi
 
 SQUASH_DIR="$squash_dir" FUSE_ENVIRONMENT="$version" THREADS="${THREADS:-8}" "$installer"
 
+# --- FuseExamples tutorials ---------------------------------------------------
+# Copy the notebooks baked into the image (a full clone with the github
+# origin, so `git pull` works later) into $HOME, where the JupyterHub file
+# browser starts. An existing copy is left alone so user edits survive
+# re-installs. Best effort: older images without the baked clone skip this.
+if [[ ! -e "$HOME/FuseExamples" ]]; then
+    echo "### Copying FuseExamples notebooks to \$HOME/FuseExamples"
+    run_args=(); [[ -n "$squash_dir" ]] && run_args=(--squash-dir "$squash_dir")
+    podman-hpc "${run_args[@]}" run --rm -v "$HOME:/mnt/home" "localhost/fuse:$version" \
+        bash -c 'if [ -d /opt/fuse/FuseExamples ]; then cp -a /opt/fuse/FuseExamples /mnt/home/; else echo "  (image predates the baked FuseExamples — skipping)"; fi' \
+        || echo "  (copy failed — get them with: git clone https://github.com/ProjectTorreyPines/FuseExamples)"
+fi
+
 echo
 echo "### FUSE container ready."
 echo "Open https://jupyter.nersc.gov, start a server, and select"
-echo "the 'Julia FUSE-$version' kernel. First cell to try:"
+echo "the 'Julia FUSE-$version' kernel — e.g. on FuseExamples/fluxmatcher.ipynb"
+echo "in the file browser. First cell to try:"
 echo "    using FUSE; ini, act = FUSE.case_parameters(:D3D, :L_mode); dd = FUSE.init(ini, act)"

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -36,7 +36,8 @@ FUSE requires **Julia 1.11 or newer** (the regression suite runs on 1.11 and the
     bash <(curl -fsSL https://raw.githubusercontent.com/ProjectTorreyPines/FUSE.jl/master/deploy/perlmutter-container/install_fuse_container_nersc.sh)
     ```
     then open [jupyter.nersc.gov](https://jupyter.nersc.gov), start a server,
-    and select the **Julia FUSE-`<version>`** kernel.
+    and select the **Julia FUSE-`<version>`** kernel — e.g. on one of the
+    `FuseExamples` notebooks the install placed in your `$HOME`.
 
     Details: [`deploy/omega-container/README.md`](https://github.com/ProjectTorreyPines/FUSE.jl/blob/master/deploy/omega-container/README.md)
     (omega) and [`deploy/perlmutter-container/README.md`](https://github.com/ProjectTorreyPines/FUSE.jl/blob/master/deploy/perlmutter-container/README.md)

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -15,7 +15,7 @@ FUSE requires **Julia 1.11 or newer** (the regression suite runs on 1.11 and the
     Laptop (Docker or podman) — JupyterLab with the FUSE kernel, served from
     inside the container (`-e THREADS=8` sets the kernel's Julia threads):
     ```bash
-    docker run -it -p 127.0.0.1:8888:8888 -e JUPYTER_TOKEN=fuse -e THREADS=8 -v "$PWD":/work -w /work ghcr.io/projecttorreypines/fuse:latest lab
+    docker run -it --pull always -p 127.0.0.1:8888:8888 -e JUPYTER_TOKEN=fuse -e THREADS=8 -v "$PWD":/work -w /work ghcr.io/projecttorreypines/fuse:latest lab
     ```
     then open the link it prints:
     <http://localhost:8888/lab/tree/FuseExamples?token=fuse>. On first run a

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -12,10 +12,19 @@ FUSE requires **Julia 1.11 or newer** (the regression suite runs on 1.11 and the
     are available for reproducibility. The tags are multi-architecture, so the
     same command pulls the right image on x86\_64 and on Apple Silicon.
 
-    Laptop (Docker or podman):
+    Laptop (Docker or podman) — JupyterLab with the FUSE kernel, served from
+    inside the container (`-e THREADS=8` sets the kernel's Julia threads):
     ```bash
-    docker run -it ghcr.io/projecttorreypines/fuse:latest
+    docker run -it -p 127.0.0.1:8888:8888 -e JUPYTER_TOKEN=fuse -e THREADS=8 -v "$PWD":/work -w /work ghcr.io/projecttorreypines/fuse:latest lab
     ```
+    then open the link it prints:
+    <http://localhost:8888/lab/tree/FuseExamples?token=fuse>. On first run a
+    copy of [`FuseExamples`](https://github.com/ProjectTorreyPines/FuseExamples)
+    is placed in the mounted current directory and the browser opens there, so
+    edits and new notebooks persist on your machine. (VS Code users can
+    instead paste that URL under **Select Kernel → Existing Jupyter Server**
+    in a notebook to get the **Julia FUSE (container)** kernel.)
+
     omega (JupyterLab, worker nodes).
     JupyterLab itself runs on the host, so `jupyter` must be on `PATH`
     (e.g. via `module load fuse`):


### PR DESCRIPTION
## Summary

Makes the published container serve the full laptop Jupyter experience from a single command, mirroring omega's `fuse-container lab`:

```bash
docker run -it -p 127.0.0.1:8888:8888 -e JUPYTER_TOKEN=fuse -e THREADS=8 \
    -v "$PWD":/work -w /work ghcr.io/projecttorreypines/fuse:latest lab
```

then click the printed link — JupyterLab opens on a writable copy of FuseExamples with the FUSE kernel ready, everything saved to the mounted host directory.

The same "tutorials are the landing page" experience covers all three container flows — before this, container users had to know FuseExamples existed and clone it themselves. omega's `fuse-container lab` gets it too: it copies the baked FuseExamples into the current directory on first run (briefly mounting the SIF with the launcher's tracked-foreground-squashfuse approach, unmounted before jupyter starts; no-op for older SIFs) and the banner token URL the user pastes lands directly on the FuseExamples file browser.

## Changes

- **Containerfile**
  - JupyterLab server in an `/opt/jupyter` venv (~300 MB), in a version-independent layer placed before the `FUSE_VERSION` cache-bust so rebuilds reuse it
  - system-wide `fuse` kernelspec launching the baked install through the `fuse` entrypoint (sysimage on amd64, pkgimages on arm64); `THREADS=N` sets the kernel's Julia threads
  - `lab`/`notebook` launchers: bind 0.0.0.0 so the published port reaches the server; copy the baked FuseExamples clone into the working directory on first run (existing copies are never touched, so user edits survive re-runs); print the host-side clickable URL (predictable via the fixed `JUPYTER_TOKEN`), opening the file browser at FuseExamples
  - full FuseExamples clone baked at `/opt/fuse/FuseExamples` (github origin kept so user copies can `git pull` later)
- **install_fuse_container_nersc.sh (NERSC)**: after kernel install, copies the baked FuseExamples to `$HOME`, where the jupyter.nersc.gov file browser starts — completing tutorial parity across all three container flows (existing copies untouched; pre-bake images skip with a note)
- **fuse-container (omega)**: `lab`/`notebook` copy FuseExamples out of the SIF on first run and open Jupyter there via `--LabApp.default_url` / `--JupyterNotebookApp.default_url` — the frontend app classes override `ServerApp.default_url` (verified live), and older host jupyters ignore the unknown class gracefully
- **acceptance.sh + container.yml verify step**: assert the server, `lab` launcher, kernelspec, and FuseExamples ship — covering both publish paths (omega amd64, CI arm64)
- **docs**: install.md laptop flow is now the `lab` one-command (with a one-line VS Code "Existing Jupyter Server" note); omega README documents the stale locally-cached `latest` tag pitfall (amd64 under emulation on Apple Silicon → HostCPUFeatures warnings, fixed by an explicit `docker pull`)

## Testing

Smoke-tested the new layers in an isolated Debian image built from the exact `RUN` blocks:

- `jupyter kernelspec list` finds the `fuse` kernel; `/api/kernelspecs` serves it with the fixed token and 403s without
- `docker run -p ... lab` boots, prints `open in your browser: http://localhost:8888/lab/tree/FuseExamples?token=fuse`, and that URL serves HTTP 200 from the host
- first run copies FuseExamples into the mounted dir (github origin intact); second run leaves an edited copy untouched
- with default_url set, both the root URL redirect and jupyter's banner URL land on `/lab/tree/FuseExamples` (and `/tree/FuseExamples` for notebook mode); the `ServerApp.default_url` form was confirmed NOT to work, hence the frontend-class flags
- `docker build --check` passes on the full Containerfile; `bash -n` passes on acceptance.sh

Note: this lands in the next published image (v1.2.0 images predate it), via the usual arm64 CI build + omega amd64 build + manifest republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
