### PR TITLE
compat: ALPHA 2 (TGLF-EP file units, jlestz closure fixes); ActorTJLFEP alpha_method defaults to :pressure

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -91,7 +91,7 @@ WeaveExt = "Weave"
 
 [compat]
 CoordinateConventions = "1"
-ALPHA = "1"
+ALPHA = "1.1"
 AbstractTrees = "0.4"
 ArgParse = "1.2.0"
 BalanceOfPlantSurrogate = "3"

--- a/Project.toml
+++ b/Project.toml
@@ -91,7 +91,7 @@ WeaveExt = "Weave"
 
 [compat]
 CoordinateConventions = "1"
-ALPHA = "1.2"
+ALPHA = "2"
 AbstractTrees = "0.4"
 ArgParse = "1.2.0"
 BalanceOfPlantSurrogate = "3"

--- a/Project.toml
+++ b/Project.toml
@@ -91,7 +91,7 @@ WeaveExt = "Weave"
 
 [compat]
 CoordinateConventions = "1"
-ALPHA = "1.1"
+ALPHA = "1.2"
 AbstractTrees = "0.4"
 ArgParse = "1.2.0"
 BalanceOfPlantSurrogate = "3"

--- a/src/actors/transport/tglfep_actor.jl
+++ b/src/actors/transport/tglfep_actor.jl
@@ -162,10 +162,9 @@ function _step(actor::ActorTJLFEP{D,P}) where {D<:Real,P<:Real}
     # the classical slowing-down profile and `min(classical, marginal)` keeps the
     # (un-flattened) classical EP density there.
     dndr = _sanitize_crit_grad(dndr_crit_out)
-    # runTHD returns the alpha_dpdr_crit.input values (10 kPa/m); ALPHA's public dpdr_crit is
-    # 10^19 m^-3·keV/m and it multiplies by 0.16022 again internally, so the stiff solver applies
-    # the file value unchanged, as the Fortran Alpha does
-    dpdr = _sanitize_crit_grad(dpdr_crit_out) ./ 0.16022
+    # ALPHA takes both critical gradients in the TGLF-EP file units (dpdr in 10 kPa/m), as
+    # the Fortran Alpha does; runTHD returns exactly those values
+    dpdr = _sanitize_crit_grad(dpdr_crit_out)
 
     crit_grad = (; dndr_crit=dndr, dpdr_crit=dpdr)
 

--- a/src/actors/transport/tglfep_actor.jl
+++ b/src/actors/transport/tglfep_actor.jl
@@ -36,7 +36,9 @@ import TurbulentTransport
     reject_tearing::Entry{Bool} = Entry{Bool}("-", "reject tearing-parity modes"; default=true)
     rotational_suppression::Entry{Bool} = Entry{Bool}("-", "apply rotational suppression"; default=true)
     alpha_method::Switch{Symbol} =
-        Switch{Symbol}([:density, :pressure], "-", "ALPHA critical-gradient variable (density or pressure threshold)"; default=:density)
+        Switch{Symbol}([:pressure, :density], "-",
+            "ALPHA critical-gradient variable: :pressure = EP pressure-gradient drive against the TGLF-EP alpha_dpdr_crit threshold (Fortran i_tot_TAE=-1 with the dpdr file; standard); :density = density-gradient drive against dndr_crit (i_tot_TAE=0)";
+            default=:pressure)
     alpha_solver::Switch{Symbol} =
         Switch{Symbol}([:stiff, :marginal], "-", "ALPHA solver (:stiff = Fortran stiff-CGM; :marginal = analytic min(classical,marginal))"; default=:stiff)
     alpha_use_ql::Entry{Bool} =
@@ -160,7 +162,10 @@ function _step(actor::ActorTJLFEP{D,P}) where {D<:Real,P<:Real}
     # the classical slowing-down profile and `min(classical, marginal)` keeps the
     # (un-flattened) classical EP density there.
     dndr = _sanitize_crit_grad(dndr_crit_out)
