### PR TITLE
omega container: prune stale kernelspecs at notebook|lab startup

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -162,11 +162,15 @@ jobs:
       # sysimage unless workload=none
       - name: Build image
         run: |
+          # pin the baked FuseExamples to current master (also busts the
+          # clone layer's cache when the notebooks changed)
+          examples_sha="$(git ls-remote https://github.com/ProjectTorreyPines/FuseExamples.git refs/heads/master | cut -f1)"
           docker build \
             -f deploy/perlmutter-container/Containerfile \
             --build-arg JULIA_CPU_TARGET="${{ matrix.cpu_target }}" \
             --build-arg FUSE_PRECOMPILE_WORKLOAD="${{ matrix.workload }}" \
             --build-arg FUSE_VERSION="${{ needs.version.outputs.version }}" \
+            --build-arg FUSEEXAMPLES_SHA="$examples_sha" \
             -t "$IMAGE:${{ needs.version.outputs.version }}-${{ matrix.arch }}" \
             .
 

--- a/deploy/omega-container/build.sh
+++ b/deploy/omega-container/build.sh
@@ -81,10 +81,16 @@ sif_dir="${SIF_DIR:-$scratch}"
 mkdir -p "$sif_dir"
 sif="$sif_dir/fuse_${version}.sif"
 
-echo "### Building $image (context: $repo_root, CPU target: $cpu_target)"
+# Pin the baked FuseExamples to current master (also busts the clone layer's
+# cache when the notebooks changed — same-version rebuilds would otherwise
+# silently ship a stale snapshot).
+examples_sha="$(git ls-remote https://github.com/ProjectTorreyPines/FuseExamples.git refs/heads/master | cut -f1)"
+
+echo "### Building $image (context: $repo_root, CPU target: $cpu_target, FuseExamples: ${examples_sha:0:9})"
 "${podman[@]}" build -t "$image" \
     --build-arg JULIA_CPU_TARGET="$cpu_target" \
     --build-arg FUSE_VERSION="$version" \
+    --build-arg FUSEEXAMPLES_SHA="$examples_sha" \
     -f "$scriptdir/../perlmutter-container/Containerfile" "$repo_root"
 
 echo "### Verifying the image contains FUSE $version"

--- a/deploy/omega-container/fuse-container
+++ b/deploy/omega-container/fuse-container
@@ -88,7 +88,18 @@ if [[ "${1:-}" == "notebook" || "${1:-}" == "lab" ]]; then
         exit 127
     fi
     version="$(basename "$sif")"; version="${version#fuse_}"; version="${version%.sif}"
-    threads="${THREADS:-1}"
+
+    # Thread count: THREADS=N wins; otherwise KEEP what the existing kernelspec
+    # for this version already has (the spec is rewritten on every run, so an
+    # unset THREADS would silently reset an 8-thread spec back to 1); 8 only
+    # when there is no prior spec.
+    threads="${THREADS:-}"
+    if [[ -z "$threads" ]]; then
+        threads="$(grep -oE -- '--threads=[0-9]+' \
+                   "$HOME/.local/share/jupyter/kernels/fuse-$version/kernel.json" 2>/dev/null \
+                   | head -1 | cut -d= -f2)"
+        threads="${threads:-8}"
+    fi
 
     # Prune stale kernelspecs left by earlier runs: a retired SIF leaves a dead
     # "Julia FUSE-<old>" entry in Jupyter's kernel picker, and a notebook saved

--- a/deploy/omega-container/fuse-container
+++ b/deploy/omega-container/fuse-container
@@ -89,6 +89,19 @@ if [[ "${1:-}" == "notebook" || "${1:-}" == "lab" ]]; then
     fi
     version="$(basename "$sif")"; version="${version#fuse_}"; version="${version%.sif}"
     threads="${THREADS:-1}"
