### PR TITLE
omega container: pass TORBEAM_DIR through the launcher

### DIFF
--- a/deploy/omega-container/README.md
+++ b/deploy/omega-container/README.md
@@ -156,6 +156,11 @@ handles the details:
 - The SIF is fully read-only, and Julia package init **crashes** if it cannot
   write logs/scratch to a depot. The in-image `fuse` entrypoint handles this:
   it prepends `$HOME/.julia_fuse_container` as a writable first depot.
+- TORBEAM (`ec_model=:TORBEAM`): the image has only the TORBEAM.jl wrapper,
+  which loads `$TORBEAM_DIR/../lib/libtorbeamB.so` from the host. The launcher
+  passes your `TORBEAM_DIR` (e.g. after `module load torbeam`) through
+  `--cleanenv`, else defaults to omega's `torbeam/gcc11.x` build under
+  `/fusion/projects/codes/torbeam`.
 
 ### Home directory over quota
 

--- a/deploy/omega-container/fuse-container
+++ b/deploy/omega-container/fuse-container
@@ -241,6 +241,15 @@ for var_dir in "FUSE_PEDESTAL_NN_DIR:pedestal_nn" "FUSE_SOLPS_NN_DIR:solps_nn_on
     fi
 done
 
+# TORBEAM (ActorTORBEAM): the image ships only the TORBEAM.jl wrapper, which
+# ccalls $TORBEAM_DIR/../lib/libtorbeamB.so at runtime. Use the caller's
+# TORBEAM_DIR (e.g. from `module load torbeam`), else omega's torbeam module
+# build; either must be inside a bind (default /fusion) to be visible.
+torbeam_dir="${TORBEAM_DIR:-/fusion/projects/codes/torbeam/c8/202505/build-generic/bin}"
+if [[ -f "$torbeam_dir/../lib/libtorbeamB.so" ]]; then
+    extra_env+=(--env "TORBEAM_DIR=$torbeam_dir")
+fi
+
 # A redirected depot (e.g. /local-scratch) is outside the default binds —
 # bind it explicitly so it exists inside the container. Nested/duplicate
 # binds (depot under /fusion or $HOME) are harmless.


### PR DESCRIPTION
The FUSE image ships the TORBEAM.jl wrapper (v1.0.4, pulled in as a FUSE dependency) but not the Fortran library it `ccall`s at runtime, `$TORBEAM_DIR/../lib/libtorbeamB.so`. On omega, `fuse-container` runs singularity with `--cleanenv`, which drops `TORBEAM_DIR` even if the user has `module load torbeam`, so `ec_model = :TORBEAM` fails inside the container. I checked the published `fuse_v1.2.0.sif`: `packages/TORBEAM` and its compiled cache are present, but there is no `libtorbeam*.so` anywhere in the image.

`fuse-container` now passes the caller's `TORBEAM_DIR` into the container, or, when it is unset, defaults to the omega `torbeam/gcc11.x` module build at `/fusion/projects/codes/torbeam/c8/202505/build-generic/bin`. It is set only if `libtorbeamB.so` actually exists at that location. `/fusion` is bound by default, so the host library is visible. Its only non-libc dependencies are `libgfortran.so.5`/`libquadmath`, which Julia already ships and loads. This follows the same pattern as the existing `FUSE_PEDESTAL_NN_DIR` / `FUSE_SOLPS_NN_DIR` pass-through. A short note is added to the omega README.

Tested on omega14 with `fuse_v1.2.0.sif`:
- `TORBEAM_DIR` unset → the container sees the default path; `dlopen` of `libtorbeamB.so` and `dlsym(:beam_)` succeed.
- `TORBEAM_DIR=/nonexistent` → skipped; the variable is unset in the container.

A full TORBEAM run through the container has not been tested yet.

This launcher is already deployed at `/fusion/projects/dt/fuse_containers/fuse-container`, where it is identical to this branch's file. This fixes omega only: the GHCR/Perlmutter images still lack the library, and baking it into the image would depend on TORBEAM's redistribution terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXer45owQRDcPNG7Bz7KTd