-    dpdr = _sanitize_crit_grad(dpdr_crit_out) ./ 0.16022   # 10 kPa/m -> 10^19 m^-3·keV/m (ALPHA's dpdr_crit convention; see runTHD)
+    # runTHD returns the alpha_dpdr_crit.input values (10 kPa/m); ALPHA's public dpdr_crit is
+    # 10^19 m^-3·keV/m and it multiplies by 0.16022 again internally, so the stiff solver applies
+    # the file value unchanged, as the Fortran Alpha does
+    dpdr = _sanitize_crit_grad(dpdr_crit_out) ./ 0.16022
 
     crit_grad = (; dndr_crit=dndr, dpdr_crit=dpdr)
 

--- a/src/actors/transport/tglfep_actor.jl
+++ b/src/actors/transport/tglfep_actor.jl
@@ -160,7 +160,7 @@ function _step(actor::ActorTJLFEP{D,P}) where {D<:Real,P<:Real}
     # the classical slowing-down profile and `min(classical, marginal)` keeps the
     # (un-flattened) classical EP density there.
     dndr = _sanitize_crit_grad(dndr_crit_out)
-    dpdr = _sanitize_crit_grad(dpdr_crit_out) ./ 0.16022   # 10 kPa/m -> 10^19 m^-3·keV /m (see runTHD)
+    dpdr = _sanitize_crit_grad(dpdr_crit_out) ./ 0.16022   # 10 kPa/m -> 10^19 m^-3·keV/m (ALPHA's dpdr_crit convention; see runTHD)
 
     crit_grad = (; dndr_crit=dndr, dpdr_crit=dpdr)
 
@@ -184,6 +184,10 @@ function _step(actor::ActorTJLFEP{D,P}) where {D<:Real,P<:Real}
     actor.alpha = ALPHA.run_alpha(dd, actor.rho_grid, crit_grad;
         solver=par.alpha_solver, method=par.alpha_method, E_alpha=Float64(par.E_alpha),
         transport_params=transport_params, ql_modes=ql_modes)
+    if par.alpha_solver == :stiff
+        @debug "ActorTJLFEP: ALPHA stiff-CGM solve" n_iter = actor.alpha.stiff_n_iter exit_reason = actor.alpha.stiff_exit_reason error = actor.alpha.stiff_error
+        actor.alpha.stiff_converged || @warn "ActorTJLFEP: ALPHA stiff-CGM solver did not converge (error=$(actor.alpha.stiff_error) after $(actor.alpha.stiff_n_iter) iterations)"
+    end
 
     return actor
 end


### PR DESCRIPTION
## Summary