+
+    # Prune stale kernelspecs left by earlier runs: a retired SIF leaves a dead
+    # "Julia FUSE-<old>" entry in Jupyter's kernel picker, and a notebook saved
+    # with one restart-loops five times before dying. Only fuse-* specs whose
+    # kernel.json points at a SIF that is no longer readable are removed.
+    for spec in "$HOME"/.local/share/jupyter/kernels/fuse-*/kernel.json; do
+        [[ -f "$spec" ]] || continue
+        spec_sif="$(grep -oE '/[^"\\ ]*\.sif' "$spec" | head -1)"
+        if [[ -n "$spec_sif" && ! -r "$spec_sif" ]]; then
+            rm -rf "$(dirname "$spec")"
+            echo "fuse-container: pruned stale kernelspec '$(basename "$(dirname "$spec")")' ($spec_sif is gone)"
+        fi
+    done
     singularity_dir="$(dirname "$(command -v singularity)")"
     launcher="$self_dir/$(basename "${BASH_SOURCE[0]:-$0}")"
     kdir="$HOME/.local/share/jupyter/kernels/fuse-$version"

--- a/deploy/omega-container/install_kernel.sh
+++ b/deploy/omega-container/install_kernel.sh
@@ -12,7 +12,7 @@
 #   SIF=/fusion/.../fuse_v1.2.0.sif ./deploy/omega-container/install_kernel.sh
 #
 # Optional:
-#   THREADS=8  number of Julia threads the kernel starts with (default 1)
+#   THREADS=N  number of Julia threads the kernel starts with (default 8)
 
 set -euo pipefail
 
@@ -23,7 +23,7 @@ if [[ ! -r "$SIF" ]]; then
     echo "ERROR: SIF not found/readable: $SIF" >&2
     exit 1
 fi
-threads="${THREADS:-1}"
+threads="${THREADS:-8}"
 
 # Version for the kernel name: parse from the SIF filename (fuse_<version>.sif).
 version="$(basename "$SIF" .sif)"

--- a/deploy/perlmutter-container/Containerfile
+++ b/deploy/perlmutter-container/Containerfile
@@ -164,8 +164,14 @@ RUN kdir=/usr/local/share/jupyter/kernels/fuse \
 RUN printf '%s\n' \
     '#!/bin/bash' \
     'mode="$(basename "$0")"' \
-    'export JULIA_NUM_THREADS="${THREADS:-${JULIA_NUM_THREADS:-1}}"' \
+    '# THREADS=N sets the kernel thread count; default 8, matching omega' \
+    '# fuse-container lab (the baked JULIA_NUM_THREADS=1 is a build artifact)' \
+    'export JULIA_NUM_THREADS="${THREADS:-8}"' \
     'echo "FUSE kernel threads: $JULIA_NUM_THREADS (set THREADS=N to change)"' \
+    '# stamp the session thread count into the kernel picker name — the' \
+    '# kernelspec is baked at build time but threads are chosen per docker run' \
+    't=threads; [ "$JULIA_NUM_THREADS" = 1 ] && t=thread' \
+    'sed -i "s/(container[^)]*)/(container, $JULIA_NUM_THREADS $t)/" /usr/local/share/jupyter/kernels/fuse/kernel.json 2>/dev/null || true' \
     '# give users a writable FuseExamples in the (mounted) working directory;' \
     '# an existing one is left alone so their edits survive re-runs' \
     'if [ ! -e FuseExamples ] && [ -w . ] && [ -d /opt/fuse/FuseExamples ]; then' \

--- a/deploy/perlmutter-container/Containerfile
+++ b/deploy/perlmutter-container/Containerfile
@@ -213,10 +213,17 @@ RUN chmod -R a+rX /opt/fuse/.julia/registries
 # FuseExamples notebooks, served by the `lab` launcher below: on startup it
 # copies this clone into the (mounted) working directory so users get a
 # writable copy whose edits persist on the host. A full clone (not shallow)
-# with the github origin, so that copy can simply `git pull` later. Placed
-# after the FUSE_VERSION cache-bust: each release build snapshots current
-# master.
-RUN git clone https://github.com/ProjectTorreyPines/FuseExamples /opt/fuse/FuseExamples
+# with the github origin, so that copy can simply `git pull` later.
+#
+# FUSEEXAMPLES_SHA pins the snapshot AND busts the layer cache: without it a
+# same-version rebuild would cache-hit an old clone and silently ship stale
+# notebooks. Build scripts pass current master (git ls-remote); empty means
+# clone HEAD, correct only when no cached clone layer exists.
+ARG FUSEEXAMPLES_SHA=""
+RUN git clone https://github.com/ProjectTorreyPines/FuseExamples /opt/fuse/FuseExamples \
+    && if [ -n "$FUSEEXAMPLES_SHA" ]; then \
+           git -C /opt/fuse/FuseExamples reset --hard "$FUSEEXAMPLES_SHA"; \
+       fi
 
 # procps: FUSE's memory monitor shells out to `ps -o rss=` (utils_end.jl).
 # openssh-client + rsync: FUSE's remote D3D data fetching (src/cases/D3D.jl).

