### PR TITLE
Add beta match actor

### DIFF
--- a/src/FUSE.jl
+++ b/src/FUSE.jl
@@ -146,6 +146,7 @@ include(joinpath("actors", "transport", "flux_matcher_actor.jl"))
 include(joinpath("actors", "transport", "mode_id_actor.jl"))
 include(joinpath("actors", "transport", "finn_actor.jl"))
 include(joinpath("actors", "transport", "eped_profiles_actor.jl"))
+include(joinpath("actors", "transport", "beta_match_actor.jl"))
 include(joinpath("actors", "transport", "core_transport_actor.jl"))
 
 include(joinpath("actors", "stability", "limits_actor.jl"))

--- a/src/actors/compound/stationary_plasma_actor.jl
+++ b/src/actors/compound/stationary_plasma_actor.jl
@@ -165,12 +165,29 @@ function _step(actor::ActorStationaryPlasma)
             j_tor_before = cp1d.j_tor
             pressure_before = cp1d.pressure
 
+            # check to see if ohmic current is negative
+            if true
+                    ip_ohm = dd.summary.global_quantities.current_ohm.value[1]
+                    ip_ni = dd.summary.global_quantities.current_non_inductive.value[1]
+                    ip_bs = dd.summary.global_quantities.current_bootstrap.value[1]
+                    ip_aux = ip_ni - ip_bs
+                    @printf("ip_ohm = %.2fMA\n", ip_ohm/1e6)
+                    @printf("ip_aux = %.2fMA\n", ip_aux/1e6)
+                if ip_ohm < 0
+                    # reduce auxiliary current drive
+                    f_cd = ip_aux > abs(ip_ohm) ? 0.75 * (ip_aux-abs(ip_ohm))/ip_aux : 0.0
+                    actor.actor_src.ec_actor.par.actuator[1].ηcd_scale = f_cd
+                    @printf("ηcd_scale = %.3f\n", actor.actor_src.ec_actor.par.actuator[1].ηcd_scale)
+                end
+            end
+
             # core_profiles, core_sources, core_transport grids from latest equilibrium
             latest_equilibrium_grids!(dd)
 
             # run sources to get updated current drive
             ProgressMeter.next!(prog; showvalues=progress_ActorStationaryPlasma(total_error, actor, actor.actor_src))
             finalize(step(actor.actor_src))
+
 
             # run pedestal actor
             ProgressMeter.next!(prog; showvalues=progress_ActorStationaryPlasma(total_error, actor, actor.actor_ped))

--- a/src/actors/compound/stationary_plasma_actor.jl
+++ b/src/actors/compound/stationary_plasma_actor.jl
@@ -165,22 +165,6 @@ function _step(actor::ActorStationaryPlasma)
             j_tor_before = cp1d.j_tor
             pressure_before = cp1d.pressure
 
-            # check to see if ohmic current is negative
-            if true
-                    ip_ohm = dd.summary.global_quantities.current_ohm.value[1]
-                    ip_ni = dd.summary.global_quantities.current_non_inductive.value[1]
-                    ip_bs = dd.summary.global_quantities.current_bootstrap.value[1]
-                    ip_aux = ip_ni - ip_bs
-                    @printf("ip_ohm = %.2fMA\n", ip_ohm/1e6)
-                    @printf("ip_aux = %.2fMA\n", ip_aux/1e6)
-                if ip_ohm < 0
-                    # reduce auxiliary current drive
-                    f_cd = ip_aux > abs(ip_ohm) ? 0.75 * (ip_aux-abs(ip_ohm))/ip_aux : 0.0
-                    actor.actor_src.ec_actor.par.actuator[1].ηcd_scale = f_cd
-                    @printf("ηcd_scale = %.3f\n", actor.actor_src.ec_actor.par.actuator[1].ηcd_scale)
-                end
-            end
-
             # core_profiles, core_sources, core_transport grids from latest equilibrium
             latest_equilibrium_grids!(dd)
 