Bumps the `ALPHA` compat to `2` so FUSE picks up [ALPHA.jl v2.0.0](https://github.com/ProjectTorreyPines/ALPHA.jl/releases/tag/v2.0.0) (and the 1.1 / 1.2 releases before it), which port Jeff Lestz's (@jlestz) fixes to the Fortran `Alpha` stiff critical-gradient EP transport solver (https://github.com/jlestz/Alpha), and makes `ActorTJLFEP` run Alpha the way the Fortran users do.

ALPHA 1.1 (closure fixes, from Jeff's fork):

- interface-grid (half-grid) diffusivity `D_half` drives the density recursion (`l_D_interface=1`): removes the grid-to-grid oscillation of `D_EP`;
- supercritical excess normalised by the grid maximum of the slowing-down reference profile (`l_norm_const=1`): removes the edge diffusivity spike;
- Fortran-production convergence (`n_iter=100000`, `tol=1e-12`, plateau exit) with a `stiff_converged` / `stiff_exit_reason` report.

ALPHA 2.0 (units): ALPHA now takes the critical gradients **in the TGLF-EP file units**, exactly as the Fortran `Alpha` reads `alpha_dndr_crit.input` / `alpha_dpdr_crit.input` (`dpdr_crit` in 10 kPa/m) — no conversion anywhere. `TJLFEP.runTHD` returns exactly those file values, so the actor now hands them straight through. Before: ALPHA 1.x expected `dpdr_crit` in `10^19 m^-3·keV/m`, which is why the actor divided by 0.16022, and ALPHA 1.0 divided a second time internally, so the `alpha_solver=:stiff, alpha_method=:pressure` threshold in FUSE was ~39× too high (effectively no AE transport). Nothing changed in the Fortran or in TGLF-EP; the factor only ever lived in the Julia port, and now it is gone.

## Default change: `alpha_method = :pressure`

The standard way to run Alpha is to feed it the TGLF-EP **`alpha_dpdr_crit.input`** and use the pressure-gradient drive (`i_tot_TAE=-1`). Jeff, Kyle and Eric all run it that way. The axial diffusivity spike Jeff found came from running the pressure drive on a critical pressure gradient *derived* from `alpha_dndr_crit.input` (`T·dndr·(1+(ΔT/T)(n/Δn))`), which is unreliable where the slowing-down density is flat or hollow. Supplying the dpdr file bypasses that translation.

`ActorTJLFEP` therefore now defaults to `alpha_method=:pressure`. `:density` (density-gradient drive against `dndr_crit`, `i_tot_TAE=0`) is still available for comparison, but it is a different drive variable, not an equivalent fix. (An earlier version of this description presented it as one; that was wrong.) ALPHA 1.2 also stopped using the dndr-derived pressure threshold for the stiff `transport_active` diagnostic under `:density`.

ITER sample case (`ngrid=51`, `rho_scan=[0.41,0.61]`, TGLF-EP `solver=:grid`), same TGLF-EP critical gradients for every row:

| solver | `alpha_method` | exit | iterations | max `n_EP` [1e19 m⁻³] | Σ `n_EP` | max `p_EP` | max `D_EP` [m²/s] |
|---|---|---|---|---|---|---|---|
| stiff | `:pressure` (new default) | tol | 40728 | 0.0920 | 1.457 | 92.2 | 0.001 |
| stiff | `:density` | tol | 40728 | 0.0920 | 1.457 | 92.2 | 0.001 |
| marginal | `:pressure` | – | – | 0.0931 | 1.464 | 93.3 | – |
| marginal | `:density` | – | – | 0.0931 | 1.464 | 93.3 | – |

In this small scan ITER is AE-stable (SFmin = 7.5 at ρ=0.41, no AE limit at the separatrix), so both drives give identical profiles; the actor runs, converges, and is unchanged in cost (TGLF-EP dominates; the stiff solve takes 0.06 s). Where the AE drive is active, e.g. Jeff's DIII-D 153071 inputs with the fixed closure, the two drives differ but neither spikes:

| case | drive | max `D` | `D` at ρ<0.05 | `D` at ρ>0.9 | retained EP inventory `N/N_cl` |
|---|---|---|---|---|---|
| t=3400 | `:pressure` (dpdr file) | 0.327 | 0.0010 | 0.036 | 0.973 |
| t=3400 | `:density` | 0.356 | 0.0014 | 0.032 | 0.974 |
| t=2200 | `:pressure` (dpdr file) | 0.510 | 0.025 | 0.229 | 0.936 |
| t=2200 | `:density` | 0.564 | 0.027 | 0.132 | 0.938 |

`ActorTJLFEP` also `@debug`-logs the stiff solve (iterations, exit reason, error) and warns if it did not converge.

ALPHA.jl reproduces the pre-fix Fortran to ~1e-10 and the fixed Fortran to ~1e-11 on Jeff's DIII-D 153071 reference runs (`examples/fortran_comparison.jl`, fixtures in `test/fixtures/d3d_153071_*`); with the file-unit inputs the fixed Fortran's critical pressure gradient is reproduced to 2e-16.

## Test plan

- [x] ALPHA.jl test suite (177 tests) incl. Fortran parity, default-method, `transport_active` and file-unit tests
- [x] ITER `ActorTJLFEP` run with the new default against ALPHA 2.0 + `run_alpha` comparison of all solver × method combinations (table above)
- [x] CI once ALPHA 2.0.0 is picked up from FuseRegistry (the `Julia 1.x` jobs fail independently until TORBEAM.jl#8 is released, see comment below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