--- a/deploy/perlmutter-container/build.sh
+++ b/deploy/perlmutter-container/build.sh
@@ -42,8 +42,13 @@ if [[ -z "${SLURM_JOB_ID:-}" ]]; then
     echo "         prefer 'salloc -N 1 -C cpu -q interactive -A m3739 -t 04:00:00' first." >&2
 fi
 
-echo "### Building $image (context: $repo_root)"
-podman-hpc build -t "$image" --build-arg FUSE_VERSION="$version" -f "$scriptdir/Containerfile" "$repo_root"
+# Pin the baked FuseExamples to current master (also busts the clone layer's
+# cache when the notebooks changed).
+examples_sha="$(git ls-remote https://github.com/ProjectTorreyPines/FuseExamples.git refs/heads/master | cut -f1)"
+
+echo "### Building $image (context: $repo_root, FuseExamples: ${examples_sha:0:9})"
+podman-hpc build -t "$image" --build-arg FUSE_VERSION="$version" \
+    --build-arg FUSEEXAMPLES_SHA="$examples_sha" -f "$scriptdir/Containerfile" "$repo_root"
 
 echo "### Migrating $image to a squashed read-only image"
 if [[ -n "${SQUASH_DIR:-}" ]]; then


### PR DESCRIPTION
A retired SIF leaves its kernelspec behind in `$HOME/.local/share/jupyter/kernels` — a dead **Julia FUSE-\<old\>** entry in the kernel picker, and any notebook last saved with it restart-loops five times and dies. This was observed live right after the v1.2.0 publish retired `fuse_v1.1.5.sif`:

```
fuse-container: SIF not found/readable: /fusion/projects/dt/fuse_containers/fuse_v1.1.5.sif
[I ...] AsyncIOLoopKernelRestarter: restarting kernel (1/5), new random ports
...
[W ...] AsyncIOLoopKernelRestarter: restart failed
```

`fuse-container notebook|lab` now prunes `fuse-*` kernelspecs whose `kernel.json` points at a SIF that is no longer readable, right before installing the current one. Specs whose SIF still exists (e.g. `fuse-v1.1.6` alongside `fuse-v1.2.0`) are kept.

Tested on omega17: a fabricated `fuse-v0.0.9` spec (pointing at a nonexistent SIF) is pruned with a notice while live specs survive, both in isolation and through a full `fuse-container lab` startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Also in this PR — kernel thread-count visibility and defaults, both sites:**

- **omega**: `THREADS=N` wins; an unset `THREADS` now *keeps* the existing kernelspec's count instead of silently resetting an 8-thread spec back to 1 (the spec is rewritten on every `notebook|lab` run); a fresh spec defaults to 8 (`install_kernel.sh` matched).
- **docker (laptop)**: the baked kernelspec's picker name was static ("Julia FUSE-v1.2.0 (container)") with no thread hint, since threads are chosen per `docker run`. The `lab` launcher now stamps the session's count into the display name at startup — "Julia FUSE-v1.2.0 (container, 8 threads)" — and defaults to 8 threads when `THREADS` is unset, matching omega. Verified against a live server: the picker shows the stamped name, and a kernel started through the server's REST/websocket API reports `Threads.nthreads() == THREADS` (an earlier `docker exec` test that showed 1 was a test artifact — exec'd processes bypass the server's environment).

The docker-side change needs an image republish to reach users (arm64 can be rebuilt/pushed from the laptop as before; amd64 from omega).
- **FuseExamples cache pinning**: the baked-clone layer is cached, so a same-version rebuild would silently ship stale notebooks even after FuseExamples gained new ones. All build entry points (CI, omega `build.sh`, perlmutter `build.sh`) now resolve FuseExamples' master SHA via `git ls-remote` and pass it as `FUSEEXAMPLES_SHA` — the layer re-runs exactly when the notebooks changed, and the snapshot is pinned/reproducible (still a full master checkout with the github origin, so user copies can `git pull`).