--- a/src/actors/transport/beta_match_actor.jl
+++ b/src/actors/transport/beta_match_actor.jl
@@ -1,0 +1,96 @@
+#= ================== =#
+#  ActorBetaMatch  #
+#= ================== =#
+@actor_parameters_struct ActorBetaMatch{T} begin
+    βn_target::Entry{T} = Entry{T}("-", "Target value for normalized toroidal beta")
+    T_shaping::Entry{T} = Entry{T}("-", "Shaping coefficient for the temperature profile")
+end
+
+mutable struct ActorBetaMatch{D,P} <: CompoundAbstractActor{D,P}
+    dd::IMAS.DD{D}
+    par::OverrideParameters{P,FUSEparameters__ActorBetaMatch{P}}
+    act::ParametersAllActors{P}
+    function ActorBetaMatch(dd::IMAS.DD{D}, par::FUSEparameters__ActorBetaMatch{P}, act::ParametersAllActors{P}; kw...) where {D<:Real,P<:Real}
+        logging_actor_init(ActorBetaMatch)
+        par = OverrideParameters(par; kw...)
+        return new{D,P}(dd, par, act)
+    end
+end
+
+"""
+    ActorBetaMatch(dd::IMAS.dd, act::ParametersAllActors; kw...)
+
+Updates core temperature profiles in order to match target betaN.
+Uses Hmode_profiles() function to scale core temperature profiles while keeping pedestal unchanged.
+Does not change density profiles.
+Does not change pedestal parameters.
+
+"""
+function ActorBetaMatch(dd::IMAS.DD, act::ParametersAllActors; kw...)
+    actor = ActorBetaMatch(dd, act.ActorBetaMatch, act; kw...)
+    step(actor)
+    finalize(actor)
+    return actor
+end
+
+"""
+    _step(actor::ActorBetaMatch)
+"""
+function _step(actor::ActorBetaMatch)
+    dd = actor.dd
+    par = actor.par
+    cp1d = dd.core_profiles.profiles_1d[]
+
+    # get profile parameters
+    wped = 1 - dd.summary.local.pedestal.position.rho_tor_norm[1]
+    te = dd.core_profiles.profiles_1d[].electrons.temperature
+    ti = dd.core_profiles.profiles_1d[].ion[1].temperature
+    te_sep = te[end]
+    ti_sep = ti[end]
+    te_ped = dd.summary.local.pedestal.t_e.value[1]
+    ti_ped = dd.summary.local.pedestal.t_i_average.value[1]
+    t_ratio = ti[1]/te[1]
+    
+    function cost_function(x)
+        te_new = IMAS.Hmode_profiles(te_sep, te_ped, x[1], length(cp1d.grid.rho_tor_norm), par.T_shaping, par.T_shaping, wped)
+        ti_new = IMAS.Hmode_profiles(ti_sep, ti_ped, x[1]*t_ratio, length(cp1d.grid.rho_tor_norm), par.T_shaping, par.T_shaping, wped)
+        cp1d.electrons.temperature = te_new
+        for ion in cp1d.ion
+            ion.temperature = ti_new
+        end
+        βn_new = IMAS.beta_tor_norm(dd.equilibrium.time_slice[], cp1d)
+        return abs(par.βn_target - βn_new)
+    end
+    
+    # run optimizer to find Te0 that gives target betaN
+    res = Optim.optimize(x -> cost_function(x), 0, 1e6)
+    #display(res)
+    Te0 = res.minimizer[1]
+    
+    # if optimized Te0 is less than te_ped, increase to be equal to te_ped
+    if Te0 < te_ped
+        Te0 = te_ped
+        te_new = IMAS.Hmode_profiles(te_sep, te_ped, Te0, length(cp1d.grid.rho_tor_norm), par.T_shaping, par.T_shaping, wped)
+        ti_new = IMAS.Hmode_profiles(ti_sep, ti_ped, Te0*t_ratio, length(cp1d.grid.rho_tor_norm), par.T_shaping, par.T_shaping, wped)
+        cp1d.electrons.temperature = te_new
+        for ion in cp1d.ion
+            ion.temperature = ti_new
+        end
+    end
+
+    return actor
+end
+
+"""
+    _finalize(actor::ActorBetaMatch)
+
+Updates IMAS.core_sources
+"""
+function _finalize(actor::ActorBetaMatch)
+    dd = actor.dd
+
+    # update sources
+    IMAS.intrinsic_sources!(dd)
+
+    return actor
+end

--- a/src/actors/transport/beta_match_actor.jl
+++ b/src/actors/transport/beta_match_actor.jl
@@ -4,6 +4,9 @@
 @actor_parameters_struct ActorBetaMatch{T} begin
     βn_target::Entry{T} = Entry{T}("-", "Target value for normalized toroidal beta")
     T_shaping::Entry{T} = Entry{T}("-", "Shaping coefficient for the temperature profile")
+    thermal::Entry{Bool} = Entry{Bool}("-", "Match thermal beta or total beta"; default=true)
+    norm::Entry{Bool} = Entry{Bool}("-", "Match normalized beta or toroidal beta"; default=true)
+    fix_pedestal::Entry{Bool} = Entry{Bool}("-", "Only scale core temperature using Hmode_Profiles"; default=true)
 end
 
 mutable struct ActorBetaMatch{D,P} <: CompoundAbstractActor{D,P}
@@ -52,13 +55,18 @@ function _step(actor::ActorBetaMatch)
     t_ratio = ti[1]/te[1]
     
     function cost_function(x)
-        te_new = IMAS.Hmode_profiles(te_sep, te_ped, x[1], length(cp1d.grid.rho_tor_norm), par.T_shaping, par.T_shaping, wped)
-        ti_new = IMAS.Hmode_profiles(ti_sep, ti_ped, x[1]*t_ratio, length(cp1d.grid.rho_tor_norm), par.T_shaping, par.T_shaping, wped)
+        if par.fix_pedestal
+            te_new = IMAS.Hmode_profiles(te_sep, te_ped, x[1], length(cp1d.grid.rho_tor_norm), par.T_shaping, par.T_shaping, wped)
+            ti_new = IMAS.Hmode_profiles(ti_sep, ti_ped, x[1]*t_ratio, length(cp1d.grid.rho_tor_norm), par.T_shaping, par.T_shaping, wped)
+        else
+            te_new  = x[1] / te[1] * te
+            ti_new = te_new * t_ratio
+        end
         cp1d.electrons.temperature = te_new
         for ion in cp1d.ion
             ion.temperature = ti_new
         end
-        βn_new = IMAS.beta_tor_norm(dd.equilibrium.time_slice[], cp1d)
+        βn_new = IMAS.beta_tor(dd.equilibrium.time_slice[], cp1d, norm=par.norm, thermal=par.thermal)
         return abs(par.βn_target - βn_new)
     end
     
@@ -68,13 +76,15 @@ function _step(actor::ActorBetaMatch)
     Te0 = res.minimizer[1]
     
     # if optimized Te0 is less than te_ped, increase to be equal to te_ped
-    if Te0 < te_ped
-        Te0 = te_ped
-        te_new = IMAS.Hmode_profiles(te_sep, te_ped, Te0, length(cp1d.grid.rho_tor_norm), par.T_shaping, par.T_shaping, wped)
-        ti_new = IMAS.Hmode_profiles(ti_sep, ti_ped, Te0*t_ratio, length(cp1d.grid.rho_tor_norm), par.T_shaping, par.T_shaping, wped)
-        cp1d.electrons.temperature = te_new
-        for ion in cp1d.ion
-            ion.temperature = ti_new
+    if par.fix_pedestal
+        if Te0 < te_ped
+            Te0 = te_ped
+            te_new = IMAS.Hmode_profiles(te_sep, te_ped, Te0, length(cp1d.grid.rho_tor_norm), par.T_shaping, par.T_shaping, wped)
+            ti_new = IMAS.Hmode_profiles(ti_sep, ti_ped, Te0*t_ratio, length(cp1d.grid.rho_tor_norm), par.T_shaping, par.T_shaping, wped)
+            cp1d.electrons.temperature = te_new
+            for ion in cp1d.ion
+                ion.temperature = ti_new
+            end
         end
     end
 

--- a/src/actors/transport/core_transport_actor.jl
+++ b/src/actors/transport/core_transport_actor.jl
@@ -2,14 +2,14 @@
 #  ActorCoreTransport  #
 #= ================== =#
 @actor_parameters_struct ActorCoreTransport{T} begin
-    model::Switch{Symbol} = Switch{Symbol}([:FluxMatcher, :FINN, :EPEDProfiles, :replay, :none], "-", "Transport actor to run"; default=:FluxMatcher)
+    model::Switch{Symbol} = Switch{Symbol}([:FluxMatcher, :FINN, :BetaMatch, :EPEDProfiles, :replay, :none], "-", "Transport actor to run"; default=:FluxMatcher)
 end
 
 mutable struct ActorCoreTransport{D,P} <: CompoundAbstractActor{D,P}
     dd::IMAS.DD{D}
     par::OverrideParameters{P,FUSEparameters__ActorCoreTransport{P}}
     act::ParametersAllActors{P}
-    tr_actor::Union{ActorFluxMatcher{D,P},ActorFINN{D,P},ActorEPEDprofiles{D,P},ActorReplay{D,P},ActorNoOperation{D,P}}
+    tr_actor::Union{ActorFluxMatcher{D,P},ActorFINN{D,P},ActorBetaMatch{D,P},ActorEPEDprofiles{D,P},ActorReplay{D,P},ActorNoOperation{D,P}}
 end
 
 """
@@ -24,6 +24,7 @@ Transport model options:
   neoclassical models to evolve temperature and density profiles
 - `:FINN`: Direct gradient prediction using the Flux-matcher Inversion Neural Network,
   bypassing iterative flux matching for 10-millisecond profile prediction
+- `:BetaMatch`: Scale temperature profiles to match target betaN value    
 - `:EPEDProfiles`: Use EPED model predictions for pedestal and core profiles
 - `:replay`: Replay profiles from experimental data or previous simulations
 - `:none`: No core transport evolution (fixed profiles)
@@ -49,6 +50,8 @@ function ActorCoreTransport(dd::IMAS.DD, par::FUSEparameters__ActorCoreTransport
         actor.tr_actor = ActorFluxMatcher(dd, act.ActorFluxMatcher, act)
     elseif par.model == :FINN
         actor.tr_actor = ActorFINN(dd, act.ActorFINN, act)
+    elseif par.model == :BetaMatch
+        actor.tr_actor = ActorBetaMatch(dd, act.ActorBetaMatch, act)
     elseif par.model == :EPEDProfiles
         actor.tr_actor = ActorEPEDprofiles(dd, act.ActorEPEDprofiles, act)
     elseif par.model == :replay


### PR DESCRIPTION
Adds a new CoreTransport actor titled "BetaMatch". This actor allows the user to scale the core profiles to match a target plasma beta. 

Use Case: Tokamak scaling studies that require a ad-hoc set of plasma kinetic profiles scaled to a target beta. Plasma profiles are set at FUSE.init() and can either be scaled uniformly (fix_pedestal=false) or in tandem with EPED to preserve the pedestal height & width and only change the core (fix_pedestal=true).